### PR TITLE
[CUBRIDQA-73] need one sub folder for each build to backup source code

### DIFF
--- a/CTP/common/ext/run_coverage.sh
+++ b/CTP/common/ext/run_coverage.sh
@@ -165,6 +165,8 @@ function backupPackages()
    	mkdir -p "$BUILD_ID"
    fi
 
+   cd $BUILD_ID
+
    mkdir -p new
    mkdir -p merge
    mkdir -p manual 


### PR DESCRIPTION
@fanzaiqiang 

create a subfolder to save source code and new coverage datas