### PR TITLE
[CBRD-21212] make_tz SPEC has changed,dbname no need on linux,so not write it into common fun.

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -1170,7 +1170,7 @@ function do_make_tz
                 fi
                 shift
                 ;;
-	     new|update)
+	     new|extend)
 		if [ "$OS" == "Windows_NT" ]
 		then
 			parameter=`echo $parameter " /$1"`
@@ -1179,18 +1179,6 @@ function do_make_tz
 		fi
 		shift
 		;;
-	     extend)
-		# dbname should be given after "extend" option
-		if [ "$OS" == "Windows_NT" ]
-                then
-                        parameter=`echo $parameter " /extend"`
-                else
-                        parameter=`echo $parameter " -g extend"`
-                fi
-                shift
-		parameter=`echo $parameter " -d $1"`
-                shift
-                ;;
 	     # do not check error
              nocheck)
                 nocheck=1


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-21212

make_tz SPEC has changed,dbname no need on linux
linux and windows has some diffence

for windows:
USAGE: make_tz.bat [/release|/debug] [/new|/extend] [-d database_name|-all] (onl
y for extend mode)

for linux:
USAGE: make_tz.sh  [-m release/debug] [-g new/extend] 
