### PR TITLE
[CUBRIDQA-196] fixed absolute path issue when delete a file

### DIFF
--- a/CTP/common/script/run_git_update
+++ b/CTP/common/script/run_git_update
@@ -115,16 +115,19 @@ git fetch auto_update_url
 
 echo Begin to check out test cases:
 echo git checkout -f -b $branch_name -t auto_update_url/$branch_name
-while true 
+while true
 do
     git checkout -f -b $branch_name -t auto_update_url/$branch_name 2>checkout.log
     fail=`cat checkout.log|grep "^error" | grep "not uptodate. Cannot merge" | head -n 1 | awk -F "'" '{print $2}'`
     if [ "$fail" == "" ]; then
         break
-    elif [ -f "$fail" ]; then
-        cat checkout.log
-	    echo =\> attempt to fix by deleting $fail.
-        rm -f "$fail"
+    else
+        fail="`git rev-parse --show-toplevel`/$fail"
+        if [ -f "$fail" ]; then
+            cat checkout.log
+            echo =\> attempt to fix by deleting $fail.
+            rm -f "$fail"
+        fi
     fi
 done
 


### PR DESCRIPTION
This patch attempts to temporarily fix a git checkout issue.
```
error: Entry '<some file>' not uptodate. Cannot merge.
```