### PR TITLE
[CUBRIDQA-25] rm all the log files and sub-folders in the log path in init step

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -620,7 +620,7 @@ function init
   fi
   export CUBRID_BITS
   
-  rm $CUBRID/log/* > /dev/null 2>&1
+  rm -rf $CUBRID/log/* > /dev/null 2>&1
 
   if [ $OS = "AIX" ];then
   	cp $init_path/commonforjdbc_aix.jar $init_path/commonforjdbc.jar


### PR DESCRIPTION
Before: rm $CUBRID/log/* > /dev/null 2>&1
After: rm -rf $CUBRID/log/* > /dev/null 2>&1