### PR TITLE
[CUBRIDQA-77] add common function 'generate_port' for test cases which need mutiple ports to test

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -56,7 +56,8 @@ function get_broker_port_from_shell_config
   echo $port
 }
 
-#get another available port 
+# This function is not recommended.
+# It is used to get another available port. 
 function generate_port {
         generated_port=$1
         while true; do

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -56,6 +56,20 @@ function get_broker_port_from_shell_config
   echo $port
 }
 
+#get another available port 
+function generate_port {
+        generated_port=$1
+        while true; do
+                ((generated_port=${generated_port} + 1 ))
+                is_use=`netstat -ant | awk '{print $4}' | grep -e "\:${generated_port}$"`
+
+                if [ -z "$is_use" ]; then
+                        break
+                fi
+        done
+        echo ${generated_port}
+}
+
 function get_curr_second
 {
 	str=`date +%s`


### PR DESCRIPTION
test cases cubrid-testcases-private/interface/CCI/shell/_20_cci/_12_issue/bug_bts_8675/cases for release 10.0 branch has used `generate_port` function in CQT of github,so add it into CTP
refer to https://github.com/CUBRID/cubrid-testtools-internal/blob/master/QATool/CQT/lib/shell/common/init.sh