### PR TITLE
[CUBRIDQA-449] fix ctp can't generate result for ha_repl

### DIFF
--- a/CTP/ha_repl/src/com/navercorp/cubridqa/ha_repl/CheckDiff.java
+++ b/CTP/ha_repl/src/com/navercorp/cubridqa/ha_repl/CheckDiff.java
@@ -36,7 +36,9 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.Properties;
 
+import com.navercorp.cubridqa.common.CommonUtils;
 import com.navercorp.cubridqa.common.Constants;
+import com.navercorp.cubridqa.common.LocalInvoker;
 
 public class CheckDiff {
 	public int check(String filePath, String masterName, String slaveOrReplicaName, String fileSuffix) {
@@ -105,7 +107,8 @@ public class CheckDiff {
 			commandScript += "	 	echo ====================== Expected difference (patch answer) ====================== >> " + resultFile + Constants.LINE_SEPARATOR;
 			commandScript += "		cat " + diffPacthResult + " >> " + resultFile + Constants.LINE_SEPARATOR;
 			commandScript += "fi" + Constants.LINE_SEPARATOR;
-			ExecCommand(commandScript);
+			int shellType = CommonUtils.getShellType(false);
+			LocalInvoker.exec(commandScript, shellType, false);
 			new File(diffPacthResult).delete();
 			new File(master_slaveOrReplicaDiffFileTemp).delete();
 			


### PR DESCRIPTION
 fix ctp can't generate result for ha_repl
Since ExecCommand in CheckDiff.java are called by execute shell file script, they can work well. so I didn't replace all function call to use LocalInvoker.exec

I will recompile all jars once the pr is approved