### PR TITLE
[CUBRIDQA-659] fix missing HOME environmental variable 

### DIFF
--- a/CTP/common/script/start_consumer.sh
+++ b/CTP/common/script/start_consumer.sh
@@ -154,6 +154,8 @@ function updateCodes()
 	    fi
 
 	    echo "#!/bin/bash " > $HOME/.autoUpdate.sh
+	    echo "export HOME=$HOME" >> $HOME/.autoUpdate.sh
+	    echo "export USER=$USER" >> $HOME/.autoUpdate.sh
 	    echo "if [ -f ~/.bash_profile ]; " >> $HOME/.autoUpdate.sh
 	    echo "then " >> $HOME/.autoUpdate.sh
 	    echo "	  . ~/.bash_profile " >> $HOME/.autoUpdate.sh


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-659

When CTP upgrades itself automatically, the HOME environmental variable will be missing which caused by 'at' system process.