### PR TITLE
[CUBRIDQA-772] easy to use memory leak test with valgrind

### DIFF
--- a/CTP/conf/medium.conf
+++ b/CTP/conf/medium.conf
@@ -28,6 +28,9 @@
 # The location of your testing scenario
 scenario=${HOME}/cubrid-testcases/medium
 
+# Run tests with valgrind (no/yes)
+enable_memory_leak=no
+
 # The excluded file list, all directories or files in testcase_exclude_from_file will not be executed by CTP
 testcase_exclude_from_file=${CTP_HOME}/conf/exclusions.txt
 

--- a/CTP/conf/sql.conf
+++ b/CTP/conf/sql.conf
@@ -31,6 +31,9 @@
 # The location of your testing scenario
 scenario=${HOME}/cubrid-testcases/sql
 
+# Run tests with valgrind (no/yes)
+enable_memory_leak=no
+
 # The excluded file list, all directories or files in testcase_exclude_from_file will not be executed by CTP
 testcase_exclude_from_file=${CTP_HOME}/conf/exclusions.txt
 

--- a/CTP/sql/bin/run_memory.sh
+++ b/CTP/sql/bin/run_memory.sh
@@ -57,26 +57,19 @@ done
 
 function check_valgrind()
 {
-   if [ `echo $PATH|grep -c 'valgrind/bin'` -eq 0 ];then
-       echo "Please confirm that your valgrin is installed and properly added \$VALGRIND_HOME/bin to the PATH."
+   valgrind_util=`which valgrind`
+   if [ -z $valgrind_util ];then
+       echo "ERROR: Please confirm that your valgrin is installed and added into PATH."
        exit 1
    else
-       OLD_IFS="$IFS"
-       IFS=":"
-       path_arr=($PATH)
-       for p in ${path_arr[@]}; do
-           if [ `echo $p |grep -c 'valgrind/bin'` -eq 1 ];then
-               export VALGRIND_HOME=${p%/bin} 
-           fi
-       done
-       IFS="${OLD_IFS}"
+       export VALGRIND_HOME=$(cd $(dirname $valgrind_util)/..; pwd) 
    fi
 
    if [ `valgrind --help|grep -c "\-\-date\-time=" ` -gt 0 ];then
        export TIME_OPTION="--date-time=yes"
    else
        export TIME_OPTION="--time-stamp=yes"
-       echo "[NOTE] Current valgrind does not support the --date-time=yes option, so replace it with --time-stamp=yes."
+       echo "NOTE: Current valgrind does not support the --date-time=yes option, so replace it with --time-stamp=yes."
        echo "If you want to use the --date-time=yes option, please get the optimized valgrind from https://github.com/CUBRID/cubrid-testtools-internal/tree/master/valgrind."
    fi
 }

--- a/CTP/sql/bin/run_memory.sh
+++ b/CTP/sql/bin/run_memory.sh
@@ -54,6 +54,33 @@ while getopts "s:f:h:" opt; do
      esac
 done
 
+
+function check_valgrind()
+{
+   if [ `echo $PATH|grep -c 'valgrind/bin'` -eq 0 ];then
+       echo "Please confirm that your valgrin is installed and properly added \$VALGRIND_HOME/bin to the PATH."
+       exit 1
+   else
+       OLD_IFS="$IFS"
+       IFS=":"
+       path_arr=($PATH)
+       for p in ${path_arr[@]}; do
+           if [ `echo $p |grep -c 'valgrind/bin'` -eq 1 ];then
+               export VALGRIND_HOME=${p%/bin} 
+           fi
+       done
+       IFS="${OLD_IFS}"
+   fi
+
+   if [ `valgrind --help|grep -c "\-\-date\-time=" ` -gt 0 ];then
+       export TIME_OPTION="--date-time=yes"
+   else
+       export TIME_OPTION="--time-stamp=yes"
+       echo "[NOTE] Current valgrind does not support the --date-time=yes option, so replace it with --time-stamp=yes."
+       echo "If you want to use the --date-time=yes option, please get the optimized valgrind from https://github.com/CUBRID/cubrid-testtools-internal/tree/master/valgrind."
+   fi
+}
+
 function clean_results()
 {
    curDir=`pwd`
@@ -69,7 +96,6 @@ function clean_results()
 
    cd $curDir
 }
-
 
 function rename_process()
 {
@@ -173,6 +199,9 @@ function format_results()
    echo "======================="  
    cd $curDir
 }
+
+#check valgrind path and --date-time option
+check_valgrind
 
 #clean up memory results
 clean_results

--- a/CTP/sql/bin/run_memory.sh
+++ b/CTP/sql/bin/run_memory.sh
@@ -59,7 +59,7 @@ function check_valgrind()
 {
    valgrind_util=`which valgrind`
    if [ -z $valgrind_util ];then
-       echo "ERROR: Please confirm that your valgrin is installed and added into PATH."
+       echo "ERROR: Please confirm that your valgrind is installed and added into PATH."
        exit 1
    else
        export VALGRIND_HOME=$(cd $(dirname $valgrind_util)/..; pwd) 

--- a/CTP/sql/memory/cub_cas.c
+++ b/CTP/sql/memory/cub_cas.c
@@ -68,10 +68,15 @@ main (int argc, char *argv[])
   const char *option1 = "--trace-children=yes";
   const char *option2 = "--leak-check=full";
   const char *option3 = "--error-limit=no";
-  const char *option4 = "--date-time=yes";
+  //const char *option4 = "--date-time=yes";
   //const char *option4 = "--expensive-definedness-checks=yes";
   const char *option5 = "--track-origins=yes";
   const char *option6 = "--num-callers=50"; 
+  char *option4 = NULL;
+  option4 = getenv ("TIME_OPTION");
+  if (option4 == NULL)
+    option4 = "--date-time=yes";
+
   char log_file[128] = { 0x00 };
   char t[128] = { 0x00 };
   strcpy (t, "--log-file=");

--- a/CTP/sql/memory/cub_server.c
+++ b/CTP/sql/memory/cub_server.c
@@ -71,10 +71,15 @@ main (int argc, char *argv[])
   const char *option1 = "--trace-children=yes";
   const char *option2 = "--leak-check=full";
   const char *option3 = "--error-limit=no";
-  const char *option4 = "--date-time=yes";
+  //const char *option4 = "--date-time=yes";
   //const char *option4 = "--expensive-definedness-checks=yes";
   const char *option5 = "--track-origins=yes";
   const char *option6 = "--num-callers=30"; 
+  char *option4 = NULL;
+  option4 = getenv ("TIME_OPTION");
+  if (option4 == NULL)
+    option4 = "--date-time=yes";
+
   char log_file[128] = { 0x00 };
   char t[128] = { 0x00 };
   strcpy (t, "--log-file=");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-772

In order to use easily, we do changes as below:
- Add 'enable_memory_leak=no' as default value into CTP/conf/sql.conf and CTP/conf/medium.conf. 
- Don't need to set VALGRIND_HOME, just make CTP find valgrind in PATH. If can't find valgrind utility, raise an error and exit test.
- If valgrind not support --date-time=yes option, then use --time-stamp=yes instead of it.
( The option '--date-time=yes|no' is an enhance of https://github.com/CUBRID/cubrid-testtools-internal/tree/master/valgrind. )