### PR TITLE
[CUBRIDQA-773] print cub_cas call stack when there are only cub_cas crashes

### DIFF
--- a/CTP/shell/init_path/shell_utils.sh
+++ b/CTP/shell/init_path/shell_utils.sh
@@ -53,46 +53,6 @@ function do_check_more_errors {
     case_name=`echo ${test_case_dir##*/}`
     result_file_full_name=${test_case_dir}/cases/${case_name}.result
 
-      if [  -f "$CTP_CORE_EXCLUDE_FILE" ]; then
-      find $init_path $CUBRID $test_case_dir -name "core*" -type f > temp_assert_log
-      local hit_all_cnt=0
-      local hit_server_cnt=0
-      local all_core_cnt=0
-      local all_server_core_cnt=0
-
-      local curr_is_server=0
-      local curr_hit=0
-      while read core
-      do
-         all_core_cnt=`expr $all_core_cnt + 1`
-
-         analyzer.sh $core  > analyzer.log 2>&1
-
-         curr_hit=`cat analyzer.log | grep -aE -f "$CTP_CORE_EXCLUDE_FILE" |wc -l`
-         if [ $curr_hit -gt 0 ]; then
-           hit_all_cnt=`expr $hit_all_cnt + 1`
-         fi
-
-         curr_is_server=`cat analyzer.log | grep "PROCESS NAME" | grep "cub_server" |wc -l`
-         if [ $curr_is_server -gt 0 ]; then            
-            all_server_core_cnt=`expr $all_server_core_cnt + 1`
-            if [ $curr_hit -gt 0 ]; then
-               hit_server_cnt=`expr $hit_server_cnt + 1`
-            fi
-         fi
-      done < temp_assert_log
-
-      if [ $hit_all_cnt -eq $all_core_cnt ] || [ $all_server_core_cnt -gt 0 -a $all_server_core_cnt -eq $hit_server_cnt ]; then
-        while read core
-        do
-          rm -rf $core
-        done < temp_assert_log
-      fi
-    fi
-
-
-    find $init_path $CUBRID $test_case_dir -name "core*" -type f>temp_log
-    core_dump_cnt=`cat temp_log|wc -l`
     fatal_err_cnt=`grep -r -n "FATAL ERROR" $CUBRID/log/* | wc -l`
     old_fatal_err_cnt=0
     if [ -f $CUBRID/log/qa_fatal_error_count.log ]
@@ -100,41 +60,97 @@ function do_check_more_errors {
 	old_fatal_err_cnt=`cat $CUBRID/log/qa_fatal_error_count.log`
     fi
 
+    local all_core_cnt=0
+    local all_server_core_cnt=0
+    local all_cas_core_cnt=0
+
+    local hit_all_cnt=0
+    local hit_server_cnt=0
+    local hit_cas_cnt=0
+
+    local curr_is_server=0
+    local curr_is_cas=0
+    local curr_hit=0
+
+    find $init_path $CUBRID $test_case_dir -name "core*" -type f > temp_assert_log
+    all_core_cnt=`cat temp_assert_log | wc -l`
+
+
+    while read core_file
+    do
+	curr_hit=0
+	core_name=`basename $core_file`
+	analyzer.sh $core_file  > analyzer_${core_name}.log 2>&1
+
+	if [  -f "$CTP_CORE_EXCLUDE_FILE" ]; then
+	    curr_hit=`cat analyzer_${core_name}.log | grep -aE -f "$CTP_CORE_EXCLUDE_FILE" |wc -l`
+	    if [ $curr_hit -gt 0 ]; then
+	       hit_all_cnt=`expr $hit_all_cnt + 1`
+	    fi
+	fi
+	 
+	 
+	curr_is_server=`cat analyzer_${core_name}.log | grep "PROCESS NAME" | grep "cub_server" |wc -l`
+	curr_is_cas=`cat analyzer_${core_name}.log | grep "PROCESS NAME" | grep "cub_cas" |wc -l`
+
+	if [ $curr_is_server -gt 0 ]; then            
+	    all_server_core_cnt=`expr $all_server_core_cnt + 1`
+	    if [ $curr_hit -gt 0 ]; then
+	       hit_server_cnt=`expr $hit_server_cnt + 1`
+	    fi
+	elif [ $curr_is_cas -gt 0 ]; then
+	    all_cas_core_cnt=`expr $all_cas_core_cnt + 1`
+	    if [ $curr_hit -gt 0 ]; then
+	       hit_cas_cnt=`expr $hit_cas_cnt + 1`
+	    fi
+	fi
+    done < temp_assert_log
+
+    if [ $hit_all_cnt -eq $all_core_cnt ] || [ $all_server_core_cnt -gt 0 -a $all_server_core_cnt -eq $hit_server_cnt ]; then
+	cat temp_assert_log | xargs rm -rf
+	all_core_cnt=0
+
+	if [ $fatal_err_cnt -eq $old_fatal_err_cnt -o "$SKIP_CHECK_FATAL_ERROR" == "TRUE" ]; then
+	    ## do not need check the cores and fatal errors
+	    return
+	fi
+    fi
+
     cub_build_id=`cubrid_rel | grep CUBRID | awk -F ')' '{print $1}' | awk -F '(' '{print $NF}'`
     current_datetime=`date "+%Y%m%d_%H%M%S"`
     backup_name=AUTO_${cub_build_id}_${current_datetime}
     backup_dir=~/ERROR_BACKUP/${backup_name}
-	host_ip="${TEST_SSH_HOST}"
-	if [ "${host_ip}" = "" ]; then
-	    host_ip=`hostname -i`
-	fi
-	export TEST_INFO_ENV="${USER}@${host_ip}:${TEST_SSH_PORT}"
-	export TEST_INFO_BUILD_ID=${cub_build_id}
+    host_ip="${TEST_SSH_HOST}"
+    if [ "${host_ip}" = "" ]; then
+	host_ip=`hostname -i`
+    fi
+    export TEST_INFO_ENV="${USER}@${host_ip}:${TEST_SSH_PORT}"
+    export TEST_INFO_BUILD_ID=${cub_build_id}
 
-    if [ $core_dump_cnt -gt 0 ] || [ $fatal_err_cnt -gt $old_fatal_err_cnt -a "$SKIP_CHECK_FATAL_ERROR" != "TRUE" ]; then
+    if [ $all_core_cnt -gt 0 ] || [ $fatal_err_cnt -gt $old_fatal_err_cnt -a "$SKIP_CHECK_FATAL_ERROR" != "TRUE" ]; then
         mkdir -p $backup_dir
 
         generage_readme ${test_case_dir} ${backup_dir}
 
-        host_ip=`hostname -i`
-        if [ $core_dump_cnt -gt 0 ]; then
- 	        out=" : NOK found core file on host "$host_ip"("$backup_dir")"
+        if [ $all_core_cnt -gt 0 ]; then
+ 	    out=" : NOK found core file on host "$host_ip"("$backup_dir")"
             echo $out >> $result_file_full_name
             echo $out
-	    while read core
+
+	    while read core_file
 	    do
-		analyzer.sh $core  > analyzer.log 2>&1
-		is_cub_cas=`cat analyzer.log | grep "PROCESS NAME:"|grep "cub_cas"|wc -l`
-		if [ $is_cub_cas -eq 0 ];then
-			  issue_title=`grep SUMMARY analyzer.log | head -n 1`
-		    echo \<!--HTMLESCAPESTART--\>\<a class=SHELLCORE href=\"javascript:reportShellCoreIssue\(\'${core}\', \'${backup_name}\', \'${host_ip}\', \'${TEST_SSH_PORT}\', \'${USER}\', \'${cub_build_id}\', \'${issue_title}\' \) \"\>\<i\>\<font color=red\>REPORT ISSUE FOR BELOW CRASH\</font\>\</i\>\</a\>\<!--HTMLESCAPEEND--\> >> $result_file_full_name
-			  cat analyzer.log >> $result_file_full_name
-			  core_full_stack_fn=${CUBRID}/`basename $core | sed 's/core/fullstack/g'`
-			  analyzer.sh -f $core > ${core_full_stack_fn}
+		core_name=`basename $core_file`
+		is_cub_cas=`cat analyzer_${core_name}.log | grep "PROCESS NAME:"|grep "cub_cas"|wc -l`
+		if [ $is_cub_cas -eq 0 ] || [ $all_cas_core_cnt -eq $all_core_cnt ];then
+		    issue_title=`grep SUMMARY analyzer_${core_name}.log | head -n 1`
+		    echo \<!--HTMLESCAPESTART--\>\<a class=SHELLCORE href=\"javascript:reportShellCoreIssue\(\'${core_file}\', \'${backup_name}\', \'${host_ip}\', \'${TEST_SSH_PORT}\', \'${USER}\', \'${cub_build_id}\', \'${issue_title}\' \) \"\>\<i\>\<font color=red\>REPORT ISSUE FOR BELOW CRASH\</font\>\</i\>\</a\>\<!--HTMLESCAPEEND--\> >> $result_file_full_name
+		    cat analyzer_${core_name}.log >> $result_file_full_name
+		    core_full_stack_fn=${CUBRID}/`echo $core_name | sed 's/core_name/fullstack/g'`
+		    analyzer.sh -f $core_file > ${core_full_stack_fn}
 		else
-			  echo "CRASH FROM CUB_CAS:${core}(skip to print call stacks)" >> $result_file_full_name
+		    echo "CRASH FROM CUB_CAS:${core_file}(skip to print call stacks)" >> $result_file_full_name
 		fi
-	    done < temp_log
+	    done < temp_assert_log
         fi
         if [ $fatal_err_cnt -gt 0 ]; then
             out=" : NOK found fatal error on host "$host_ip"("$backup_dir")"

--- a/CTP/shell/init_path/shell_utils.sh
+++ b/CTP/shell/init_path/shell_utils.sh
@@ -52,7 +52,7 @@ function get_core_analyzer_file {
     local core_stack_fn=${CUBRID}/`basename $core | sed 's/core/briefstack/g'`
     if [ ! -f ${core_stack_fn} ]; then
        analyzer.sh $core > ${core_stack_fn}
-    fi    
+    fi
     echo ${core_stack_fn}
 }
 
@@ -68,7 +68,47 @@ function do_check_more_errors {
 
     local core_brief_stack_fn=""
     clear_core_analyzer_files
+    
+    if [  -f "$CTP_CORE_EXCLUDE_FILE" ]; then
+      find $init_path $CUBRID $test_case_dir -name "core*" -type f > temp_assert_log
+      local hit_all_cnt=0
+      local hit_server_cnt=0
+      local all_core_cnt=0
+      local all_server_core_cnt=0
 
+      local curr_is_server=0
+      local curr_hit=0
+      while read core
+      do
+         all_core_cnt=`expr $all_core_cnt + 1`
+
+         core_brief_stack_fn=`get_core_analyzer_file $core`
+
+         curr_hit=`cat ${core_brief_stack_fn} | grep -aE -f "$CTP_CORE_EXCLUDE_FILE" |wc -l`
+         if [ $curr_hit -gt 0 ]; then
+           hit_all_cnt=`expr $hit_all_cnt + 1`
+         fi
+
+         curr_is_server=`cat ${core_brief_stack_fn} | grep "PROCESS NAME" | grep "cub_server" |wc -l`
+         if [ $curr_is_server -gt 0 ]; then            
+            all_server_core_cnt=`expr $all_server_core_cnt + 1`
+            if [ $curr_hit -gt 0 ]; then
+               hit_server_cnt=`expr $hit_server_cnt + 1`
+            fi
+         fi
+      done < temp_assert_log
+
+      if [ $hit_all_cnt -eq $all_core_cnt ] || [ $all_server_core_cnt -gt 0 -a $all_server_core_cnt -eq $hit_server_cnt ]; then
+        while read core
+        do
+          rm -rf $core
+        done < temp_assert_log
+      fi
+    fi
+
+
+    find $init_path $CUBRID $test_case_dir -name "core*" -type f>temp_log
+    core_dump_cnt=`cat temp_log|wc -l`
     fatal_err_cnt=`grep -r -n "FATAL ERROR" $CUBRID/log/* | wc -l`
     old_fatal_err_cnt=0
     if [ -f $CUBRID/log/qa_fatal_error_count.log ]
@@ -76,94 +116,55 @@ function do_check_more_errors {
 	old_fatal_err_cnt=`cat $CUBRID/log/qa_fatal_error_count.log`
     fi
 
-    local all_core_cnt=0
-    local all_server_core_cnt=0
-    local all_cas_core_cnt=0
-
-    local hit_all_cnt=0
-    local hit_server_cnt=0
-    local hit_cas_cnt=0
-
-    local curr_is_server=0
-    local curr_is_cas=0
-    local curr_hit=0
-
-    find $init_path $CUBRID $test_case_dir -name "core*" -type f > temp_log
-    all_core_cnt=`cat temp_log | wc -l`
-
-    while read core
-    do
-	curr_hit=0
-	core_brief_stack_fn=`get_core_analyzer_file $core`
-
-	if [  -f "$CTP_CORE_EXCLUDE_FILE" ]; then
-	    curr_hit=`cat $core_brief_stack_fn | grep -aE -f "$CTP_CORE_EXCLUDE_FILE" |wc -l`
-	    if [ $curr_hit -gt 0 ]; then
-	       hit_all_cnt=`expr $hit_all_cnt + 1`
-	    fi
-	fi	 
-	 
-	curr_is_server=`cat $core_brief_stack_fn | grep "PROCESS NAME" | grep "cub_server" |wc -l`
-	curr_is_cas=`cat $core_brief_stack_fn | grep "PROCESS NAME" | grep "cub_cas" |wc -l`
-
-	if [ $curr_is_server -gt 0 ]; then            
-	    all_server_core_cnt=`expr $all_server_core_cnt + 1`
-	    if [ $curr_hit -gt 0 ]; then
-	       hit_server_cnt=`expr $hit_server_cnt + 1`
-	    fi
-	elif [ $curr_is_cas -gt 0 ]; then
-	    all_cas_core_cnt=`expr $all_cas_core_cnt + 1`
-	    if [ $curr_hit -gt 0 ]; then
-	       hit_cas_cnt=`expr $hit_cas_cnt + 1`
-	    fi
-	fi
-    done < temp_log
-
-    if [ $hit_all_cnt -eq $all_core_cnt ] || [ $all_server_core_cnt -gt 0 -a $all_server_core_cnt -eq $hit_server_cnt ]; then
-	cat temp_log | xargs rm -rf
-	all_core_cnt=0
-
-	if [ $fatal_err_cnt -eq $old_fatal_err_cnt -o "$SKIP_CHECK_FATAL_ERROR" == "TRUE" ]; then
-	    ## do not need check the cores and fatal errors
-	    return
-	fi
-    fi
-
     cub_build_id=`cubrid_rel | grep CUBRID | awk -F ')' '{print $1}' | awk -F '(' '{print $NF}'`
     current_datetime=`date "+%Y%m%d_%H%M%S"`
     backup_name=AUTO_${cub_build_id}_${current_datetime}
     backup_dir=~/ERROR_BACKUP/${backup_name}
-    host_ip="${TEST_SSH_HOST}"
-    if [ "${host_ip}" = "" ]; then
-	host_ip=`hostname -i`
-    fi
-    export TEST_INFO_ENV="${USER}@${host_ip}:${TEST_SSH_PORT}"
-    export TEST_INFO_BUILD_ID=${cub_build_id}
+	host_ip="${TEST_SSH_HOST}"
+	if [ "${host_ip}" = "" ]; then
+	    host_ip=`hostname -i`
+	fi
+	export TEST_INFO_ENV="${USER}@${host_ip}:${TEST_SSH_PORT}"
+	export TEST_INFO_BUILD_ID=${cub_build_id}
 
-    if [ $all_core_cnt -gt 0 ] || [ $fatal_err_cnt -gt $old_fatal_err_cnt -a "$SKIP_CHECK_FATAL_ERROR" != "TRUE" ]; then
+    if [ $core_dump_cnt -gt 0 ] || [ $fatal_err_cnt -gt $old_fatal_err_cnt -a "$SKIP_CHECK_FATAL_ERROR" != "TRUE" ]; then
         mkdir -p $backup_dir
 
         generage_readme ${test_case_dir} ${backup_dir}
 
-        if [ $all_core_cnt -gt 0 ]; then
+        host_ip=`hostname -i`
+        if [ $core_dump_cnt -gt 0 ]; then
  	    out=" : NOK found core file on host "$host_ip"("$backup_dir")"
             echo $out >> $result_file_full_name
             echo $out
 
+            local has_cub_server_crash=0
+            local is_cub_server=0
+            while read core
+            do
+                 core_brief_stack_fn=`get_core_analyzer_file $core`
+                 is_cub_server=`cat ${core_brief_stack_fn} | grep "PROCESS NAME:"|grep "cub_server"|wc -l`
+                 if [ ${is_cub_server} -gt 0 ]; then
+                      has_cub_server_crash=1
+                 fi
+            done < temp_log
+
 	    while read core
 	    do
-		core_brief_stack_fn=`get_core_analyzer_file $core`
-		is_cub_cas=`cat $core_brief_stack_fn | grep "PROCESS NAME:"|grep "cub_cas"|wc -l`
-		if [ $is_cub_cas -eq 0 ] || [ $all_cas_core_cnt -eq $all_core_cnt ];then
-		    issue_title=`grep SUMMARY $core_brief_stack_fn | head -n 1`
+                core_brief_stack_fn=`get_core_analyzer_file $core`
+		is_cub_cas=`cat ${core_brief_stack_fn} | grep "PROCESS NAME:"|grep "cub_cas"|wc -l`
+		if [ ${has_cub_server_crash} -eq 0 -o $is_cub_cas -eq 0 ];then
+			  issue_title=`grep SUMMARY ${core_brief_stack_fn} | head -n 1`
 		    echo \<!--HTMLESCAPESTART--\>\<a class=SHELLCORE href=\"javascript:reportShellCoreIssue\(\'${core}\', \'${backup_name}\', \'${host_ip}\', \'${TEST_SSH_PORT}\', \'${USER}\', \'${cub_build_id}\', \'${issue_title}\' \) \"\>\<i\>\<font color=red\>REPORT ISSUE FOR BELOW CRASH\</font\>\</i\>\</a\>\<!--HTMLESCAPEEND--\> >> $result_file_full_name
-		    cat $core_brief_stack_fn >> $result_file_full_name		    
-		    core_full_stack_fn=${CUBRID}/`basename $core | sed 's/core/fullstack/g'`
-		    analyzer.sh -f $core > ${core_full_stack_fn}
+			  cat ${core_brief_stack_fn} >> $result_file_full_name
+			  core_full_stack_fn=${CUBRID}/`basename $core | sed 's/core/fullstack/g'`
+			  analyzer.sh -f $core > ${core_full_stack_fn}
 		else
-		    echo "CRASH FROM CUB_CAS:${core}(skip to print call stacks)" >> $result_file_full_name
+			  echo "CRASH FROM CUB_CAS:${core}(skip to print call stacks)" >> $result_file_full_name
 		fi
 	    done < temp_log
+            
+            clear_core_analyzer_files
         fi
         if [ $fatal_err_cnt -gt 0 ]; then
             out=" : NOK found fatal error on host "$host_ip"("$backup_dir")"
@@ -173,12 +174,12 @@ function do_check_more_errors {
         cp -rf $CUBRID $backup_dir/CUBRID
         cp -rf $test_case_dir $backup_dir
         cp -rf $init_path $backup_dir/init_path
-	    cd ~/ERROR_BACKUP
-	    tar zcvf AUTO_${cub_build_id}_${current_datetime}.tar.gz AUTO_${cub_build_id}_${current_datetime}
-	    rm -rf AUTO_${cub_build_id}_${current_datetime}
+	cd ~/ERROR_BACKUP
+	tar zcvf AUTO_${cub_build_id}_${current_datetime}.tar.gz AUTO_${cub_build_id}_${current_datetime}
+	rm -rf AUTO_${cub_build_id}_${current_datetime}
         cd -
 
-	    cat temp_log | xargs -i rm -rf {}
+	cat temp_log | xargs -i rm -rf {}
         echo $fatal_err_cnt>$CUBRID/log/qa_fatal_error_count.log
     fi
     rm temp_log -f >/dev/null 2>&1

--- a/CTP/shell/init_path/shell_utils.sh
+++ b/CTP/shell/init_path/shell_utils.sh
@@ -146,6 +146,7 @@ function do_check_more_errors {
                  is_cub_server=`cat ${core_brief_stack_fn} | grep "PROCESS NAME:"|grep "cub_server"|wc -l`
                  if [ ${is_cub_server} -gt 0 ]; then
                       has_cub_server_crash=1
+                      break
                  fi
             done < temp_log
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-773
1. analyze all the core file in a loop:
(1) to count the number of cub_server and cub_cas 
(2) if the core is recorded in the excluded file, then change the hit value

2. if the cores can be excluded, and then verify the number of fatal error
(1) if there is no fatal error, return
(2) if there is fatal error, continue to do the following backup steps

3. Backup and print the core stacks
(1) if the current core is not a cas core, print it
(2) if the number of cas core is equal to the number of the call total, print it
(3) else, skip printing the core stack

I have test this, all the scenarios are passed.
http://jira.cubrid.org/secure/EditComment!default.jspa?id=1409521&commentId=4751477