### PR TITLE
[CBRD-22768] enhance scripts for dbtran_def.h file

### DIFF
--- a/CTP/common/script/util_compat_test.sh
+++ b/CTP/common/script/util_compat_test.sh
@@ -217,6 +217,10 @@ function config_cci_test_environment()
         rm -f cas_cci.h cas_error.h
         cp ${CUBRID}_${dirver_bk}/include/cas_cci.h .
         cp ${CUBRID}_${dirver_bk}/include/cas_error.h .
+        if [ -e ${CUBRID}_${dirver_bk}/include/dbtran_def.h ]
+        then
+             cp ${CUBRID}_${dirver_bk}/include/dbtran_def.h . 
+        fi  
 	
         #save driver and server info
         echo "CCI_Version=${the1st}" >$CUBRID/qa.conf


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-22768
cci compatibility installation save driver's dbtran_def.h file  
eg:
tar zxvf CUBRID-CCI-10.2.0.8277-0234bbb-Linux.x86_64.tar.gz 
CUBRID-CCI-10.2.0.8277-0234bbb-Linux.x86_64/include/cas_cci.h
CUBRID-CCI-10.2.0.8277-0234bbb-Linux.x86_64/include/cas_error.h
CUBRID-CCI-10.2.0.8277-0234bbb-Linux.x86_64/include/dbtran_def.h
CUBRID-CCI-10.2.0.8277-0234bbb-Linux.x86_64/lib/libcascci.so
CUBRID-CCI-10.2.0.8277-0234bbb-Linux.x86_64/lib/libcascci.so.10.2