### PR TITLE
[CUBRIDQA-876] enhance script to avoid patch operation failed

### DIFF
--- a/CTP/common/ext/run_compat_jdbc.sh
+++ b/CTP/common/ext/run_compat_jdbc.sh
@@ -139,9 +139,14 @@ function run_sql() {
     #exclude cases and do patch for some case
     cd ${CTP_HOME}/../${git_repo_name}
     run_git_update -f . -b $branch
-    cat $exclude_file|grep "^${ctp_scenario}"|xargs -i rm -rf {}
-    cd ${ctp_scenario}
-    patch -p0 -f < $patch_file
+    if [ -s $exclude_file ] ;then
+       cat $exclude_file|grep "^${ctp_scenario}"|xargs -i rm -rf {}
+    fi 
+    git status .
+    cd ${ctp_scenario} 
+    if [ -s $patch_file ] ;then
+        patch -p0 -f < $patch_file
+    fi
     cd ${CTP_HOME}/..
 
     ini.sh -s sql ${TEST_RUNTIME_CONF} scenario '${CTP_HOME}'/../${git_repo_name}/$ctp_scenario


### PR DESCRIPTION
**Now when we test jdbc compatibility,it sometimes appears apply patch files failed,so enhance test scripts.**



eg:
can't find file to patch at input line 16629
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:


---_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_01_insert_syntax_t.answer        (revision 61825)
+++ _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_01_insert_syntax_t.answer        (working copy)

No file to patch.  Skipping patch.
3 out of 3 hunks ignored
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_01_insert_syntax_ts.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_02_insert_constraints_dtltz.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_02_insert_constraints_dttz.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_02_insert_constraints_tsltz.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_02_insert_constraints_tstz.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_03_insert_value_format_dtltz.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_03_insert_value_format_dttz.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_03_insert_value_format_tsltz.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_03_insert_value_format_tstz.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_04_insert_boundary_dtltz.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_04_insert_boundary_dttz.answer
Hunk #1 FAILED at 46.
Hunk #2 FAILED at 92.
2 out of 2 hunks FAILED -- saving rejects to file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_0
4_insert_boundary_dttz.answer.rej
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_04_insert_boundary_tsltz.answer
patching file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_04_insert_boundary_tstz.answer
Hunk #1 FAILED at 46.
Hunk #2 FAILED at 99.
2 out of 2 hunks FAILED -- saving rejects to file _27_banana_qa/issue_5765_timezone_support/_01_table_operations/_03_insert_update/answers/_0
4_insert_boundary_tstz.answer.rej