### PR TITLE
[CUBRIDQA-1040] improve unittest test to support different versions

### DIFF
--- a/CTP/common/script/run_cubrid_install
+++ b/CTP/common/script/run_cubrid_install
@@ -393,7 +393,7 @@ function needDevToolSet()
     version=$1
     major_version=$(echo $version | cut -d . -f 1)
     minor_version=$(echo $version | cut -d . -f 2)
-    if [ $major_version -ge 10 -a $minor_version -ge 2 ];then
+    if [ $major_version -ge 11 -o $major_version -eq 10 -a $minor_version -ge 2 ];then
 	echo true
     else
 	echo false

--- a/CTP/common/script/run_cubrid_install
+++ b/CTP/common/script/run_cubrid_install
@@ -421,7 +421,6 @@ function change_url_to_local {
     return 1
 }
 
-
 function BuildAndInstallForUnitTest()
 {
     build_url=$1
@@ -435,61 +434,60 @@ function BuildAndInstallForUnitTest()
     echo ""
 
     cmake >/dev/null 2>&1
-    [ $? -ne 0 ] && echo "Please make sure CMAKE is installed!" && exit 0    
+    [ $? -ne 0 ] && echo "Please make sure CMAKE is installed!" && exit 0
 
     rm $buildFile >/dev/null 2>&1
     wget -t 3 -T 120 $build_url
     if [ $? -ne 0 ];then
-	echo "[ERROR] download build fail with url $build_url"
-	print_current_machine_status
+        echo "[ERROR] download build fail with url $build_url"
+        print_current_machine_status
     fi
 
     if [ -d $cub ]
     then
             rm -rf $cub
     fi
-    
+
     mkdir -p $cub
-    tar -zvxf $buildFile 
-    cp -rf ${buildName}/* $cub/  
+    tar -zvxf $buildFile
+    cp -rf ${buildName}/* $cub/
     cd $cub
     if [ -f VERSION ]; then
-    	version_file=VERSION
+        version_file=VERSION
     elif [ -f VERSION-DIST ]; then
-    	version_file=VERSION-DIST
+        version_file=VERSION-DIST
     fi
     version=$(cat $version_file)
 
-    change_url_to_local ./CMakeLists.txt "http://thrysoee.dk/editline/"  
-    change_url_to_local ./CMakeLists.txt "https://github.com/Tencent/rapidjson/archive/"  
-    change_url_to_local ./CMakeLists.txt "https://github.com/libexpat/libexpat/releases/download/R_2_2_5/"  
-    change_url_to_local ./CMakeLists.txt "http://www.digip.org/jansson/releases/jansson-2.10.tar.gz"  
-    change_url_to_local ./CMakeLists.txt "http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz"  
-    change_url_to_local ./CMakeLists.txt "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.27.tar.bz2"  
+    change_url_to_local ./CMakeLists.txt "http://thrysoee.dk/editline/"
+    change_url_to_local ./CMakeLists.txt "https://github.com/Tencent/rapidjson/archive/"
+    change_url_to_local ./CMakeLists.txt "https://github.com/libexpat/libexpat/releases/download/R_2_2_5/"
+    change_url_to_local ./CMakeLists.txt "http://www.digip.org/jansson/releases/jansson-2.10.tar.gz"
+    change_url_to_local ./CMakeLists.txt "http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz"
+    change_url_to_local ./CMakeLists.txt "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.27.tar.bz2"
 
-    configure_options="-DCMAKE_BUILD_TYPE=Debug"
+    configure_options=" -t 64 -m debug -b build_debug "
     if [ "$tCat" == "unit-release" ];then
-	configure_options="-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+        configure_options=" -t 64 -m release -b build_release "
     fi
-    	 
+
     if [ "`needDevToolSet ${version}`" == "true" ];then
-	[ ! -f "/opt/rh/devtoolset-6/enable" ] && echo "[Error]: devtoolset-6 is not found" && exit 1
-	(
-	  source /opt/rh/devtoolset-6/enable
-	  cmake ${configure_options}
-          make -j
-	)
+        [ ! -f "/opt/rh/devtoolset-8/enable" ] && echo "[Error]: devtoolset-8 is not found" && exit 1
+        (
+          source /opt/rh/devtoolset-8/enable
+          sh build.sh ${configure_options}
+        )
     else
-	  cmake ${configure_options}
-          make -j
-    fi 
-    
-    cd $HOME   
+        sh build.sh ${configure_options}
+    fi
+
+    cd $HOME
     rm $buildFile
     rm -rf ${buildName}
     echo "INSTALL `date '+%Y%m%d%H%M%s'` $@" 2>&1 |tee -a $HOME/.unitTestInstall.log
     cd $curDir
 }
+
 
 if [ "$tCat" == "general" ]
 then

--- a/CTP/shell/local/unittest.sh
+++ b/CTP/shell/local/unittest.sh
@@ -29,7 +29,11 @@ function init {
 }
 
 function list {
+    # below to 10.1
     find $CUBRID/util $CUBRID/bin -name unittests* 2>/dev/null | grep -v CMake
+    # over to 10.2
+    find $CUBRID/build_release/bin $CUBRID/build_debug/bin -name "unittests*" 2>/dev/null
+    find $CUBRID/build_*/util/unittest* 2>/dev/null
 }
 
 function execute {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1040

Modified to script for support to version 11 over.

We are use to devtools-set 8 for version 10.2 over.
and below version 10.1 was used to devtools-set 4.
but, 'run_cubrid_script' was not supported to version 11 over.
because, not switched to devtools-set 8.

