### PR TITLE
[CUBRIDQA-1040] improve unittest test to support different versions

### DIFF
--- a/CTP/common/script/run_cubrid_install
+++ b/CTP/common/script/run_cubrid_install
@@ -393,7 +393,7 @@ function needDevToolSet()
     version=$1
     major_version=$(echo $version | cut -d . -f 1)
     minor_version=$(echo $version | cut -d . -f 2)
-    if [ $major_version -ge 10 -a $minor_version -ge 2 ];then
+    if [ $major_version -ge 11 -o $major_version -eq 10 -a $minor_version -ge 2 ];then
 	echo true
     else
 	echo false

--- a/CTP/common/script/run_cubrid_install
+++ b/CTP/common/script/run_cubrid_install
@@ -393,7 +393,8 @@ function needDevToolSet()
     version=$1
     major_version=$(echo $version | cut -d . -f 1)
     minor_version=$(echo $version | cut -d . -f 2)
-    if [ $major_version -ge 11 -o $major_version -eq 10 -a $minor_version -ge 2 ];then
+    compare_version=${major_version}${minor_version}
+    if [ $compare_version -ge 102 ];then
 	echo true
     else
 	echo false


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1040

Modified to script for support to version 11 over.

We are use to devtools-set 8 for version 10.2 over.
and below version 10.1 was used to devtools-set 4.
but, 'run_cubrid_script' was not supported to version 11 over.
because, not switched to devtools-set 8.