### PR TITLE
[CUBRIDQA-1084] Add url properties for validity of checking jdbc conn…

### DIFF
--- a/CTP/sql/configuration/test_config/test_default.xml
+++ b/CTP/sql/configuration/test_config/test_default.xml
@@ -13,6 +13,7 @@
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>
+    <url_properties>useSSL=true</url_properties>
    <reset>
        <!-- <item>SET NAMES utf8</item>-->
        <item>SET SYSTEM PARAMETERS 'add_column_update_hard_default=default'</item>

--- a/CTP/sql/configuration/test_config/test_default.xml
+++ b/CTP/sql/configuration/test_config/test_default.xml
@@ -13,7 +13,7 @@
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>
-    <url_properties>useSSL=true</url_properties>
+    <!--<url_properties>useSSL=true</url_properties> -->
    <reset>
        <!-- <item>SET NAMES utf8</item>-->
        <item>SET SYSTEM PARAMETERS 'add_column_update_hard_default=default'</item>

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -274,6 +274,9 @@ public class ConsoleDAO extends Executor {
 				String url = dbConf.getDburl() + "?charset=" + dbConf.getCharSet();
 				String user = dbConf.getDbuser();
 				String password = dbConf.getDbpassword();
+                               	if (Test.urlProperties != null && Test.urlProperties.length() != 0) {
+				     url += "&" + Test.urlProperties;
+		         	}
 				conn = MyDriverManager.giveConnection(driver, url, user, password);
 			} else {
 				dataSource = dataSourceMap.get(db);
@@ -388,9 +391,12 @@ public class ConsoleDAO extends Executor {
 		Iterator<DefTestDB> iter = dbMap.values().iterator();
 		while (iter.hasNext()) {
 			DefTestDB dbConf = (DefTestDB) iter.next();
-			url = dbConf.getDburl();
+			url = dbConf.getDburl()  + "?charset=" + dbConf.getCharSet();
 			user = dbConf.getDbuser();
 			password = dbConf.getDbpassword();
+			if (Test.urlProperties != null && Test.urlProperties.length() != 0) {
+				url += "&" + Test.urlProperties;
+			}
 
 			Connection conn = null;
 			conn = MyDriverManager.giveConnection(driver, url, user, password);

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -275,8 +275,8 @@ public class ConsoleDAO extends Executor {
 				String user = dbConf.getDbuser();
 				String password = dbConf.getDbpassword();
 				if (Test.urlProperties != null && Test.urlProperties.length() != 0) {
-            url += "&" + Test.urlProperties;
-        }
+					url += "&" + Test.urlProperties;
+				}
 				conn = MyDriverManager.giveConnection(driver, url, user, password);
 			} else {
 				dataSource = dataSourceMap.get(db);

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -274,9 +274,9 @@ public class ConsoleDAO extends Executor {
 				String url = dbConf.getDburl() + "?charset=" + dbConf.getCharSet();
 				String user = dbConf.getDbuser();
 				String password = dbConf.getDbpassword();
-                               	if (Test.urlProperties != null && Test.urlProperties.length() != 0) {
-				     url += "&" + Test.urlProperties;
-		         	}
+				if (Test.urlProperties != null && Test.urlProperties.length() != 0) {
+            url += "&" + Test.urlProperties;
+        }
 				conn = MyDriverManager.giveConnection(driver, url, user, password);
 			} else {
 				dataSource = dataSourceMap.get(db);


### PR DESCRIPTION
…ection
http://jira.cubrid.org/browse/CUBRIDQA-1084

CTP checks connection before testing sql TCs. 
However, it fails to connect in case that a url property doesn't have useSSL=true and cubrid is configured to set SSL=ON. 
CTP for sql testing should have url properties for prechecking a connection. 