### PR TITLE
[CUBRIDQA-1086] When the JDBC compatibility test, can not apply to patch & exclude list.

### DIFF
--- a/CTP/common/ext/run_compat_jdbc.sh
+++ b/CTP/common/ext/run_compat_jdbc.sh
@@ -124,11 +124,6 @@ function run_sql() {
     fi
     get_best_version_for_exclude_patch_file "${exclude_file_dir}" "$COMPAT_TEST_CATAGORY"
 
-    #exclude cases and do patch for some case
-    cd ${CTP_HOME}/../${git_repo_name}
-    run_git_update -f . -b $branch
-    git status .
-   
     fileName=${exclude_file##*/}
     fileName2=${patch_file##*/}
     cp -f $exclude_file $tmpdir/$fileName
@@ -138,6 +133,11 @@ function run_sql() {
     if [ ` cat ${exclude_file}|grep "^scenario"|wc -l` -ge 1 ];then
          sed -i 's/scenario\///g' $exclude_file
     fi
+
+    #exclude cases and do patch for some case
+    cd ${CTP_HOME}/../${git_repo_name}
+    run_git_update -f . -b $branch
+    git status .
 
     cd ${ctp_scenario} 
     if [ -s $patch_file ] 

--- a/CTP/common/ext/run_compat_jdbc.sh
+++ b/CTP/common/ext/run_compat_jdbc.sh
@@ -121,6 +121,7 @@ function run_sql() {
     elif [ "${COMPAT_TEST_CATAGORY##*_}" == "D" ]; then
         branch=$BUILD_SCENARIO_BRANCH_GIT
         exclude_file_dir=$HOME/${git_repo_name}/${ctp_scenario}/config/daily_regression_test_exclude_list_compatibility
+        run_git_update -f $HOME/${git_repo_name} -b $exclude_branch
     fi
     get_best_version_for_exclude_patch_file "${exclude_file_dir}" "$COMPAT_TEST_CATAGORY"
 

--- a/CTP/common/ext/run_compat_jdbc.sh
+++ b/CTP/common/ext/run_compat_jdbc.sh
@@ -121,7 +121,7 @@ function run_sql() {
     elif [ "${COMPAT_TEST_CATAGORY##*_}" == "D" ]; then
         branch=$BUILD_SCENARIO_BRANCH_GIT
         exclude_file_dir=$HOME/${git_repo_name}/${ctp_scenario}/config/daily_regression_test_exclude_list_compatibility
-        run_git_update -f $HOME/${git_repo_name} -b $exclude_branch
+        run_git_update -f $HOME/${git_repo_name} -b $branch
     fi
     get_best_version_for_exclude_patch_file "${exclude_file_dir}" "$COMPAT_TEST_CATAGORY"
 


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CUBRIDQA-1086

It only occurs to over 10.0 server versions.
(Below to 9.x versions is not occurs)

because the code sequence was wrong on 'run_compat_jdbc.sh'.