### PR TITLE
[CUBRIDQA-1087] When sql ext test in JDBC compatibility, patch file was the wrong path.

### DIFF
--- a/CTP/common/ext/run_compat_jdbc.sh
+++ b/CTP/common/ext/run_compat_jdbc.sh
@@ -114,7 +114,7 @@ function run_sql() {
         if [ "$BUILD_IS_FROM_GIT" == "1" ];then
            exclude_branch=$BUILD_SCENARIO_BRANCH_GIT
            exclude_file_dir=$HOME/${compat_config_repo_name}/${ctp_scenario}/config/daily_regression_test_exclude_list_compatibility
-           run_git_update -f $HOME/${git_repo_name} -b $exclude_branch
+           run_git_update -f $HOME/${compat_config_repo_name} -b $exclude_branch
         elif [ "$BUILD_IS_FROM_GIT" == "0" ];then
            exclude_branch=$BUILD_SVN_BRANCH_NEW
            exclude_file_dir=$HOME/dailyqa/$BUILD_SVN_BRANCH_NEW/config
@@ -123,7 +123,7 @@ function run_sql() {
     elif [ "${COMPAT_TEST_CATAGORY##*_}" == "D" ]; then
         branch=$BUILD_SCENARIO_BRANCH_GIT
         exclude_file_dir=$HOME/${compat_config_repo_name}/${ctp_scenario}/config/daily_regression_test_exclude_list_compatibility
-        run_git_update -f $HOME/${git_repo_name} -b $branch
+        run_git_update -f $HOME/${compat_config_repo_name} -b $branch
     fi
     get_best_version_for_exclude_patch_file "${exclude_file_dir}" "$COMPAT_TEST_CATAGORY"
 

--- a/CTP/common/ext/run_compat_jdbc.sh
+++ b/CTP/common/ext/run_compat_jdbc.sh
@@ -82,7 +82,9 @@ function run_sql() {
         exit
     fi
     cp -f ${test_config_template} ${TEST_RUNTIME_CONF}
- 
+
+    compat_config_repo_name=cubrid-testcases 
+
     if [ "$COMPAT_BUILD_SCENARIOS" == "medium" ];then
         ctp_type="medium"
         git_repo_name=cubrid-testcases
@@ -111,7 +113,7 @@ function run_sql() {
         branch=$COMPAT_BUILD_SCENARIO_BRANCH_GIT
         if [ "$BUILD_IS_FROM_GIT" == "1" ];then
            exclude_branch=$BUILD_SCENARIO_BRANCH_GIT
-           exclude_file_dir=$HOME/${git_repo_name}/${ctp_scenario}/config/daily_regression_test_exclude_list_compatibility
+           exclude_file_dir=$HOME/${compat_config_repo_name}/${ctp_scenario}/config/daily_regression_test_exclude_list_compatibility
            run_git_update -f $HOME/${git_repo_name} -b $exclude_branch
         elif [ "$BUILD_IS_FROM_GIT" == "0" ];then
            exclude_branch=$BUILD_SVN_BRANCH_NEW
@@ -120,7 +122,7 @@ function run_sql() {
         fi
     elif [ "${COMPAT_TEST_CATAGORY##*_}" == "D" ]; then
         branch=$BUILD_SCENARIO_BRANCH_GIT
-        exclude_file_dir=$HOME/${git_repo_name}/${ctp_scenario}/config/daily_regression_test_exclude_list_compatibility
+        exclude_file_dir=$HOME/${compat_config_repo_name}/${ctp_scenario}/config/daily_regression_test_exclude_list_compatibility
         run_git_update -f $HOME/${git_repo_name} -b $branch
     fi
     get_best_version_for_exclude_patch_file "${exclude_file_dir}" "$COMPAT_TEST_CATAGORY"


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CUBRIDQA-1087

This shell file worked to same the test case repository and patch & exclude list repository.
So, when executing the sql ext test, patch & exclude list path was 'cubrid-testcases-private' repository then patch was not applied.

I was fixed it.

Modified list
- CTP/common/ext/run_compat_jdbc.sh