### PR TITLE
[CUBRIDQA-1098] support javasp server utility for sql test

### DIFF
--- a/CTP/sql/bin/run.sh
+++ b/CTP/sql/bin/run.sh
@@ -54,7 +54,7 @@ test_data_file=""
 interface_type=""
 alias ini="sh ${CTP_HOME}/bin/ini.sh"
 cci_urlproperty=""
-
+support_javasp=""
 
 function usage ()
 {
@@ -179,6 +179,7 @@ function do_init()
     fi
     
     cci_urlproperty=`ini -s sql ${config_file_main} cci_urlproperty`
+    support_javasp=`cubrid | grep -w javasp | awk '{if($1=="javasp") {print "yes"}}'`
     
     cd $curDir
 }
@@ -455,6 +456,12 @@ function stop_db()
          cubrid server stop $1 2>&1 > /dev/null
      fi
 
+     if [ $support_javasp == "yes" -a $javasp_param == "yes" ]
+     then
+          cubrid javasp stop $1 2>&1 >> $log_filename
+          echo "stop javasp database $1"
+     fi
+
      sleep 2
      cubrid service stop 2>&1 > /dev/null
 }
@@ -517,6 +524,14 @@ function start_db()
      else
          cubrid server start $1 2>&1 >> $log_filename
      fi
+     
+     javasp_param=`ini -s "common"  $CUBRID/conf/cubrid.conf java_stored_procedure`     
+     if [ $support_javasp == "yes" -a $javasp_param == "yes" ]
+     then
+          cubrid javasp start $1 2>&1 >> $log_filename
+          echo "start javasp database $1"
+     fi     
+     
      sleep 2
 }
 

--- a/CTP/sql/bin/run.sh
+++ b/CTP/sql/bin/run.sh
@@ -456,7 +456,8 @@ function stop_db()
          cubrid server stop $1 2>&1 > /dev/null
      fi
 
-     if [ $support_javasp == "yes" -a $javasp_param == "yes" ]
+     jcnt=`cat $CUBRID/conf/cubrid.conf | grep -v "#" | grep java_stored_procedure | grep -E 'on|yes' | wc -l`
+     if [ $support_javasp == "yes" -a $jcnt -gt 0 ]
      then
           cubrid javasp stop $1 2>&1 >> $log_filename
           echo "stop javasp database $1"
@@ -525,8 +526,8 @@ function start_db()
          cubrid server start $1 2>&1 >> $log_filename
      fi
      
-     javasp_param=`ini -s "common"  $CUBRID/conf/cubrid.conf java_stored_procedure`     
-     if [ $support_javasp == "yes" -a $javasp_param == "yes" ]
+     jcnt=`cat $CUBRID/conf/cubrid.conf | grep -v "#" | grep java_stored_procedure | grep -E 'on|yes' | wc -l`     
+     if [ $support_javasp == "yes" -a $jcnt -gt 0 ]
      then
           cubrid javasp start $1 2>&1 >> $log_filename
           echo "start javasp database $1"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1098

The javasp test scenario for sql should be run after the javasp utility is started.
It should also support SQL testing for the before and after version of the javasp utility implementation.

