### PR TITLE
Tool changed to register job schedule

### DIFF
--- a/CTP/common/script/start_consumer.sh
+++ b/CTP/common/script/start_consumer.sh
@@ -174,7 +174,7 @@ function updateCodes()
                 m=$(date +%M)
 		let "m=m+1"
 		timeStr="$h:$m"
-		at $timeStr cmd /c sh $HOME/.autoUpdate.sh
+                schtasks /create /tn "CTP upgrade" /tr sh $HOME/.autoUpdate.sh /sc once /st $timeStr
 		echo "At task will be start: $timeStr" >> $HOME/.autoUpdate.sh
 	    fi 
 	    export LC_ALL=$default_lc_all


### PR DESCRIPTION
AT command is not used. Use schtasks to register a job schedule according to the MS guide.