### PR TITLE
[CBRD-23843] Separate link file of cascci for compatibility test

### DIFF
--- a/CTP/common/script/util_compat_test.sh
+++ b/CTP/common/script/util_compat_test.sh
@@ -187,30 +187,36 @@ function config_cci_test_environment()
         miner_v=`echo $the1st |awk -F '.' '{print $2}'`
         the3st=${main_v}"."${miner_v}
 
-        #config file in lib folder
-        cd $CUBRID/lib
-        rm libcascci.*
-        cp -d ${CUBRID}_${dirver_bk}/lib/libcascci.* .
+        #CBRD-23843 (dblink) : The libcubridsa.so links libcascci.so 
+        #If The libcascci.so is changed, The libcubridsa.so can't link libcascci.so
+	cd ${CUBRID}_${dirver_bk}/lib
         exactfile=`find . -type f -name "libcascci.so.*" |uniq|sort -r| head -n 1`
-        if [ ! -e libcascci.so ]
+	
+	if [ ! -e libcascci.so ]
         then
           ln -s $exactfile libcascci.so
-        fi  
-        
+        fi
+	mv libcascci.so libcascci_compat.so
+
         if [ ! -e libcascci.so.${the1st} ]
         then
           ln -s $exactfile libcascci.so.${the1st}
         fi
-        
+
         if [ ! -e libcascci.so.${the2nd} ]
         then
           ln -s $exactfile libcascci.so.${the2nd}
         fi
-        
+
         if [ ! -e libcascci.so.${the3st} ]
         then
           ln -s $exactfile libcascci.so.${the3st}
         fi
+
+
+        #config file in lib folder
+        cd $CUBRID/lib
+        cp -d ${CUBRID}_${dirver_bk}/lib/libcascci*.* .
         
         #config include file
         cd $CUBRID/include

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -1367,7 +1367,7 @@ function gcc(){
 gcc_exec=`which gcc`
 gcc_option=$@
 
-if [ -e libcascci_compat.so ]
+if [ -e ${CUBRID}/lib/libcascci_compat.so ]
 then
     gcc_option=`echo $gcc_option|sed "s#-lcascci#-lcascci_compat#g"`
 fi
@@ -1400,7 +1400,7 @@ gcc_option=`echo $gcc_option|sed "s#-lpthread##g"`
 
 #CBRD-23843 : libcascci name is changed only for QA test. 
 #get common compile option
-if [ ! -e libcascci_compat.so ]
+if [ ! -e ${CUBRID}/lib/libcascci_compat.so ]
 then 
     gcc_option="-g -I$CUBRID/include -L$CUBRID/lib -lcascci $gcc_option"
 else

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -1362,8 +1362,24 @@ fi
 echo $BIT_VERSION
 }
 
+#CBRD-23843 (dblink) : Another file name of libcascci.so is used only for QA test.
+function gcc(){
+gcc_exec=`which gcc`
+gcc_option=$@
+
+if [ -e libcascci_compat.so ]
+then
+    gcc_option=`echo $gcc_option|sed "s#-lcascci#-lcascci_compat#g"`
+fi
+
+$gcc_exec $gcc_option
+}
+
+
 #replace gcc to cross platforms
 function xgcc(){
+gcc_exec=`which gcc`
+
 BIT_VERSION=`get_bit_ver`
 
 #recive parameters and delete options
@@ -1382,8 +1398,14 @@ gcc_option=`echo $gcc_option|sed "s#-lcascci##g"`
 gcc_option=`echo $gcc_option|sed "s#-lpthread##g"`
 
 
+#CBRD-23843 : libcascci name is changed only for QA test. 
 #get common compile option
-gcc_option="-g -I$CUBRID/include -L$CUBRID/lib -lcascci $gcc_option"
+if [ ! -e libcascci_compat.so ]
+then 
+    gcc_option="-g -I$CUBRID/include -L$CUBRID/lib -lcascci $gcc_option"
+else
+    gcc_option="-g -I$CUBRID/include -L$CUBRID/lib -lcascci_compat $gcc_option"
+fi
 
 #get bit version of cubrid
 if [ "$BIT_VERSION" -eq 32 ]
@@ -1407,7 +1429,7 @@ else
     esac
 fi
 #compile c program using gcc_option
-gcc $gcc_option
+$gcc_exec $gcc_option
 
 } 
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23843

Refer to https://github.com/CUBRID/cubrid/pull/3183/files#diff-97411a44f560c0c56145dabbd9496b2d6da041f19a081d5c9979729ed1e9a944R510 
See  target_link_libraries(cubridsa cascci) which makes 'cubrid_rel' not to link lower version of cascci library.

The solution is another cascci file in case of the compatibility test . 