### PR TITLE
[CBRD-23843] Keep the current version of libcascci.so.* for the compatibility test. 

### DIFF
--- a/CTP/common/script/util_compat_test.sh
+++ b/CTP/common/script/util_compat_test.sh
@@ -187,8 +187,7 @@ function config_cci_test_environment()
         miner_v=`echo $the1st |awk -F '.' '{print $2}'`
         the3st=${main_v}"."${miner_v}
 
-        #CBRD-23843 (dblink) : The libcubridsa.so links libcascci.so 
-        #If The libcascci.so is changed, The libcubridsa.so can't link libcascci.so
+        #CBRD-23843 (dblink) : The current version of libcascci.so should not be removed because the libcubridsa has to link it. 
 	cd ${CUBRID}_${dirver_bk}/lib
         exactfile=`find . -type f -name "libcascci.so.*" |uniq|sort -r| head -n 1`
 	
@@ -196,7 +195,6 @@ function config_cci_test_environment()
         then
           ln -s $exactfile libcascci.so
         fi
-	mv libcascci.so libcascci_compat.so
 
         if [ ! -e libcascci.so.${the1st} ]
         then

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -1362,24 +1362,8 @@ fi
 echo $BIT_VERSION
 }
 
-#CBRD-23843 (dblink) : Another file name of libcascci.so is used only for QA test.
-function gcc(){
-gcc_exec=`which gcc`
-gcc_option=$@
-
-if [ -e ${CUBRID}/lib/libcascci_compat.so ]
-then
-    gcc_option=`echo $gcc_option|sed "s#-lcascci#-lcascci_compat#g"`
-fi
-
-$gcc_exec $gcc_option
-}
-
-
 #replace gcc to cross platforms
 function xgcc(){
-gcc_exec=`which gcc`
-
 BIT_VERSION=`get_bit_ver`
 
 #recive parameters and delete options
@@ -1398,14 +1382,8 @@ gcc_option=`echo $gcc_option|sed "s#-lcascci##g"`
 gcc_option=`echo $gcc_option|sed "s#-lpthread##g"`
 
 
-#CBRD-23843 : libcascci name is changed only for QA test. 
 #get common compile option
-if [ ! -e ${CUBRID}/lib/libcascci_compat.so ]
-then 
-    gcc_option="-g -I$CUBRID/include -L$CUBRID/lib -lcascci $gcc_option"
-else
-    gcc_option="-g -I$CUBRID/include -L$CUBRID/lib -lcascci_compat $gcc_option"
-fi
+gcc_option="-g -I$CUBRID/include -L$CUBRID/lib -lcascci $gcc_option"
 
 #get bit version of cubrid
 if [ "$BIT_VERSION" -eq 32 ]
@@ -1429,7 +1407,7 @@ else
     esac
 fi
 #compile c program using gcc_option
-$gcc_exec $gcc_option
+gcc $gcc_option
 
 } 
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23843

The cubrid_rel links not libcascci.so but the real file name like libcascci.so.12.0

The real file should not be removed for the compatibility test.