### PR TITLE
[CUBRIDQA-1157] Modify runone.sh in isolation/ctltool for waiting blocked DROP query

### DIFF
--- a/CTP/isolation/ctltool/runone.sh
+++ b/CTP/isolation/ctltool/runone.sh
@@ -63,7 +63,7 @@ function format_ctl_result()
 	sed -i 's/STATUS: forcefully killing pid [0-9]*/STATUS: forcefully killing pid ?/g' $1
 	sed -i 's/key: [0-9]*(OID:/key: ?(OID:/g' $1
 	sed -i 's/\: [0-9]*|[0-9]*|[0-9]*/\: ?/g' $1
-	for i in `cat -n $1 | grep "ERROR RETURNED" | grep "You are waiting for user" | awk '{print $1}'`; do 
+	for i in `cat -n $1 | grep -E "(ERROR RETURNED|timed out waiting on)" | grep "You are waiting for user" | awk '{print $1}'`; do 
 	    sed -i "${i}s/`hostname -f`/localhost/g" $1
 	    sed -E -i "${i}s/([0-9])+/?/g" $1
 	done


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CUBRIDQA-1157

To apply the same result format to the lock timeout error message of DDL query (user1@host1|9808)->(PUBLIC@localhost|?), 
the grep condition in function format_ctl_result() is modified.
