### PR TITLE
[CUBRIDQA-1162] Fix an problem the TC path is in the form 'release_12.…

### DIFF
--- a/CTP/common/script/convert_to_git_url.sh
+++ b/CTP/common/script/convert_to_git_url.sh
@@ -64,6 +64,9 @@ function convert_to_git_url(){
 	fi
 	
         branch_name=`git rev-parse --abbrev-ref HEAD`
+	if [[ "$branch_name" == release_* ]];then
+		branch_name=`echo $branch_name|sed 's#_#/#g'`
+	fi
         repo_root_url_prefix=`echo ${root_git_url}|sed 's/\.git$//g'|sed 's#//.*github\.com#//github.com#g'`
 
         while [ ! -d .git ] && [ ! "`pwd`" = "/" ]


### PR DESCRIPTION
…0' when reporting cores automatically.
refer to http://jira.cubrid.org/browse/CUBRIDQA-1162

When automatically reporting the core, the TC path is in the form of 'release_12.0'.
The actual path is the form of 'release/12.0'
This is when 'release/' is changed to 'release_' by run_git_update.
For resolution, we need to add a code that changes 'release_' to 'release/' in CTP/common/script/ convert_to_git_url.sh.
If branch_name originally contains '_', it may change incorrectly.(e.g release_json to release/json)
branch_name internally manages not to be used in 'release_' format, and adds code to change 'release_' to 'release/'.