### PR TITLE
[CUBRIDQA-1184] print error messages to the result files when server-message is on

### DIFF
--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/common/SQLParser.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/common/SQLParser.java
@@ -76,7 +76,7 @@ public class SQLParser {
                     } else {
                         String controlCmd = getControlCommand(line);
                         if (controlCmd != null) {
-                            // control command : either hodcas or server-output
+                            // control command : either hodcas or server-message
                             Sql sql = new Sql("", controlCmd, null, false);
                             list.add(sql);
                         }
@@ -148,7 +148,7 @@ public class SQLParser {
     private static String getControlCommand(String line) {
         if (line.startsWith("--+")) {
             String s = line.replaceAll(" ", "").toLowerCase();
-            if (s.startsWith("--+holdcas") || s.startsWith("--+server-output")) {
+            if (s.startsWith("--+holdcas") || s.startsWith("--+server-message")) {
                 return line.trim() + System.getProperty("line.separator");
             }
         }

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Test.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Test.java
@@ -92,7 +92,7 @@ public class Test {
 
 	private String autocommit = "";
 
-	private String serverOutput = "off";
+	private String serverMessage = "off";
 
 	private boolean needSummaryXML = false;
 
@@ -205,12 +205,12 @@ public class Test {
 		this.holdcas = holdcas;
 	}
 
-	public String getServerOutput() {
-		return serverOutput;
+	public String getServerMessage() {
+		return serverMessage;
 	}
 	
-	public void setServerOutput (String so) {
-		this.serverOutput = so;
+	public void setServerMessage (String so) {
+		this.serverMessage = so;
 	}
 
 	public String getReset_scripts() {

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Test.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Test.java
@@ -1,26 +1,27 @@
 /**
  * Copyright (c) 2016, Search Solution Corporation. All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions are met:
- * 
- *   * Redistributions of source code must retain the above copyright notice, 
- *     this list of conditions and the following disclaimer.
- * 
- *   * Redistributions in binary form must reproduce the above copyright 
- *     notice, this list of conditions and the following disclaimer in 
- *     the documentation and/or other materials provided with the distribution.
- * 
- *   * Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products 
- *     derived from this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
- * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ *
+ * <p>Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * <p>* Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * <p>* Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * <p>* Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.navercorp.cubridqa.cqt.console.bean;
 
@@ -36,559 +37,558 @@ import java.util.Set;
 import java.util.Vector;
 
 public class Test {
-	public static final int MODE_RUN = 0;
+    public static final int MODE_RUN = 0;
 
-	public static final int MODE_MAKE_ANSWER = 1;
+    public static final int MODE_MAKE_ANSWER = 1;
 
-	public static final int MODE_RESULT = 2;
+    public static final int MODE_RESULT = 2;
 
-	public static final int MODE_NO_RESULT = 3;
+    public static final int MODE_NO_RESULT = 3;
 
-	public static final int TYPE_FUNCTION = 0;
+    public static final int TYPE_FUNCTION = 0;
 
-	public static final int TYPE_PERFORMANCE = 1;
+    public static final int TYPE_PERFORMANCE = 1;
 
-	public static String urlProperties = "";
+    public static String urlProperties = "";
 
-	private String testId;
-	
-	private String caseFilter;
+    private String testId;
 
-	private String testType;
+    private String caseFilter;
 
-	private String testTypeAlias;
+    private String testType;
 
-	private String testBit;
+    private String testTypeAlias;
 
-	private String path;
+    private String testBit;
 
-	private int siteRunTimes;
+    private String path;
 
-	private boolean editorExecute;
+    private int siteRunTimes;
 
-	private String version = "";
+    private boolean editorExecute;
 
-	private String codeset = "";
+    private String version = "";
 
-	private String language = "";
+    private String codeset = "";
 
-	private String collation = "";
+    private String language = "";
 
-	private String result_dir = "";
+    private String collation = "";
 
-	private boolean i18n;
+    private String result_dir = "";
 
-	private boolean qaview = false;
+    private boolean i18n;
 
-	private boolean isFirstTime = true;
+    private boolean qaview = false;
 
-	private String run_mode = null;
+    private boolean isFirstTime = true;
 
-	private String runModeSecondary = null;
+    private String run_mode = null;
 
-	private String holdcas = "";
+    private String runModeSecondary = null;
 
-	private String reset_scripts = "";
+    private String holdcas = "";
 
-	private String autocommit = "";
+    private String reset_scripts = "";
 
-	private String serverMessage = "off";
+    private String autocommit = "";
 
-	private boolean needSummaryXML = false;
+    private String serverMessage = "off";
 
-	private boolean needAnswerInSummary = false;
+    private boolean needSummaryXML = false;
 
-	private boolean needCheckServerStatus = false;
+    private boolean needAnswerInSummary = false;
 
-	private boolean needDebugHint = false;
+    private boolean needCheckServerStatus = false;
 
-	private String scenarioRootPath = "";
-	
-	private Map<String, List<File>> coreCaseMap = new HashMap<String, List<File>>();
-	
-	private List<String> allCoreList = new ArrayList<String>();
+    private boolean needDebugHint = false;
 
-	public List<String> getAllCoreList() {
-		return allCoreList;
-	}
+    private String scenarioRootPath = "";
 
-	public void setAllCoreList(List<String> allCoreList) {
-		this.allCoreList = allCoreList;
-	}
+    private Map<String, List<File>> coreCaseMap = new HashMap<String, List<File>>();
 
-	public Map<String, List<File>> getCoreCaseMap() {
-		return coreCaseMap;
-	}
-	
-	public void putCoreCaseIntoMap(String caseFile, List<File> flist){
-		this.coreCaseMap.put(caseFile, flist);
-	}
+    private List<String> allCoreList = new ArrayList<String>();
 
-	public String getScenarioRootPath() {
-		return scenarioRootPath;
-	}
+    public List<String> getAllCoreList() {
+        return allCoreList;
+    }
 
-	public void setScenarioRootPath(String scenarioRootPath) {
-		this.scenarioRootPath = scenarioRootPath;
-	}
+    public void setAllCoreList(List<String> allCoreList) {
+        this.allCoreList = allCoreList;
+    }
 
-	public String getUrlProperties() {
-		return urlProperties;
-	}
+    public Map<String, List<File>> getCoreCaseMap() {
+        return coreCaseMap;
+    }
 
-	public void setUrlProperties(String urlProperties) {
-		this.urlProperties = urlProperties;
-	}
+    public void putCoreCaseIntoMap(String caseFile, List<File> flist) {
+        this.coreCaseMap.put(caseFile, flist);
+    }
 
-	public boolean isNeedDebugHint() {
-		return needDebugHint;
-	}
+    public String getScenarioRootPath() {
+        return scenarioRootPath;
+    }
 
-	public void setNeedDebugHint(boolean needDebugHint) {
-		this.needDebugHint = needDebugHint;
-	}
+    public void setScenarioRootPath(String scenarioRootPath) {
+        this.scenarioRootPath = scenarioRootPath;
+    }
 
-	public boolean isNeedCheckServerStatus() {
-		return needCheckServerStatus;
-	}
+    public String getUrlProperties() {
+        return urlProperties;
+    }
 
-	public void setNeedCheckServerStatus(boolean needCheckServerStatus) {
-		this.needCheckServerStatus = needCheckServerStatus;
-	}
+    public void setUrlProperties(String urlProperties) {
+        this.urlProperties = urlProperties;
+    }
 
-	public boolean isNeedSummaryXML() {
-		return needSummaryXML;
-	}
+    public boolean isNeedDebugHint() {
+        return needDebugHint;
+    }
 
-	public void setNeedSummaryXML(boolean needSummaryXML) {
-		this.needSummaryXML = needSummaryXML;
-	}
+    public void setNeedDebugHint(boolean needDebugHint) {
+        this.needDebugHint = needDebugHint;
+    }
 
-	private BufferedWriter fileHandle = null;
+    public boolean isNeedCheckServerStatus() {
+        return needCheckServerStatus;
+    }
 
-	public BufferedWriter getFileHandle() {
-		return fileHandle;
-	}
+    public void setNeedCheckServerStatus(boolean needCheckServerStatus) {
+        this.needCheckServerStatus = needCheckServerStatus;
+    }
 
-	public void setFileHandle(BufferedWriter fileHandle) {
-		this.fileHandle = fileHandle;
-	}
+    public boolean isNeedSummaryXML() {
+        return needSummaryXML;
+    }
 
-	private TestCaseSummary[] failList;
+    public void setNeedSummaryXML(boolean needSummaryXML) {
+        this.needSummaryXML = needSummaryXML;
+    }
 
-	public TestCaseSummary[] getFailList() {
-		return failList;
-	}
+    private BufferedWriter fileHandle = null;
 
-	public void setFailList(TestCaseSummary[] failList) {
-		this.failList = failList;
-	}
+    public BufferedWriter getFileHandle() {
+        return fileHandle;
+    }
 
-	public void initFailSummary() {
-		failList = new TestCaseSummary[100];
-		this.setFailList(failList);
-	}
+    public void setFileHandle(BufferedWriter fileHandle) {
+        this.fileHandle = fileHandle;
+    }
 
-	public String getAutocommit() {
-		return autocommit;
-	}
+    private TestCaseSummary[] failList;
 
-	public void setAutocommit(String autocommit) {
-		this.autocommit = autocommit;
-	}
+    public TestCaseSummary[] getFailList() {
+        return failList;
+    }
 
-	public String getHoldcas() {
-		return holdcas;
-	}
+    public void setFailList(TestCaseSummary[] failList) {
+        this.failList = failList;
+    }
 
-	public void setHoldcas(String holdcas) {
-		this.holdcas = holdcas;
-	}
+    public void initFailSummary() {
+        failList = new TestCaseSummary[100];
+        this.setFailList(failList);
+    }
 
-	public String getServerMessage() {
-		return serverMessage;
-	}
-	
-	public void setServerMessage (String so) {
-		this.serverMessage = so;
-	}
+    public String getAutocommit() {
+        return autocommit;
+    }
 
-	public String getReset_scripts() {
-		return reset_scripts;
-	}
+    public void setAutocommit(String autocommit) {
+        this.autocommit = autocommit;
+    }
 
-	public void setReset_scripts(String reset_scripts) {
-		this.reset_scripts = reset_scripts;
-	}
+    public String getHoldcas() {
+        return holdcas;
+    }
 
-	public String getRun_mode() {
-		return run_mode;
-	}
+    public void setHoldcas(String holdcas) {
+        this.holdcas = holdcas;
+    }
 
-	public void setRun_mode(String run_mode) {
-		this.run_mode = run_mode;
-	}
+    public String getServerMessage() {
+        return serverMessage;
+    }
 
-	public String[] getScripts() {
-		return scripts;
-	}
+    public void setServerMessage(String so) {
+        this.serverMessage = so;
+    }
 
-	public void setScripts(String[] scripts) {
-		this.scripts = scripts;
-	}
+    public String getReset_scripts() {
+        return reset_scripts;
+    }
 
-	private String[] scripts;
+    public void setReset_scripts(String reset_scripts) {
+        this.reset_scripts = reset_scripts;
+    }
 
-	private String charset_file = "default_charset.xml";
+    public String getRun_mode() {
+        return run_mode;
+    }
 
-	public boolean isFirstTime() {
-		return isFirstTime;
-	}
+    public void setRun_mode(String run_mode) {
+        this.run_mode = run_mode;
+    }
 
-	public void setFirstTime(boolean isFirstTime) {
-		this.isFirstTime = isFirstTime;
-	}
+    public String[] getScripts() {
+        return scripts;
+    }
 
-	public int getSiteRunTimes() {
-		return siteRunTimes;
-	}
+    public void setScripts(String[] scripts) {
+        this.scripts = scripts;
+    }
 
-	public void setSiteRunTimes(int siteRunTimes) {
-		this.siteRunTimes = siteRunTimes;
-	}
+    private String[] scripts;
 
-	private int runMode;
+    private String charset_file = "default_charset.xml";
 
-	private String[] cases;
+    public boolean isFirstTime() {
+        return isFirstTime;
+    }
 
-	private Map<String, Object> testInfoMap = new Hashtable<String, Object>();
+    public void setFirstTime(boolean isFirstTime) {
+        this.isFirstTime = isFirstTime;
+    }
 
-	private List<String> caseFileList = new ArrayList<String>();
+    public int getSiteRunTimes() {
+        return siteRunTimes;
+    }
 
-	private Map<String, CaseResult> caseMap = new Hashtable<String, CaseResult>();
+    public void setSiteRunTimes(int siteRunTimes) {
+        this.siteRunTimes = siteRunTimes;
+    }
 
-	private Map<String, Summary> summaryMap = new Hashtable<String, Summary>();
+    private int runMode;
 
-	private Map<String, SummaryInfo> summaryInfoMap = new Hashtable<String, SummaryInfo>();
+    private String[] cases;
 
-	private Map catMap = new Hashtable();
+    private Map<String, Object> testInfoMap = new Hashtable<String, Object>();
 
-	private Map<String, String> caseDbMap = new Hashtable<String, String>();
+    private List<String> caseFileList = new ArrayList<String>();
 
-	private String dbId = null;
+    private Map<String, CaseResult> caseMap = new Hashtable<String, CaseResult>();
 
-	private String connId = "";
+    private Map<String, Summary> summaryMap = new Hashtable<String, Summary>();
 
-	private List<String> dirPath = new Vector<String>();
+    private Map<String, SummaryInfo> summaryInfoMap = new Hashtable<String, SummaryInfo>();
 
-	private Summary summary;
+    private Map catMap = new Hashtable();
 
-	private SummaryInfo summaryInfo;
+    private Map<String, String> caseDbMap = new Hashtable<String, String>();
 
-	private String dbVersion;
+    private String dbId = null;
 
-	private String dbBuild;
+    private String connId = "";
 
-	private int sqlRunTime = 1;
+    private List<String> dirPath = new Vector<String>();
 
-	private int type = 0;
+    private Summary summary;
 
-	private boolean isDebug;
+    private SummaryInfo summaryInfo;
 
-	private Map<String, Object> connIDList = new Hashtable<String, Object>();
+    private String dbVersion;
 
-	private Set<String> resultDirSet = new HashSet();
+    private String dbBuild;
 
-	public Test(String testId) {
-		this.testId = testId;
-	}
+    private int sqlRunTime = 1;
 
-	public Map getCatMap() {
-		return catMap;
-	}
+    private int type = 0;
 
-	public String getConnId() {
-		return connId;
-	}
+    private boolean isDebug;
 
-	public String getTestId() {
-		return testId;
-	}
+    private Map<String, Object> connIDList = new Hashtable<String, Object>();
 
-	public String getCaseFilter() {
-		return caseFilter;
-	}
+    private Set<String> resultDirSet = new HashSet();
 
-	public void setCaseFilter(String caseFilter) {
-		this.caseFilter = caseFilter;
-	}
-	
-	public Summary getSummary() {
-		return summary;
-	}
+    public Test(String testId) {
+        this.testId = testId;
+    }
 
-	public void setSummary(Summary testSummary) {
-		this.summary = testSummary;
-	}
+    public Map getCatMap() {
+        return catMap;
+    }
 
-	public boolean isNeedAnswerInSummary() {
-		return needAnswerInSummary;
-	}
+    public String getConnId() {
+        return connId;
+    }
 
-	public void setNeedAnswerInSummary(boolean needAnswerInSummary) {
-		this.needAnswerInSummary = needAnswerInSummary;
-	}
+    public String getTestId() {
+        return testId;
+    }
 
-	public List<String> getDirPath() {
-		return dirPath;
-	}
+    public String getCaseFilter() {
+        return caseFilter;
+    }
 
-	public int getRunMode() {
-		return runMode;
-	}
+    public void setCaseFilter(String caseFilter) {
+        this.caseFilter = caseFilter;
+    }
 
-	public void setRunMode(int runMode) {
-		this.runMode = runMode;
-	}
+    public Summary getSummary() {
+        return summary;
+    }
 
-	public String getRunModeSecondary() {
-		return runModeSecondary;
-	}
+    public void setSummary(Summary testSummary) {
+        this.summary = testSummary;
+    }
 
-	public void setRunModeSecondary(String runModeSecondary) {
-		this.runModeSecondary = runModeSecondary;
-	}
+    public boolean isNeedAnswerInSummary() {
+        return needAnswerInSummary;
+    }
 
-	public List<String> getCaseFileList() {
-		return caseFileList;
-	}
+    public void setNeedAnswerInSummary(boolean needAnswerInSummary) {
+        this.needAnswerInSummary = needAnswerInSummary;
+    }
 
-	public void putCaseResultToMap(String caseFile, CaseResult caseResult) {
-		caseMap.put(caseFile, caseResult);
-	}
+    public List<String> getDirPath() {
+        return dirPath;
+    }
 
-	public CaseResult getCaseResultFromMap(String caseFile) {
-		return (CaseResult) caseMap.get(caseFile);
-	}
+    public int getRunMode() {
+        return runMode;
+    }
 
-	public void putSummaryToMap(String path, Summary summary) {
-		summaryMap.put(path, summary);
-	}
+    public void setRunMode(int runMode) {
+        this.runMode = runMode;
+    }
 
-	public Summary getSummaryFromMap(String path) {
-		return (Summary) summaryMap.get(path);
-	}
+    public String getRunModeSecondary() {
+        return runModeSecondary;
+    }
 
-	public void putSummaryInfoToMap(String path, SummaryInfo summaryInfo) {
-		summaryInfoMap.put(path, summaryInfo);
-	}
+    public void setRunModeSecondary(String runModeSecondary) {
+        this.runModeSecondary = runModeSecondary;
+    }
 
-	public SummaryInfo getSummaryInfoFromMap(String path) {
-		return (SummaryInfo) summaryInfoMap.get(path);
-	}
+    public List<String> getCaseFileList() {
+        return caseFileList;
+    }
 
-	public SummaryInfo getSummaryInfo() {
-		return summaryInfo;
-	}
+    public void putCaseResultToMap(String caseFile, CaseResult caseResult) {
+        caseMap.put(caseFile, caseResult);
+    }
 
-	public void setSummaryInfo(SummaryInfo summaryInfo) {
-		this.summaryInfo = summaryInfo;
-	}
+    public CaseResult getCaseResultFromMap(String caseFile) {
+        return (CaseResult) caseMap.get(caseFile);
+    }
 
-	public void setConnId(String connId) {
-		this.connId = connId;
-	}
+    public void putSummaryToMap(String path, Summary summary) {
+        summaryMap.put(path, summary);
+    }
 
-	public String[] getCases() {
-		return cases;
-	}
+    public Summary getSummaryFromMap(String path) {
+        return (Summary) summaryMap.get(path);
+    }
 
-	public void setCases(String[] cases) {
-		this.cases = cases;
-	}
+    public void putSummaryInfoToMap(String path, SummaryInfo summaryInfo) {
+        summaryInfoMap.put(path, summaryInfo);
+    }
 
-	public Map<String, Object> getTestInfoMap() {
-		return testInfoMap;
-	}
+    public SummaryInfo getSummaryInfoFromMap(String path) {
+        return (SummaryInfo) summaryInfoMap.get(path);
+    }
 
-	public void putCaseDbToMap(String caseFile, String db) {
-		caseDbMap.put(caseFile, db);
-	}
+    public SummaryInfo getSummaryInfo() {
+        return summaryInfo;
+    }
 
-	public String getDbId(String caseFile) {
-		return (String) caseDbMap.get(caseFile);
-	}
+    public void setSummaryInfo(SummaryInfo summaryInfo) {
+        this.summaryInfo = summaryInfo;
+    }
 
-	public String getDbId() {
-		return dbId;
-	}
+    public void setConnId(String connId) {
+        this.connId = connId;
+    }
 
-	public void setDbId(String dbId) {
-		this.dbId = dbId;
-	}
+    public String[] getCases() {
+        return cases;
+    }
 
-	public String getPath() {
-		return path;
-	}
+    public void setCases(String[] cases) {
+        this.cases = cases;
+    }
 
-	public void setPath(String path) {
-		this.path = path;
-	}
+    public Map<String, Object> getTestInfoMap() {
+        return testInfoMap;
+    }
 
-	public String getDbVersion() {
-		return dbVersion;
-	}
+    public void putCaseDbToMap(String caseFile, String db) {
+        caseDbMap.put(caseFile, db);
+    }
 
-	public void setDbVersion(String dbVersion) {
-		this.dbVersion = dbVersion;
-	}
+    public String getDbId(String caseFile) {
+        return (String) caseDbMap.get(caseFile);
+    }
 
-	public String getDbBuild() {
-		return dbBuild;
-	}
+    public String getDbId() {
+        return dbId;
+    }
 
-	public void setDbBuild(String dbBuild) {
-		this.dbBuild = dbBuild;
-	}
+    public void setDbId(String dbId) {
+        this.dbId = dbId;
+    }
 
-	public int getType() {
-		return type;
-	}
+    public String getPath() {
+        return path;
+    }
 
-	public void setType(int type) {
-		this.type = type;
-	}
+    public void setPath(String path) {
+        this.path = path;
+    }
 
-	public String getTestTypeAlias() {
-		return testTypeAlias;
-	}
+    public String getDbVersion() {
+        return dbVersion;
+    }
 
-	public void setTestTypeAlias(String testTypeAlias) {
-		this.testTypeAlias = testTypeAlias;
-	}
+    public void setDbVersion(String dbVersion) {
+        this.dbVersion = dbVersion;
+    }
 
-	public int getSqlRunTime() {
-		return sqlRunTime;
-	}
+    public String getDbBuild() {
+        return dbBuild;
+    }
 
-	public void setSqlRunTime(int sqlRunTime) {
-		this.sqlRunTime = sqlRunTime;
-	}
+    public void setDbBuild(String dbBuild) {
+        this.dbBuild = dbBuild;
+    }
 
-	public Set<String> getResultDirSet() {
-		return resultDirSet;
-	}
+    public int getType() {
+        return type;
+    }
 
-	public void setResultDirSet(Set<String> resultDirSet) {
-		this.resultDirSet = resultDirSet;
-	}
+    public void setType(int type) {
+        this.type = type;
+    }
 
-	public void addResultDir(String resultDir) {
-		resultDirSet.add(resultDir);
-	}
+    public String getTestTypeAlias() {
+        return testTypeAlias;
+    }
 
-	public boolean isEditorExecute() {
-		return editorExecute;
-	}
+    public void setTestTypeAlias(String testTypeAlias) {
+        this.testTypeAlias = testTypeAlias;
+    }
 
-	public void setEditorExecute(boolean editorExecute) {
-		this.editorExecute = editorExecute;
-	}
+    public int getSqlRunTime() {
+        return sqlRunTime;
+    }
 
-	public String getVersion() {
-		return version;
-	}
+    public void setSqlRunTime(int sqlRunTime) {
+        this.sqlRunTime = sqlRunTime;
+    }
 
-	public void setVersion(String version) {
-		this.version = version;
-	}
+    public Set<String> getResultDirSet() {
+        return resultDirSet;
+    }
 
-	public String getCodeset() {
-		return codeset;
-	}
+    public void setResultDirSet(Set<String> resultDirSet) {
+        this.resultDirSet = resultDirSet;
+    }
 
-	public void setCodeset(String codeset) {
-		this.codeset = codeset;
-	}
+    public void addResultDir(String resultDir) {
+        resultDirSet.add(resultDir);
+    }
 
-	public String getLanguage() {
-		return language;
-	}
+    public boolean isEditorExecute() {
+        return editorExecute;
+    }
 
-	public void setLanguage(String language) {
-		this.language = language;
-	}
+    public void setEditorExecute(boolean editorExecute) {
+        this.editorExecute = editorExecute;
+    }
 
-	public String getCollation() {
-		return collation;
-	}
+    public String getVersion() {
+        return version;
+    }
 
-	public void setCollation(String collation) {
-		this.collation = collation;
-	}
+    public void setVersion(String version) {
+        this.version = version;
+    }
 
-	public boolean isI18n() {
-		return i18n;
-	}
+    public String getCodeset() {
+        return codeset;
+    }
 
-	public void setI18n(boolean i18n) {
-		this.i18n = i18n;
-	}
+    public void setCodeset(String codeset) {
+        this.codeset = codeset;
+    }
 
-	public boolean isQaview() {
-		return qaview;
-	}
+    public String getLanguage() {
+        return language;
+    }
 
-	public void setQaview(boolean qaview) {
-		this.qaview = qaview;
-	}
+    public void setLanguage(String language) {
+        this.language = language;
+    }
 
-	public boolean isDebug() {
-		return isDebug;
-	}
+    public String getCollation() {
+        return collation;
+    }
 
-	public void setDebug(boolean isDebug) {
-		this.isDebug = isDebug;
-	}
+    public void setCollation(String collation) {
+        this.collation = collation;
+    }
 
-	public String getCharset_file() {
-		return charset_file;
-	}
+    public boolean isI18n() {
+        return i18n;
+    }
 
-	public void setCharset_file(String charset_file) {
-		this.charset_file = charset_file;
-	}
+    public void setI18n(boolean i18n) {
+        this.i18n = i18n;
+    }
 
-	public String getResult_dir() {
-		return result_dir;
-	}
+    public boolean isQaview() {
+        return qaview;
+    }
 
-	public void setResult_dir(String result_dir) {
-		this.result_dir = result_dir;
-	}
+    public void setQaview(boolean qaview) {
+        this.qaview = qaview;
+    }
 
-	public Map<String, Object> getConnIDList() {
-		return connIDList;
-	}
+    public boolean isDebug() {
+        return isDebug;
+    }
 
-	public void setConnIDList(Map<String, Object> connIDList) {
-		this.connIDList = connIDList;
-	}
+    public void setDebug(boolean isDebug) {
+        this.isDebug = isDebug;
+    }
 
-	public String getTestType() {
-		return testType;
-	}
+    public String getCharset_file() {
+        return charset_file;
+    }
 
-	public void setTestType(String testType) {
-		this.testType = testType;
-	}
+    public void setCharset_file(String charset_file) {
+        this.charset_file = charset_file;
+    }
 
-	public String getTestBit() {
-		return testBit;
-	}
+    public String getResult_dir() {
+        return result_dir;
+    }
 
-	public void setTestBit(String testBit) {
-		this.testBit = testBit;
-	}
+    public void setResult_dir(String result_dir) {
+        this.result_dir = result_dir;
+    }
 
+    public Map<String, Object> getConnIDList() {
+        return connIDList;
+    }
+
+    public void setConnIDList(Map<String, Object> connIDList) {
+        this.connIDList = connIDList;
+    }
+
+    public String getTestType() {
+        return testType;
+    }
+
+    public void setTestType(String testType) {
+        this.testType = testType;
+    }
+
+    public String getTestBit() {
+        return testBit;
+    }
+
+    public void setTestBit(String testBit) {
+        this.testBit = testBit;
+    }
 }

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
@@ -1,57 +1,36 @@
 /**
  * Copyright (c) 2016, Search Solution Corporation. All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions are met:
- * 
- *   * Redistributions of source code must retain the above copyright notice, 
- *     this list of conditions and the following disclaimer.
- * 
- *   * Redistributions in binary form must reproduce the above copyright 
- *     notice, this list of conditions and the following disclaimer in 
- *     the documentation and/or other materials provided with the distribution.
- * 
- *   * Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products 
- *     derived from this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
- * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ *
+ * <p>Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * <p>* Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * <p>* Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * <p>* Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.navercorp.cubridqa.cqt.console.bo;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.lang.reflect.Method;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Types;
-import java.text.NumberFormat;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.navercorp.cubridqa.common.coreanalyzer.AnalyzerMain;
-import com.navercorp.cubridqa.cqt.common.CommonUtils;
+import com.navercorp.cubridqa.cqt.common.SQLParser;
 import com.navercorp.cubridqa.cqt.console.Executor;
 import com.navercorp.cubridqa.cqt.console.bean.CaseResult;
 import com.navercorp.cubridqa.cqt.console.bean.ProcessMonitor;
 import com.navercorp.cubridqa.cqt.console.bean.Sql;
-import com.navercorp.cubridqa.cqt.console.bean.SqlParam;
 import com.navercorp.cubridqa.cqt.console.bean.Summary;
 import com.navercorp.cubridqa.cqt.console.bean.Test;
 import com.navercorp.cubridqa.cqt.console.bean.TestCaseSummary;
@@ -68,1455 +47,1624 @@ import com.navercorp.cubridqa.cqt.console.util.RepositoryPathUtil;
 import com.navercorp.cubridqa.cqt.console.util.StringUtil;
 import com.navercorp.cubridqa.cqt.console.util.SystemUtil;
 import com.navercorp.cubridqa.cqt.console.util.TestUtil;
-import com.navercorp.cubridqa.cqt.common.SQLParser;
-
 import cubrid.jdbc.driver.CUBRIDConnection;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ConsoleBO extends Executor {
-	private ProcessMonitor processMonitor = new ProcessMonitor();
-	private boolean useMonitor;
-	private boolean saveEveryone = true;
-	private String os = SystemUtil.getOS();
-	private String homePath = "d:\\";
-	private boolean isFirstTime = true;
-
-	public boolean isUseMonitor() {
-		return useMonitor;
-	}
-
-	public void setUseMonitor(boolean useMonitor) {
-		this.useMonitor = useMonitor;
-	}
-
-	public boolean isSaveEveryone() {
-		return saveEveryone;
-	}
-
-	public void setSaveEveryone(boolean saveEveryone) {
-		this.saveEveryone = saveEveryone;
-	}
-
-	private Test test;
-
-	private ConfigureUtil configureUtil;
-
-	private ConsoleDAO dao;
-
-	private boolean hasSql = false;
-
-	public ConsoleBO() {
-		this.logId = "ConsoleBO";
-		this.useMonitor = false;
-		this.saveEveryone = true;
-	}
-
-	public ConsoleBO(boolean usemonitor) {
-		this.useMonitor = usemonitor;
-		this.logId = "ConsoleBO";
-	}
-
-	public ConsoleBO(boolean usemonitor, boolean saveeveryone) {
-		this.useMonitor = usemonitor;
-		this.saveEveryone = saveeveryone;
-		this.logId = "ConsoleBO";
-		initConsoleBoLog(this.logId);
-	}
-
-	private void initConsoleBoLog(String logId) {
-		LogUtil.clearLog(logId);
-		LogUtil.log(logId, "[time]clearLog:" + (System.currentTimeMillis() - startTime));
-	}
-
-	/**
-	 * run the test case .
-	 * 
-	 * @param test
-	 * @return
-	 */
-	@SuppressWarnings("deprecation")
-	public Summary runTest(Test test) {
-		if (test == null) {
-			return null;
-		}
-
-		this.test = test;
-		configureUtil = new ConfigureUtil();
-		long startTime = System.currentTimeMillis();
-		processMonitor.setStartTime(startTime);
-
-		if (useMonitor) {
-			File f = new File(RepositoryPathUtil.getTestResultDir(test.getTestId()));
-			if (!f.exists())
-				f.mkdirs();
-
-		}
-		LogUtil.log(logId, "[time]startMonitor:" + (System.currentTimeMillis() - startTime));
-		try {
-			startTime = System.currentTimeMillis();
-			init();
-			LogUtil.log(logId, "[time]init:" + (System.currentTimeMillis() - startTime));
-
-			startTime = System.currentTimeMillis();
-			dao = new ConsoleDAO(test, configureUtil);
-			LogUtil.log(logId, "[time]createDAO:" + (System.currentTimeMillis() - startTime));
-
-			startTime = System.currentTimeMillis();
-			buildTest(test);
-			LogUtil.log(logId, "[time]buildTest:" + (System.currentTimeMillis() - startTime));
-
-			processMonitor.setAllFile(test.getCaseFileList().size());
-
-			startTime = System.currentTimeMillis();
-			boolean ok = checkDb(test);
-			LogUtil.log(logId, "[time]checkDb:" + (System.currentTimeMillis() - startTime));
-			if (!ok) {
-				onMessage("-10000");
-				LogUtil.log(logId, "-10000");
-				processMonitor.doException();
-				return null;
-			}
-
-			createResultDirs(test);
-
-			if (test.isNeedSummaryXML()) {
-				// create test case list into summary file
-				test.setFileHandle(FileUtil.openOneFileHandle(test.getResult_dir() + TestUtil.SUMMARYLIST_FILE));
-				LogUtil.log(logId, "[Test Configuration File]:" + test.getCharset_file());
-				// write test case list head
-				FileUtil.writeHeadForXML(test.getFileHandle());
-			}
-
-			startTime = System.currentTimeMillis();
-
-			System.out.println("---------------execute begin--------------------");
-			execute(test);
-			System.out.println("---------------execute end  --------------------");
-
-			if (this.processMonitor.getCurrentstate() == this.processMonitor.Status_Stoping) {
-				this.processMonitor.setCurrentstate(this.processMonitor.Status_Stoped);
-				return null;
-			}
-			LogUtil.log(logId, "[time]execute:" + (System.currentTimeMillis() - startTime));
-
-			if (test.getType() == Test.TYPE_FUNCTION) {
-				startTime = System.currentTimeMillis();
-				if (test.getRunMode() == Test.MODE_RESULT) {
-					createResultDirs(test);
-				} else if (test.getRunMode() == Test.MODE_MAKE_ANSWER) {
-					createAnswerDirs(test);
-				}
-				LogUtil.log(logId, "[time]createDir:" + (System.currentTimeMillis() - startTime));
-
-				startTime = System.currentTimeMillis();
-
-				if (!saveEveryone) {
-					saveTempResults(test);
-					LogUtil.log(logId, "[time]saveTempResult:" + (System.currentTimeMillis() - startTime));
-
-					startTime = System.currentTimeMillis();
-					if (test.getRunMode() == Test.MODE_RESULT || test.getRunMode() == Test.MODE_NO_RESULT) {
-						saveResults(test);
-					} else if (test.getRunMode() == Test.MODE_MAKE_ANSWER) {
-						saveAnswers(test);
-					}
-				}
-				LogUtil.log(logId, "[time]saveResultOrAnswer:" + (System.currentTimeMillis() - startTime));
-			} else if (test.getType() == Test.TYPE_PERFORMANCE) {
-				startTime = System.currentTimeMillis();
-				LogUtil.log(logId, "[time]savePerformanceResult:" + (System.currentTimeMillis() - startTime));
-			}
-			onMessage("*******results saved.");
-		} catch (Throwable e) {
-			e.printStackTrace();
-			onMessage(e.getMessage());
-			LogUtil.log(logId, LogUtil.getExceptionMessage(new Exception(e.getMessage(), e)));
-		} finally {
-			startTime = System.currentTimeMillis();
-			if (dao != null) {
-				dao.release();
-			}
-			LogUtil.log(logId, "[time]DAO release:" + (System.currentTimeMillis() - startTime));
-			startTime = System.currentTimeMillis();
-			LogUtil.log(logId, "[time]stopMonitor:" + (System.currentTimeMillis() - startTime));
-		}
-		LogUtil.log(logId, "*******Done.");
-		onMessage("*******Done.");
-
-		// end fail summary.xml file writing
-		if (test.getFileHandle() != null) {
-			FileUtil.writeFooterForXml(test.getFileHandle());
-			FileUtil.closeFileHandle(test.getFileHandle());
-		}
-		return test.getSummary();
-	}
-
-	/**
-	 * get the summary info from directory
-	 * 
-	 * @param directory
-	 * @return
-	 */
-	public Map<String, Integer> checkAnswers(String directory) {
-		List<String> caseFileList = new ArrayList<String>();
-		List<Integer> SiteRunTimes = new ArrayList<Integer>();
-		String[] postFixes = TestUtil.getCaseFilePostFix(directory);
-		try {
-			TestUtil.getCaseFiles(null, directory, caseFileList, postFixes);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-
-		int caseCount = caseFileList.size();
-		int answerCount = 0;
-		for (int i = 0; i < caseFileList.size(); i++) {
-			String caseFile = (String) caseFileList.get(i);
-			String answerFile = TestUtil.getAnswerFile(caseFile);
-			File file = new File(answerFile);
-			if (file.exists()) {
-				answerCount++;
-			}
-		}
-		Map<String, Integer> ret = new Hashtable<String, Integer>();
-		ret.put("caseCount", caseCount);
-		ret.put("answerCount", answerCount);
-		return ret;
-	}
-
-	/**
-	 * 
-	 * @param test
-	 * @throws Exception
-	 */
-	private void buildTest(Test test) throws Exception {
-		LogUtil.log(logId, "*********build cases...");
-		this.onMessage("*********build cases...");
-		getCaseFiles(test);
-		build(test);
-	}
-
-	/**
-	 * @deprecated
-	 * @param test
-	 * @throws Exception
-	 */
-	private void getCaseFiles(Test test) throws Exception {
-		String[] files = test.getCases();
-		ArrayList SiteRuntimeList = new ArrayList();
-		int fileSize = 0;
-		for (int i = 0; i < files.length; i++) {
-			if (files[i] == null) {
-				continue;
-			}
-			String file = files[i];
-			String db = null;
-			String filter = null;
-			int position = file.toLowerCase().indexOf("?db=");
-			if (position != -1) {
-				file = files[i].substring(0, position);
-				if (files[i].indexOf("&filter=") >= 0) {
-					db = files[i].substring(position + "?db=".length(), files[i].indexOf("&filter="));
-					filter = files[i].substring(files[i].indexOf("&filter=") + "&filter=".length());
-				} else {
-					db = files[i].substring(position + "?db=".length());
-				}
-
-				test.setDbId(db);
-				test.setCaseFilter(filter);
-				test.setScenarioRootPath(file);
-				dao.addDb(db);
-			}
-			String[] postFixes = TestUtil.getCaseFilePostFix(file);
-			TestUtil.getCaseFiles(test, file, test.getCaseFileList(), postFixes);
-			TestUtil.filterExcludedCaseFile(test.getCaseFileList(), filter, file);
-
-		}
-	}
-
-	/**
-	 * build the test .
-	 * 
-	 * @param test
-	 */
-	private void build(Test test) {
-		List<String> caseFileList = test.getCaseFileList();
-		if (caseFileList == null || caseFileList.size() == 0) {
-			this.onMessage("[ERROR] Please your case directory contains valid case files");
-			System.exit(1);
-		}
-
-		for (int i = 0; i < caseFileList.size(); i++) {
-			String caseFile = (String) caseFileList.get(i);
-			CaseResult caseResult = test.getCaseResultFromMap(caseFile);
-			if (caseResult != null) {
-				caseFileList.remove(i--);
-				continue;
-			}
-
-			int testType = TestUtil.getTestType(caseFile);
-			String caseName = FileUtil.getFileName(caseFile);
-
-			if (testType == CaseResult.TYPE_SQL) {
-				this.hasSql = true;
-			}
-
-			String resultDir = TestUtil.getResultDir(test, caseFile);
-			String catPath = TestUtil.getTestCatPath(caseFile, test);
-			String answerFile = TestUtil.getAnswerFile(caseFile);
-			boolean hasAnswer = true;
-			boolean shouldRun = true;
-			if (testType == CaseResult.TYPE_SQL || testType == CaseResult.TYPE_GROOVY) {
-				hasAnswer = new File(answerFile).exists();
-				if (!hasAnswer) {
-					if (test.getRunMode() == Test.MODE_RESULT || test.getRunMode() == Test.MODE_NO_RESULT) {
-						// caseFileList.remove(i--);
-						// continue;
-						shouldRun = false;
-					}
-				} else {
-					if (test.getRun_mode() != null && test.getRun_mode().length() > 0) {
-						String runModeExtensionAnswer = answerFile + "_" + test.getRun_mode();
-						String runModeExtSecondaryAnswer = answerFile + "_" + test.getRunModeSecondary();
-						boolean hasRunModeSecondaryAnswer = new File(runModeExtSecondaryAnswer).exists();
-						boolean hasRunModeExtAnswer = new File(runModeExtensionAnswer).exists();
-						if (hasRunModeExtAnswer) {
-							answerFile = runModeExtensionAnswer;
-						} else if (hasRunModeSecondaryAnswer) {
-							answerFile = runModeExtSecondaryAnswer;
-						}
-					}
-				}
-			}
-
-			// summary
-			Map currentLayer = TestUtil.getCatMap(test, caseFile);
-			if (!currentLayer.containsKey(TestUtil.SUMMARY_KEY)) {
-				Summary summary = new Summary();
-				summary.setType(Summary.TYPE_BOTTOM);
-				summary.setResultDir(resultDir);
-				summary.setCatPath(catPath);
-				summary.setSiteRunTimes(test.getSiteRunTimes());
-				currentLayer.put(TestUtil.SUMMARY_KEY, summary);
-				test.putSummaryToMap(summary.getResultDir(), summary);
-			}
-
-			// case
-			caseResult = new CaseResult();
-			caseResult.setShouldRun(shouldRun);
-			caseResult.setType(testType);
-			caseResult.setCaseFile(caseFile);
-			caseResult.setHasAnswer(hasAnswer);
-			caseResult.setCaseName(caseName);
-			caseResult.setResultDir(resultDir);
-			caseResult.setCaseDir(FileUtil.getDir(caseFile));
-			caseResult.setAnswerFile(answerFile);
-			caseResult.setPrintQueryPlan(TestUtil.isPrintQueryPlan(caseFile));
-			// caseResult.setSiteRunTimes(test.getSiteRunTimes());
-
-			test.putCaseResultToMap(caseResult.getCaseFile(), caseResult);
-			Summary summary = test.getSummaryFromMap(resultDir);
-			summary.getCaseList().add(caseResult);
-		}
-	}
-
-	/**
-	 * run the test case .
-	 * 
-	 * @param test
-	 */
-	private void execute(Test test) {
-		try {
-			this.onMessage("*********execute...");
-			List<String> caseFileList = test.getCaseFileList();
-			processMonitor.setAllFile(test.getCaseFileList().size());
-			processMonitor.setProcessName(test.getTestId());
-			processMonitor.setProcessDesc(TestUtil.getResultPreDir(test.getTestId()));
-			boolean endfile = false;
-			int currentCount = 0;
-			int totalCaseCount = caseFileList.size();
-
-			for (int i = 0; i < totalCaseCount; i++) {
-				if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
-					break;
-				} else if (processMonitor.getCurrentstate() == processMonitor.Status_Starting) {
-					processMonitor.setCurrentstate(processMonitor.Status_Started);
-				}
-				endfile = i == totalCaseCount - 1;
-				String caseFile = (String) caseFileList.get(i);
-				currentCount++;
-				NumberFormat format = NumberFormat.getPercentInstance();
-				format.setMinimumFractionDigits(2);
-				float ratio = (float) currentCount / totalCaseCount * 100;
-				String completeRatio = format.format((ratio / 100.0));
-				printMessage(
-						"Testing " + caseFile + " (" + currentCount + "/" + totalCaseCount + " " + completeRatio + ")",
-						true, false);
-
-				CaseResult caseResult = test.getCaseResultFromMap(caseFile);
-				if (caseResult == null || !caseResult.isShouldRun()) {
-					processMonitor.setCompleteFile(processMonitor.getCompleteFile() + 1);
-					processMonitor.setFailedFile(processMonitor.getFailedFile() + 1);
-					continue;
-				}
-
-				int testType = caseResult.getType();
-				processMonitor.setCurrentfiletype(testType);
-				executeSqlFile(test, caseResult);
-				processMonitor.setCompleteFile(processMonitor.getCompleteFile() + 1);
-				if (saveEveryone) {
-					saveTempResults(caseFile);
-					if (test.getType() == Test.TYPE_FUNCTION) {
-						if (test.getRunMode() == Test.MODE_RESULT || test.getRunMode() == Test.MODE_NO_RESULT) {
-							saveResults(caseFile);
-						} else if (test.getRunMode() == Test.MODE_MAKE_ANSWER) {
-							saveAnswers(caseFile);
-						}
-					}
-					caseResult.setResult("");
-				}
-
-				boolean isSucc = caseResult.isSuccessFul();
-				if (!isSucc) {
-					List<File> coreFileList = CommonFileUtile.getCoreFiles(CubridUtil.getCubridPath(),
-							test.getAllCoreList());
-					if (coreFileList != null && coreFileList.size() > 0) {
-						test.putCoreCaseIntoMap(caseFile, coreFileList);
-						caseResult.setHasCore(true);
-					}
-				}
-				printMessage(isSucc ? " [OK]" : " [NOK]", false, true);
-				if (ErrorInterruptUtil.isCaseRunError(this, caseFile)) {
-					this.onMessage("[ERROR]: Run case interrupt error!");
-					break;
-				}
-			}
-			if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping)
-				return;
-			if ((test.getType() == Test.TYPE_FUNCTION)) {
-				if (saveEveryone) {
-					if (test.getRunMode() != Test.MODE_RUN) {
-						TestUtil.makeSummary(test, test.getCatMap());
-						TestUtil.makeSummaryInfo(test, test.getCatMap(), null);
-						TestUtil.saveResultSummary(test, test.getCatMap());
-					}
-				} else {
-					saveTempResults(test);
-					TestUtil.makeSummary(test, test.getCatMap());
-					TestUtil.makeSummaryInfo(test, test.getCatMap(), null);
-					TestUtil.saveResult(test, test.getCatMap());
-				}
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-			LogUtil.log(logId, LogUtil.getExceptionMessage(e));
-			processMonitor.doException();
-		}
-	}
-
-	/**
-	 * create the directory for test answer.
-	 * 
-	 * @param test
-	 */
-	private void createAnswerDirs(Test test) {
-		List<String> caseFileList = test.getCaseFileList();
-		this.onMessage("*********create answer dirs...");
-		for (int i = 0; i < caseFileList.size(); i++) {
-			String caseFile = (String) caseFileList.get(i);
-			if (TestUtil.getTestType(caseFile) == CaseResult.TYPE_SQL
-					|| TestUtil.getTestType(caseFile) == CaseResult.TYPE_GROOVY) {
-				CaseResult caseResult = (CaseResult) test.getCaseResultFromMap(caseFile);
-				FileUtil.createDir(FileUtil.getDirPath(caseResult.getAnswerFile()));
-			}
-		}
-	}
-
-	/**
-	 * create directory for test result .
-	 * 
-	 * @param test
-	 */
-	private void createResultDirs(Test test) {
-		List<String> caseFileList = test.getCaseFileList();
-		this.onMessage("*********create result dirs...");
-		for (int i = 0; i < caseFileList.size(); i++) {
-			String caseFile = (String) caseFileList.get(i);
-			String resultPath = TestUtil.getResultDir(test, caseFile);
-			FileUtil.createDir(resultPath);
-			test.addResultDir(resultPath);
-		}
-	}
-
-	/**
-	 * save the temporary result .
-	 * 
-	 * @param test
-	 */
-	private void saveTempResults(Test test) {
-		this.onMessage("*********save temp results...");
-		List<String> caseFileList = test.getCaseFileList();
-		for (int i = 0; i < caseFileList.size(); i++) {
-			String caseFile = (String) caseFileList.get(i);
-			saveTempResults(caseFile);
-		}
-	}
-
-	/**
-	 * save the temporary result.
-	 * 
-	 * @param caseFile
-	 */
-	private void saveTempResults(String caseFile) {
-		CaseResult caseResult = (CaseResult) test.getCaseResultFromMap(caseFile);
-		if (caseResult.getType() == CaseResult.TYPE_SQL || caseResult.getType() == CaseResult.TYPE_GROOVY) {
-			String caseDir = caseResult.getCaseDir();
-			String resultFile = caseDir + "/" + caseResult.getCaseName() + ".result";
-			FileUtil.writeToFile(resultFile, caseResult.getResult());
-		}
-	}
-
-	/**
-	 * save the result file .
-	 * 
-	 * @param test
-	 */
-	private void saveResults(Test test) {
-		LogUtil.log(logId, "*********save results...");
-		this.onMessage("*********save results...");
-		List<String> caseFileList = test.getCaseFileList();
-		if (caseFileList.size() == 0) {
-			return;
-		}
-
-		try {
-			for (int i = 0; i < caseFileList.size(); i++) {
-
-				String caseFile = (String) caseFileList.get(i);
-				saveResults(caseFile);
-				CaseResult temp_caseresult = test.getCaseResultFromMap(caseFile);
-				TestUtil.saveResult(temp_caseresult, test.getCodeset());
-			}
-		} catch (Exception e) {
-			LogUtil.log(logId, LogUtil.getExceptionMessage(e));
-		}
-
-		TestUtil.makeSummary(test, test.getCatMap());
-		TestUtil.makeSummaryInfo(test, test.getCatMap(), null);
-		TestUtil.saveResult(test, test.getCatMap());
-	}
-
-	/**
-	 * save the result file .
-	 * 
-	 * 
-	 * @param caseFile
-	 */
-	private synchronized void saveResults(String caseFile) {
-		CaseResult caseResult = (CaseResult) test.getCaseResultFromMap(caseFile);
-		if (!caseResult.isShouldRun()) {
-			return;
-		}
-		if (caseResult.getType() == CaseResult.TYPE_SQL || caseResult.getType() == CaseResult.TYPE_GROOVY) {
-			String result = caseResult.getResult();
-			String answer = FileUtil.readFile(caseResult.getAnswerFile());
-			result = result.replaceAll("\r", "").replaceAll("\n", "");
-			answer = answer.replaceAll("\r", "").replaceAll("\n", "");
-			TestCaseSummary fs = new TestCaseSummary();
-
-			if (!answer.equals(result)) {
-				fs.setTestResult("fail");
-				caseResult.setSuccessFul(false);
-				TestUtil.saveResult(caseResult, test.getCodeset());
-				processMonitor.setFailedFile(processMonitor.getFailedFile() + 1);
-			} else {
-				processMonitor.setSuccessFile(processMonitor.getSuccessFile() + 1);
-				fs.setTestResult("success");
-			}
-
-			if (test.isNeedSummaryXML()) {
-				String caseFileDir = "";
-				String answerFileDir = "";
-				String ansFile = StringUtil.replaceSlashBasedSystem(caseResult.getAnswerFile());
-				String rootPath = test.getScenarioRootPath();
-				String testType = test.getTestType();
-
-				int rootPathLength = rootPath.length();
-				caseFileDir = testType + File.separator
-						+ StringUtil.replaceSlashBasedSystem(caseFile).substring(rootPathLength);
-				answerFileDir = testType + File.separator + ansFile.substring(rootPathLength);
-
-				fs.setCaseFile(StringUtil.replaceSlash(caseFileDir));
-				fs.setAnswerFile(StringUtil.replaceSlash(answerFileDir));
-				fs.setElapseTime(String.valueOf(caseResult.getTotalTime()));
-				TestUtil.copyCaseAnswerFile(caseResult);
-				FileUtil.writeDataToFileWithHandle(test.getFileHandle(), fs.toXmlString());
-			}
-
-		} else {
-			int position = caseFile.indexOf(".sh");
-			String resultFile = caseFile.substring(0, position) + ".result";
-			boolean isOk = isScriptCaseOk(resultFile);
-			if (!isOk) {
-				caseResult.setSuccessFul(false);
-				TestUtil.saveResult(caseResult, TestUtil.DEFAULT_CODESET);
-				processMonitor.setFailedFile(processMonitor.getFailedFile() + 1);
-			} else {
-
-				processMonitor.setSuccessFile(processMonitor.getSuccessFile() + 1);
-			}
-		}
-	}
-
-	public void saveCoreCallStackFile(String caseFile, List<File> coreFileList) {
-		CaseResult caseResult = (CaseResult) test.getCaseResultFromMap(caseFile);
-		String caseResultDir = caseResult.getResultDir();
-		String coreFile = caseResultDir + File.separator + caseResult.getCaseName() + ".err";
-		StringBuffer headerText = new StringBuffer();
-		StringBuffer bodyText = new StringBuffer();
-		int coreFileListSize = coreFileList == null ? 0 : coreFileList.size();
-		String rootCoreBackupDir = EnvGetter.getenv("CORE_BACKUP_DIR");
-		if (coreFileListSize != 0) {
-			headerText.append("SUMMARY:");
-			headerText.append(System.getProperty("line.separator"));
-			if (rootCoreBackupDir != null && rootCoreBackupDir.length() > 0) {
-				headerText.append("CORE_DIR:" + rootCoreBackupDir + File.separator + test.getTestId());
-				headerText.append(System.getProperty("line.separator"));
-			} else {
-				headerText.append("CORE_DIR:" + CubridUtil.getCubridPath());
-				headerText.append(System.getProperty("line.separator"));
-			}
-		}
-
-		for (int i = 0; i < coreFileList.size(); i++) {
-			File coreFileName = coreFileList.get(i);
-			try {
-				String[] callStackInfo = AnalyzerMain.fetchCoreFullStack(coreFileName);
-				String coreName = coreFileName.getName();
-				if (callStackInfo != null && callStackInfo.length > 1) {
-					headerText.append(coreName + " [" + callStackInfo[2] + "] " + callStackInfo[0]
-							+ System.getProperty("line.separator"));
-					bodyText.append(System.getProperty("line.separator") + "==================" + coreName
-							+ "==================" + System.getProperty("line.separator"));
-					bodyText.append("");
-					bodyText.append(callStackInfo[1]);
-				}
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		}
-
-		CommonFileUtile.writeFile(headerText.toString() + bodyText.toString(), coreFile);
-
-	}
-
-	/**
-	 * save the answer file .
-	 * 
-	 * @param test
-	 */
-	private void saveAnswers(Test test) {
-		this.onMessage("*********save answers...");
-		List<String> caseFileList = test.getCaseFileList();
-		for (int i = 0; i < caseFileList.size(); i++) {
-			String caseFile = (String) caseFileList.get(i);
-			saveAnswers(caseFile);
-		}
-	}
-
-	/**
-	 * save the answer file .
-	 * 
-	 * @param caseFile
-	 */
-	private void saveAnswers(String caseFile) {
-		CaseResult caseResult = (CaseResult) test.getCaseResultFromMap(caseFile);
-		if (caseResult.getType() == CaseResult.TYPE_SQL || caseResult.getType() == CaseResult.TYPE_GROOVY) {
-			FileUtil.writeToFile(caseResult.getAnswerFile(), caseResult.getResult());
-
-		}
-	}
-
-	/**
-	 * determine the case file is correct or not .
-	 * 
-	 * @param resultFile
-	 * @return
-	 */
-	private boolean isScriptCaseOk(String resultFile) {
-		boolean isOk = true;
-
-		BufferedReader reader = null;
-		try {
-			File file = new File(resultFile);
-			if (!file.exists()) {
-				return false;
-			}
-
-			reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
-			String line = reader.readLine();
-			while (line != null) {
-				String[] subCaseData = line.split(":");
-				if (subCaseData.length < 2 || !subCaseData[1].trim().equalsIgnoreCase("ok")) {
-					return false;
-				}
-
-				line = reader.readLine();
-			}
-		} catch (Exception e) {
-		} finally {
-			if (reader != null) {
-				try {
-					reader.close();
-				} catch (IOException e) {
-				}
-			}
-		}
-
-		return isOk;
-	}
-
-	// this function is in order to make sure to execute set names before do
-	// each sql file testing
-	public void resetConnection(CubridConnection cubCon, Test test) {
-		String charset_sql = "";
-		Statement stmt = null;
-		ResultSet rs = null;
-		Connection conn = null;
-		cubCon.isAvlible();
-		conn = cubCon.getConn();
-
-		if (test.getReset_scripts() == null || (test.getReset_scripts()).length() == 0
-				|| "".equalsIgnoreCase((test.getReset_scripts()).trim())) {
-			if (test.getAutocommit() != null && test.getAutocommit().length() != 0 && conn != null
-					&& !"medium".equalsIgnoreCase(test.getTestType())) {
-				try {
-					conn.setAutoCommit(Boolean.valueOf(test.getAutocommit()));
-					resetHoldCas(conn);
-				} catch (SQLException e) {
-					String exceptionMessage = TestUtil.TEST_CONFIG + " file:" + test.getCharset_file()
-							+ System.getProperty("line.separator");
-					this.onMessage(exceptionMessage);
-					e.printStackTrace();
-				}
-				return;
-			} else {
-				return;
-			}
-		}
-
-		charset_sql = test.getReset_scripts() + TestUtil.SQL_END;
-		try {
-			if (test.getAutocommit() != null) {
-				conn.setAutoCommit(Boolean.valueOf(test.getAutocommit()));
-			}
-
-			// reset hold cas
-			resetHoldCas(conn);
-			stmt = conn.createStatement();
-			stmt.execute(charset_sql);
-		} catch (SQLException e) {
-			String exceptionMessage = TestUtil.TEST_CONFIG + " file:" + test.getCharset_file()
-					+ System.getProperty("line.separator");
-			String msg = "Set System Parameter Error: ";
-			this.onMessage(msg + exceptionMessage);
-		} finally {
-			if (rs != null) {
-				try {
-					rs.close();
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					this.onMessage(e.getMessage());
-				}
-			}
-			if (stmt != null) {
-				try {
-					stmt.close();
-				} catch (SQLException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}
-			}
-		}
-	}
-
-	private void resetHoldCas(Connection conn) {
-		String holdcas = test.getHoldcas();
-		try {
-			if ("on".equalsIgnoreCase(holdcas)) {
-				Method method = conn.getClass().getMethod("setCASChangeMode", new Class[] { int.class });
-				method.invoke(conn, new Object[] { CUBRIDConnection.CAS_CHANGE_MODE_KEEP });
-			} else if ("off".equalsIgnoreCase(holdcas)) {
-				Method method = conn.getClass().getMethod("setCASChangeMode", new Class[] { int.class });
-				method.invoke(conn, new Object[] { CUBRIDConnection.CAS_CHANGE_MODE_AUTO });
-			}
-		} catch (Exception e) {
-			String message = "Exception: the current version can't support hold cas!";
-			this.onMessage(message);
-		}
-	}
-
-	public void checkServerStatus(CubridConnection cubCon) {
-		int timer = 0;
-		while (true) {
-			// timeout length is 180 seconds, if server will not alive after 180
-			// second, test will go on
-			if (isAliveForServerStatus(cubCon) || timer >= 180) {
-				String message = "";
-				if (timer >= 180) {
-					message = "Server still cann't recovery dead, so timeout was execute!";
-				} else {
-					message = "Server was recoveryed at " + timer + "seconds!";
-				}
-
-				this.onMessage(message);
-				break;
-			} else {
-				// sleep 5 seconds to check server status again
-				try {
-					Thread.sleep(5000);
-				} catch (InterruptedException e) {
-					this.onMessage(e.getMessage());
-				}
-				timer += 5;
-				String message = "Server status is not alive, CQT will try to check it again after  " + timer
-						+ " seconds!!";
-				this.onMessage(message);
-			}
-		}
-	}
-
-	public boolean isAliveForServerStatus(CubridConnection cubCon) {
-		boolean status = false;
-		String sql = "SELECT 1;";
-		Statement stmt = null;
-		ResultSet rs = null;
-		Connection conn = null;
-		int value = 0;
-		cubCon.isAvlible();
-		conn = cubCon.getConn();
-
-		try {
-			stmt = conn.createStatement();
-			rs = stmt.executeQuery(sql);
-			while (rs.next()) {
-				value = rs.getInt(1);
-				if (value == 1) {
-					return true;
-				}
-			}
-
-		} catch (SQLException e) {
-			e.printStackTrace();
-		} finally {
-			if (rs != null) {
-				try {
-					rs.close();
-				} catch (SQLException e) {
-					e.printStackTrace();
-				}
-			}
-
-			if (stmt != null) {
-				try {
-					stmt.close();
-				} catch (SQLException e) {
-					e.printStackTrace();
-				}
-			}
-
-		}
-
-		return status;
-	}
-
-	/**
-	 * execute the sql test .
-	 * 
-	 * @param test
-	 * @param caseResult
-	 * @return
-	 */
-	private String executeSqlFile(Test test, CaseResult caseResult) {
-		ArrayList<Connection> ConnList = new ArrayList<Connection>();
-		if (test == null || caseResult == null) {
-			return null;
-		}
-		if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
-			return null;
-		}
-
-		String caseFile = caseResult.getCaseFile();
-		StringBuilder result = new StringBuilder();
-		List<Sql> sqlList = SQLParser.parseSqlFile(caseFile, test.getCodeset(), test.isNeedDebugHint ());
-		if (sqlList == null) {
-			return null;
-		}
-
-		// clear connection id list for each sql file
-		if (!test.getConnIDList().isEmpty()) {
-			test.getConnIDList().clear();
-		}
-
-		for (int i = 0; i < test.getSqlRunTime(); i++) {
-			this.onMessage((new StringBuilder()).append("Now Running File  ..... \t").append(caseFile).toString());
-			if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
-				return null;
-			}
-			try {
-				test.setDbId(test.getDbId(caseFile));
-
-				String dbId = test.getDbId();
-				String connId = test.getConnId();
-				CubridConnection cubridConnection = dao.getCubridConnection(dbId, connId, test.getType());
-
-				test.getConnIDList().put(connId, cubridConnection);
-
-				// check if CQT need check server status when start each file
-				// test executing
-				if (test.isNeedCheckServerStatus()) {
-					checkServerStatus(cubridConnection);
-				}
-
-				// set db charset for test
-				resetConnection(cubridConnection, test);
-
-				long startTime = System.currentTimeMillis();
-				for (int k = 0; k < sqlList.size(); k++) {
-					if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
-						return null;
-					}
-					Sql sql = (Sql) sqlList.get(k);
-					if (sql == null) {
-						continue;
-					}
-
-					// isQueryPlan from two ways, one is "--@queryplan" in sql
-					// file, another is "XXX.queryPlan" file whose name is same
-					// as sql file
-
-					String thisConnId = sql.getConnId();
-					if (!thisConnId.equals("") && !thisConnId.equals(connId)) {
-						cubridConnection = dao.getCubridConnection(dbId, thisConnId, test.getType());
-						if (!test.getConnIDList().containsKey(thisConnId)) {
-							test.getConnIDList().put(thisConnId, cubridConnection);
-							// set connection reset for test
-							resetConnection(cubridConnection, test);
-						}
-					}
-
-					String script = sql.getScript();
-					cubridConnection.isAvlible();
-					Connection conn = cubridConnection.getConn();
-					ConnList.add(conn);
-
-					// ===============2010-10-20==========================
-					// int pos = script.indexOf("autocommit ");
-					// if (pos != -1) {
-					// String onOff = script.substring(pos
-					// + "autocommit ".length());
-					// conn.setAutoCommit(onOff.indexOf("on") != -1);
-					// String message = "@" + test.getConnId()
-					// + ": autocommit " + onOff;
-					// this.onMessage(message);
-					// } else {
-					// String message = "@" + test.getDbId() + "/"
-					// + test.getConnId() + ":" + sql.getScript();
-					// this.onMessage(message);
-					//
-					// dao.execute(conn, sql, caseResult.isPrintQueryPlan());
-					//
-					// if (i == 0) {
-					// result
-					// .append("===================================================");
-					// result.append(System.getProperty("line.separator"));
-					//
-					// result.append(sql.getResult());
-					// }
-					// }
-					// ===============2010-10-20==========================
-
-					// ===============replace above=======================
-					boolean isOn = isPropOn(TestUtil.AUTOCOMMIT, script);
-					boolean isOff = isPropOff(TestUtil.AUTOCOMMIT, script);
-					boolean isHoldCasOn = isPropOn(TestUtil.HOLDCAS, script);
-					boolean isHoldCasOff = isPropOff(TestUtil.HOLDCAS, script);
-					boolean isServerMessageOn = isPropOn(TestUtil.SERVER_MESSAGE, script);
-					boolean isServerMessageOff = isPropOff(TestUtil.SERVER_MESSAGE, script);
-
-					if (isOn) {
-						conn.setAutoCommit(isOn);
-						String message = "@" + test.getConnId() + ": autocommit " + isOn;
-						this.onMessage(message);
-					} else if (isOff) {
-						conn.setAutoCommit(!isOff);
-						String message = "@" + test.getConnId() + ": autocommit " + !isOff;
-						this.onMessage(message);
-					} else if (isHoldCasOn) {
-						try {
-							String message = "@" + test.getConnId() + ": hold cas " + isHoldCasOn;
-
-							Method method = conn.getClass().getMethod("setCASChangeMode", new Class[] { int.class });
-							method.invoke(conn, new Object[] { CUBRIDConnection.CAS_CHANGE_MODE_KEEP });
-
-							this.onMessage(message);
-						} catch (Exception e) {
-							String message = "Exception: the current version can't support hold cas!";
-							this.onMessage(message);
-						}
-					} else if (isHoldCasOff) {
-						try {
-							String message = "@" + test.getConnId() + ": hold cas " + isHoldCasOff;
-							Method method = conn.getClass().getMethod("setCASChangeMode", new Class[] { int.class });
-							method.invoke(conn, new Object[] { CUBRIDConnection.CAS_CHANGE_MODE_AUTO });
-							this.onMessage(message);
-						} catch (Exception e) {
-							String message = "Exception: the current version can't support hold cas!";
-							this.onMessage(message);
-						}
-					} else if (isServerMessageOn) {
-						try {
-							String message = "@" + test.getConnId() + ": server message " + isServerMessageOn;
-							this.onMessage(message);
-							test.setServerMessage("on");
-							// TODO: DBMS_OUTPUT.enable ()
-							Sql enableSql = new Sql(connId, "CALL enable(20000)", null, true); // TODO: set
-																								// size of
-																								// enable
-							dao.execute(conn, enableSql, false);
-						} catch (Exception e) {
-							String message = "Exception: the current version can't support DBMS_OUTPUT!";
-							this.onMessage(message);
-						}
-					} else if (isServerMessageOff) {
-						try {
-							String message = "@" + test.getConnId() + ": server message " + isServerMessageOff;
-							this.onMessage(message);
-
-							test.setServerMessage("off");
-							// TODO: DBMS_OUTPUT.disable()
-							Sql disableSql = new Sql(connId, "CALL disable()", null, true);
-							dao.execute(conn, disableSql, false);
-						} catch (Exception e) {
-							String message = "Exception: the current version can't support DBMS_OUTPUT!";
-							this.onMessage(message);
-						}
-					} else {
-						String message = "@" + test.getDbId() + "/" + test.getConnId() + ":" + sql.getScript();
-						this.onMessage(message);
-
-						// System.out.println ("script = " + sql.getScript());
-
-						dao.execute(conn, sql, caseResult.isPrintQueryPlan());
-
-						if (i == 0) {
-							result.append("===================================================");
-							result.append(System.getProperty("line.separator"));
-
-							result.append(sql.getResult());
-						}
-					}
-
-					cubridConnection.free();
-				}
-
-				long totalTime = System.currentTimeMillis() - startTime;
-				caseResult.setTotalTime(totalTime);
-				caseResult.setSiteRunTimes(1);
-			} catch (Exception e) {
-				if (i == 0) {
-					result.append(e.getMessage() + System.getProperty("line.separator"));
-				}
-				this.onMessage(e.getMessage());
-			} finally {
-				if (i == 0) {
-					caseResult.setResult(result.toString());
-					caseResult.setSiteRunTimes(1);
-				}
-			}
-
-			Statement stmt;
-			ResultSet rs;
-			int charset;
-			String sql;
-
-			for (Connection conn1 : ConnList) {
-				try {
-					conn1.commit();
-				} catch (Exception e) {
-					e.printStackTrace();
-				}
-			}
-
-			if (test.isQaview()) {
-				for (Connection conn : ConnList) {
-					try {
-
-						if (conn.getAutoCommit() == false)
-							this.onMessage("[QA REVIEW] FOGOT TO RESET AUTOCOMMIT" + " (" + caseFile + ")");
-
-						conn.setAutoCommit(true);
-
-						stmt = conn.createStatement();
-
-						sql = "select class_name,class_type from db_class where is_system_class<>'YES'";
-						rs = stmt.executeQuery(sql);
-						while (rs.next()) {
-							this.onMessage("[QA REVIEW] FOGOT TO DELETE " + rs.getString(1) + " with " + rs.getString(2)
-									+ " type" + " (" + caseFile + ")");
-						}
-						rs.close();
-
-						sql = "select name from db_serial";
-						rs = stmt.executeQuery(sql);
-						while (rs.next()) {
-							this.onMessage(
-									"[QA REVIEW] FOGOT TO DELETE serial " + rs.getString(1) + " (" + caseFile + ")");
-						}
-						rs.close();
-
-						sql = "select name from db_trigger";
-						rs = stmt.executeQuery(sql);
-						while (rs.next()) {
-							this.onMessage(
-									"[QA REVIEW] FOGOT TO DELETE trigger " + rs.getString(1) + " (" + caseFile + ")");
-						}
-						rs.close();
-
-						sql = "select name from db_user where name not in ('DBA', 'PUBLIC');";
-						rs = stmt.executeQuery(sql);
-						while (rs.next()) {
-							this.onMessage(
-									"[QA REVIEW] FOGOT TO DELETE user " + rs.getString(1) + " (" + caseFile + ")");
-						}
-						rs.close();
-
-						sql = "select sp_name from db_stored_procedure";
-						rs = stmt.executeQuery(sql);
-						while (rs.next()) {
-							this.onMessage("[QA REVIEW] FOGOT TO DELETE SP " + rs.getString(1) + " (" + caseFile + ")");
-						}
-						rs.close();
-
-						sql = "select USER";
-						rs = stmt.executeQuery(sql);
-						String user;
-						while (rs.next()) {
-							user = rs.getString(1);
-							if (!user.equalsIgnoreCase("DBA")) {
-								this.onMessage("[QA REVIEW] FOGOT TO RECOVERY USER: " + user + " (" + caseFile + ")");
-							}
-						}
-						rs.close();
-
-						rs = stmt.executeQuery("SELECT charset from db_root");
-						rs.next();
-						charset = rs.getInt(1);
-						rs.close();
-
-						String collation;
-						sql = "select collation('a')";
-						try {
-							rs = stmt.executeQuery(sql);
-							rs.next();
-							collation = rs.getString(1);
-						} catch (Exception e) {
-							if (rs != null)
-								rs.close();
-							if (stmt != null)
-								stmt.close();
-							continue;
-						}
-
-						if (charset == 4) {
-							if (!collation.equalsIgnoreCase("euckr_bin")) {
-								this.onMessage("[QA REVIEW] FOGOT TO RECOVERY collation: " + collation + " (" + caseFile
-										+ ")");
-							}
-						} else if (charset == 5) {
-							if (!collation.equalsIgnoreCase("utf8_bin")) {
-								this.onMessage("[QA REVIEW] FOGOT TO RECOVERY collation: " + collation + " (" + caseFile
-										+ ")");
-							}
-						} else if (charset == 3) {
-							if (!collation.equalsIgnoreCase("iso88591_bin")) {
-								this.onMessage("[QA REVIEW] FOGOT TO RECOVERY collation: " + collation + " (" + caseFile
-										+ ")");
-							}
-						} else {
-							if (!collation.equalsIgnoreCase("iso88591_bin")) {
-								this.onMessage("[QA REVIEW] FOGOT TO RECOVERY collation: " + collation + " (" + caseFile
-										+ ")");
-							}
-						}
-
-						if (charset == 4) {
-							stmt.executeUpdate("SET NAMES euckr collate euckr_bin");
-						} else if (charset == 5) {
-							stmt.executeUpdate("SET NAMES utf8 collate utf8_bin");
-						} else if (charset == 3) {
-							stmt.executeUpdate("SET NAMES iso88591 collate iso88591_bin");
-						} else {
-							stmt.executeUpdate("SET NAMES iso88591 collate iso88591_bin");
-						}
-
-						stmt.close();
-
-					} catch (SQLException e) {
-						this.onMessage(e.getMessage());
-					}
-				}
-			}
-
-		}
-		return caseResult.toString();
-	}
-
-	/**
-	 * determine if Database is normal.
-	 * 
-	 * @param test
-	 * @return
-	 */
-	@SuppressWarnings("deprecation")
-	private boolean checkDb(Test test) {
-		boolean flag = true;
-		if (hasSql && !dao.isDbOk()) {
-			flag = false;
-		}
-		return flag;
-	}
-
-	/**
-	 * 
-	 */
-	protected void init() {
-		long startTime = System.currentTimeMillis();
-		startTime = System.currentTimeMillis();
-		String dbVersion = configureUtil.getProperty("dbversion");
-		String dbBuild = configureUtil.getProperty("dbbuildnumber");
-		test.setDbVersion(dbVersion);
-		test.setDbBuild(dbBuild);
-		LogUtil.log(logId, "[time]getProperties:" + (System.currentTimeMillis() - startTime));
-
-		startTime = System.currentTimeMillis();
-	}
-
-	public ProcessMonitor getProcessMonitor() {
-		return processMonitor;
-	}
-
-	/**
-	 * this inner class created by anson cheung,it used for execute sql
-	 * muti-thread
-	 * 
-	 * @author Administrator
-	 * 
-	 */
-	class MutiSqlEx extends Thread {
-		private Test test;
-		private int index;
-
-		private CaseResult caseResult;
-
-		public void setTest(Test test) {
-			this.test = test;
-		}
-
-		public void setCaseResult(CaseResult caseResult) {
-			this.caseResult = caseResult;
-		}
-
-		public CaseResult getCaseResult() {
-			return caseResult;
-		}
-
-		private ConsoleBO bo;
-
-		public void setBo(ConsoleBO bo) {
-			this.bo = bo;
-		}
-
-		public MutiSqlEx(String name) {
-			super(name);
-		}
-
-		@Override
-		public void run() {
-			List<Connection> ConnList = new ArrayList<Connection>();
-			if (test == null || caseResult == null || processMonitor.getCurrentstate() == processMonitor.Status_Stoping
-					|| processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
-				return;
-			}
-			String caseFile = caseResult.getCaseFile();
-			StringBuilder result = new StringBuilder();
-			List<Sql> sqlList = SQLParser.parseSqlFile(caseFile, test.getCodeset(), test.isNeedDebugHint ());
-
-			String dbId = test.getDbId();
-			String connId = test.getConnId();
-			CubridConnection cubridConnection = dao.getCubridConnection(dbId, connId, test.getType());
-
-			// check if CQT need check server status when start each file test
-			// executing
-			if (test.isNeedCheckServerStatus()) {
-				checkServerStatus(cubridConnection);
-			}
-
-			// set db charset for test
-			resetConnection(cubridConnection, test);
-
-			if (sqlList == null) {
-				return;
-			}
-			try {
-				test.setDbId(test.getDbId(caseFile));
-				long startTime = System.currentTimeMillis();
-				for (int k = 0; k < sqlList.size(); k++) {
-					if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping
-							|| processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
-						return;
-					}
-					Sql sql = (Sql) sqlList.get(k);
-					if (sql == null) {
-						continue;
-					}
-
-					String script = sql.getScript();
-					// String dbId = test.getDbId();
-					// String connId = test.getConnId();
-					String ThreadConnId = connId;
-					String thisConnId = sql.getConnId();
-					if (!thisConnId.equals("") && !thisConnId.equals(connId)) {
-						ThreadConnId = thisConnId;
-						cubridConnection = dao.getCubridConnection(dbId, ThreadConnId, index, test.getType());
-						resetConnection(cubridConnection, test);
-					}
-
-					cubridConnection.isAvlible();
-					Connection conn = cubridConnection.getConn();
-					ConnList.add(conn);
-					boolean isOn = isPropOn(TestUtil.AUTOCOMMIT, script);
-					boolean isOff = isPropOff(TestUtil.AUTOCOMMIT, script);
-					boolean isHoldCasOn = isPropOn(TestUtil.HOLDCAS, script);
-					boolean isHoldCasOff = isPropOff(TestUtil.HOLDCAS, script);
-					boolean isServerMessageOn = isPropOn(TestUtil.SERVER_MESSAGE, script);
-					boolean isServerMessageOff = isPropOff(TestUtil.SERVER_MESSAGE, script);
-
-					if (isOn) {
-						conn.setAutoCommit(isOn);
-						String message = "@" + test.getConnId() + ": autocommit " + isOn;
-						bo.onMessage("[THREAD:" + index + "]" + message);
-					} else if (isOff) {
-						conn.setAutoCommit(!isOff);
-						String message = "@" + test.getConnId() + ": autocommit " + !isOff;
-						bo.onMessage("[THREAD:" + index + "]" + message);
-					} else if (isHoldCasOn) {
-						try {
-							String message = "@" + test.getConnId() + ": hold cas " + isHoldCasOn;
-
-							Method method = conn.getClass().getMethod("setCASChangeMode", new Class[] { int.class });
-							method.invoke(conn, new Object[] { CUBRIDConnection.CAS_CHANGE_MODE_KEEP });
-
-							bo.onMessage("--- hold cas -- " + isHoldCasOn);
-						} catch (Exception e) {
-							String message = "Exception: the current version can't support hold cas!";
-							bo.onMessage(message);
-						}
-					} else if (isHoldCasOff) {
-						try {
-							String message = "@" + test.getConnId() + ": hold cas " + isHoldCasOff;
-							Method method = conn.getClass().getMethod("setCASChangeMode", new Class[] { int.class });
-							method.invoke(conn, new Object[] { CUBRIDConnection.CAS_CHANGE_MODE_AUTO });
-							bo.onMessage("--- hold cas -- " + isHoldCasOff);
-						} catch (Exception e) {
-							String message = "Exception: the current version can't support hold cas!";
-							bo.onMessage(message);
-						}
-					} else if (isServerMessageOn) {
-						try {
-							String message = "@" + test.getConnId() + ": server message " + isServerMessageOn;
-							bo.onMessage(message);
-
-							Sql enableSql = new Sql(connId, "CALL DBMS_OUTPUT.enable(20000)", null, true); // TODO: set
-																											// size of
-																											// enable
-							dao.execute(conn, enableSql, false);
-						} catch (Exception e) {
-							String message = "Exception: the current version can't support DBMS_OUTPUT!";
-							bo.onMessage(message);
-						}
-					} else if (isServerMessageOff) {
-						try {
-							String message = "@" + test.getConnId() + ": server message " + isServerMessageOff;
-							bo.onMessage(message);
-							Sql disableSql = new Sql(connId, "CALL DBMS_OUTPUT.disable()", null, true);
-							dao.execute(conn, disableSql, false);
-						} catch (Exception e) {
-							String message = "Exception: the current version can't support DBMS_OUTPUT!";
-							bo.onMessage(message);
-						}
-					} else {
-						// System.out.println("--- use default autocommit -- " + conn.getAutoCommit());
-						String message = "@" + test.getDbId() + "/" + test.getConnId() + ":" + sql.getScript();
-						bo.onMessage("[THREAD:" + index + "]" + message);
-
-						// System.out.println ("script = " + sql.getScript());
-
-						dao.execute(conn, sql, caseResult.isPrintQueryPlan());
-						result.append("===================================================");
-						result.append(System.getProperty("line.separator"));
-						result.append(sql.getResult());
-					}
-
-					cubridConnection.free();
-				}
-				long totalTime = System.currentTimeMillis() - startTime;
-				caseResult.setTotalTime(totalTime);
-
-			} catch (Exception e) {
-
-				result.append(e.getMessage() + System.getProperty("line.separator"));
-
-				e.printStackTrace();
-			} finally {
-				caseResult.setResult(result.toString());
-				caseResult.setSiteRunTimes(test.getSiteRunTimes());
-
-			}
-			for (Connection conn : ConnList) {
-				try {
-					conn.commit();
-				} catch (SQLException e) {
-					e.printStackTrace();
-				}
-			}
-		}
-
-		public int getIndex() {
-			return index;
-		}
-
-		public void setIndex(int index) {
-			this.index = index;
-		}
-
-	}
-
-	public Test getTest() {
-		return test;
-	}
-
-	private boolean isPropOn(String prop, String sql) {
-		String tmp = sql.trim();
-		String regex = prop + "\\s+on\\s*;?";
-		Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
-		Matcher matcher = pattern.matcher(tmp);
-		return matcher.find();
-	}
-
-	private boolean isPropOff(String prop, String sql) {
-		String tmp = sql.trim();
-		String regex = prop + "\\s+off\\s*;?";
-		Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
-		Matcher matcher = pattern.matcher(tmp);
-		return matcher.find();
-	}
+    private ProcessMonitor processMonitor = new ProcessMonitor();
+    private boolean useMonitor;
+    private boolean saveEveryone = true;
+    private String os = SystemUtil.getOS();
+    private String homePath = "d:\\";
+    private boolean isFirstTime = true;
+
+    public boolean isUseMonitor() {
+        return useMonitor;
+    }
+
+    public void setUseMonitor(boolean useMonitor) {
+        this.useMonitor = useMonitor;
+    }
+
+    public boolean isSaveEveryone() {
+        return saveEveryone;
+    }
+
+    public void setSaveEveryone(boolean saveEveryone) {
+        this.saveEveryone = saveEveryone;
+    }
+
+    private Test test;
+
+    private ConfigureUtil configureUtil;
+
+    private ConsoleDAO dao;
+
+    private boolean hasSql = false;
+
+    public ConsoleBO() {
+        this.logId = "ConsoleBO";
+        this.useMonitor = false;
+        this.saveEveryone = true;
+    }
+
+    public ConsoleBO(boolean usemonitor) {
+        this.useMonitor = usemonitor;
+        this.logId = "ConsoleBO";
+    }
+
+    public ConsoleBO(boolean usemonitor, boolean saveeveryone) {
+        this.useMonitor = usemonitor;
+        this.saveEveryone = saveeveryone;
+        this.logId = "ConsoleBO";
+        initConsoleBoLog(this.logId);
+    }
+
+    private void initConsoleBoLog(String logId) {
+        LogUtil.clearLog(logId);
+        LogUtil.log(logId, "[time]clearLog:" + (System.currentTimeMillis() - startTime));
+    }
+
+    /**
+     * run the test case .
+     *
+     * @param test
+     * @return
+     */
+    @SuppressWarnings("deprecation")
+    public Summary runTest(Test test) {
+        if (test == null) {
+            return null;
+        }
+
+        this.test = test;
+        configureUtil = new ConfigureUtil();
+        long startTime = System.currentTimeMillis();
+        processMonitor.setStartTime(startTime);
+
+        if (useMonitor) {
+            File f = new File(RepositoryPathUtil.getTestResultDir(test.getTestId()));
+            if (!f.exists()) f.mkdirs();
+        }
+        LogUtil.log(logId, "[time]startMonitor:" + (System.currentTimeMillis() - startTime));
+        try {
+            startTime = System.currentTimeMillis();
+            init();
+            LogUtil.log(logId, "[time]init:" + (System.currentTimeMillis() - startTime));
+
+            startTime = System.currentTimeMillis();
+            dao = new ConsoleDAO(test, configureUtil);
+            LogUtil.log(logId, "[time]createDAO:" + (System.currentTimeMillis() - startTime));
+
+            startTime = System.currentTimeMillis();
+            buildTest(test);
+            LogUtil.log(logId, "[time]buildTest:" + (System.currentTimeMillis() - startTime));
+
+            processMonitor.setAllFile(test.getCaseFileList().size());
+
+            startTime = System.currentTimeMillis();
+            boolean ok = checkDb(test);
+            LogUtil.log(logId, "[time]checkDb:" + (System.currentTimeMillis() - startTime));
+            if (!ok) {
+                onMessage("-10000");
+                LogUtil.log(logId, "-10000");
+                processMonitor.doException();
+                return null;
+            }
+
+            createResultDirs(test);
+
+            if (test.isNeedSummaryXML()) {
+                // create test case list into summary file
+                test.setFileHandle(
+                        FileUtil.openOneFileHandle(
+                                test.getResult_dir() + TestUtil.SUMMARYLIST_FILE));
+                LogUtil.log(logId, "[Test Configuration File]:" + test.getCharset_file());
+                // write test case list head
+                FileUtil.writeHeadForXML(test.getFileHandle());
+            }
+
+            startTime = System.currentTimeMillis();
+
+            System.out.println("---------------execute begin--------------------");
+            execute(test);
+            System.out.println("---------------execute end  --------------------");
+
+            if (this.processMonitor.getCurrentstate() == this.processMonitor.Status_Stoping) {
+                this.processMonitor.setCurrentstate(this.processMonitor.Status_Stoped);
+                return null;
+            }
+            LogUtil.log(logId, "[time]execute:" + (System.currentTimeMillis() - startTime));
+
+            if (test.getType() == Test.TYPE_FUNCTION) {
+                startTime = System.currentTimeMillis();
+                if (test.getRunMode() == Test.MODE_RESULT) {
+                    createResultDirs(test);
+                } else if (test.getRunMode() == Test.MODE_MAKE_ANSWER) {
+                    createAnswerDirs(test);
+                }
+                LogUtil.log(logId, "[time]createDir:" + (System.currentTimeMillis() - startTime));
+
+                startTime = System.currentTimeMillis();
+
+                if (!saveEveryone) {
+                    saveTempResults(test);
+                    LogUtil.log(
+                            logId,
+                            "[time]saveTempResult:" + (System.currentTimeMillis() - startTime));
+
+                    startTime = System.currentTimeMillis();
+                    if (test.getRunMode() == Test.MODE_RESULT
+                            || test.getRunMode() == Test.MODE_NO_RESULT) {
+                        saveResults(test);
+                    } else if (test.getRunMode() == Test.MODE_MAKE_ANSWER) {
+                        saveAnswers(test);
+                    }
+                }
+                LogUtil.log(
+                        logId,
+                        "[time]saveResultOrAnswer:" + (System.currentTimeMillis() - startTime));
+            } else if (test.getType() == Test.TYPE_PERFORMANCE) {
+                startTime = System.currentTimeMillis();
+                LogUtil.log(
+                        logId,
+                        "[time]savePerformanceResult:" + (System.currentTimeMillis() - startTime));
+            }
+            onMessage("*******results saved.");
+        } catch (Throwable e) {
+            e.printStackTrace();
+            onMessage(e.getMessage());
+            LogUtil.log(logId, LogUtil.getExceptionMessage(new Exception(e.getMessage(), e)));
+        } finally {
+            startTime = System.currentTimeMillis();
+            if (dao != null) {
+                dao.release();
+            }
+            LogUtil.log(logId, "[time]DAO release:" + (System.currentTimeMillis() - startTime));
+            startTime = System.currentTimeMillis();
+            LogUtil.log(logId, "[time]stopMonitor:" + (System.currentTimeMillis() - startTime));
+        }
+        LogUtil.log(logId, "*******Done.");
+        onMessage("*******Done.");
+
+        // end fail summary.xml file writing
+        if (test.getFileHandle() != null) {
+            FileUtil.writeFooterForXml(test.getFileHandle());
+            FileUtil.closeFileHandle(test.getFileHandle());
+        }
+        return test.getSummary();
+    }
+
+    /**
+     * get the summary info from directory
+     *
+     * @param directory
+     * @return
+     */
+    public Map<String, Integer> checkAnswers(String directory) {
+        List<String> caseFileList = new ArrayList<String>();
+        List<Integer> SiteRunTimes = new ArrayList<Integer>();
+        String[] postFixes = TestUtil.getCaseFilePostFix(directory);
+        try {
+            TestUtil.getCaseFiles(null, directory, caseFileList, postFixes);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        int caseCount = caseFileList.size();
+        int answerCount = 0;
+        for (int i = 0; i < caseFileList.size(); i++) {
+            String caseFile = (String) caseFileList.get(i);
+            String answerFile = TestUtil.getAnswerFile(caseFile);
+            File file = new File(answerFile);
+            if (file.exists()) {
+                answerCount++;
+            }
+        }
+        Map<String, Integer> ret = new Hashtable<String, Integer>();
+        ret.put("caseCount", caseCount);
+        ret.put("answerCount", answerCount);
+        return ret;
+    }
+
+    /**
+     * @param test
+     * @throws Exception
+     */
+    private void buildTest(Test test) throws Exception {
+        LogUtil.log(logId, "*********build cases...");
+        this.onMessage("*********build cases...");
+        getCaseFiles(test);
+        build(test);
+    }
+
+    /**
+     * @deprecated
+     * @param test
+     * @throws Exception
+     */
+    private void getCaseFiles(Test test) throws Exception {
+        String[] files = test.getCases();
+        ArrayList SiteRuntimeList = new ArrayList();
+        int fileSize = 0;
+        for (int i = 0; i < files.length; i++) {
+            if (files[i] == null) {
+                continue;
+            }
+            String file = files[i];
+            String db = null;
+            String filter = null;
+            int position = file.toLowerCase().indexOf("?db=");
+            if (position != -1) {
+                file = files[i].substring(0, position);
+                if (files[i].indexOf("&filter=") >= 0) {
+                    db =
+                            files[i].substring(
+                                    position + "?db=".length(), files[i].indexOf("&filter="));
+                    filter = files[i].substring(files[i].indexOf("&filter=") + "&filter=".length());
+                } else {
+                    db = files[i].substring(position + "?db=".length());
+                }
+
+                test.setDbId(db);
+                test.setCaseFilter(filter);
+                test.setScenarioRootPath(file);
+                dao.addDb(db);
+            }
+            String[] postFixes = TestUtil.getCaseFilePostFix(file);
+            TestUtil.getCaseFiles(test, file, test.getCaseFileList(), postFixes);
+            TestUtil.filterExcludedCaseFile(test.getCaseFileList(), filter, file);
+        }
+    }
+
+    /**
+     * build the test .
+     *
+     * @param test
+     */
+    private void build(Test test) {
+        List<String> caseFileList = test.getCaseFileList();
+        if (caseFileList == null || caseFileList.size() == 0) {
+            this.onMessage("[ERROR] Please your case directory contains valid case files");
+            System.exit(1);
+        }
+
+        for (int i = 0; i < caseFileList.size(); i++) {
+            String caseFile = (String) caseFileList.get(i);
+            CaseResult caseResult = test.getCaseResultFromMap(caseFile);
+            if (caseResult != null) {
+                caseFileList.remove(i--);
+                continue;
+            }
+
+            int testType = TestUtil.getTestType(caseFile);
+            String caseName = FileUtil.getFileName(caseFile);
+
+            if (testType == CaseResult.TYPE_SQL) {
+                this.hasSql = true;
+            }
+
+            String resultDir = TestUtil.getResultDir(test, caseFile);
+            String catPath = TestUtil.getTestCatPath(caseFile, test);
+            String answerFile = TestUtil.getAnswerFile(caseFile);
+            boolean hasAnswer = true;
+            boolean shouldRun = true;
+            if (testType == CaseResult.TYPE_SQL || testType == CaseResult.TYPE_GROOVY) {
+                hasAnswer = new File(answerFile).exists();
+                if (!hasAnswer) {
+                    if (test.getRunMode() == Test.MODE_RESULT
+                            || test.getRunMode() == Test.MODE_NO_RESULT) {
+                        // caseFileList.remove(i--);
+                        // continue;
+                        shouldRun = false;
+                    }
+                } else {
+                    if (test.getRun_mode() != null && test.getRun_mode().length() > 0) {
+                        String runModeExtensionAnswer = answerFile + "_" + test.getRun_mode();
+                        String runModeExtSecondaryAnswer =
+                                answerFile + "_" + test.getRunModeSecondary();
+                        boolean hasRunModeSecondaryAnswer =
+                                new File(runModeExtSecondaryAnswer).exists();
+                        boolean hasRunModeExtAnswer = new File(runModeExtensionAnswer).exists();
+                        if (hasRunModeExtAnswer) {
+                            answerFile = runModeExtensionAnswer;
+                        } else if (hasRunModeSecondaryAnswer) {
+                            answerFile = runModeExtSecondaryAnswer;
+                        }
+                    }
+                }
+            }
+
+            // summary
+            Map currentLayer = TestUtil.getCatMap(test, caseFile);
+            if (!currentLayer.containsKey(TestUtil.SUMMARY_KEY)) {
+                Summary summary = new Summary();
+                summary.setType(Summary.TYPE_BOTTOM);
+                summary.setResultDir(resultDir);
+                summary.setCatPath(catPath);
+                summary.setSiteRunTimes(test.getSiteRunTimes());
+                currentLayer.put(TestUtil.SUMMARY_KEY, summary);
+                test.putSummaryToMap(summary.getResultDir(), summary);
+            }
+
+            // case
+            caseResult = new CaseResult();
+            caseResult.setShouldRun(shouldRun);
+            caseResult.setType(testType);
+            caseResult.setCaseFile(caseFile);
+            caseResult.setHasAnswer(hasAnswer);
+            caseResult.setCaseName(caseName);
+            caseResult.setResultDir(resultDir);
+            caseResult.setCaseDir(FileUtil.getDir(caseFile));
+            caseResult.setAnswerFile(answerFile);
+            caseResult.setPrintQueryPlan(TestUtil.isPrintQueryPlan(caseFile));
+            // caseResult.setSiteRunTimes(test.getSiteRunTimes());
+
+            test.putCaseResultToMap(caseResult.getCaseFile(), caseResult);
+            Summary summary = test.getSummaryFromMap(resultDir);
+            summary.getCaseList().add(caseResult);
+        }
+    }
+
+    /**
+     * run the test case .
+     *
+     * @param test
+     */
+    private void execute(Test test) {
+        try {
+            this.onMessage("*********execute...");
+            List<String> caseFileList = test.getCaseFileList();
+            processMonitor.setAllFile(test.getCaseFileList().size());
+            processMonitor.setProcessName(test.getTestId());
+            processMonitor.setProcessDesc(TestUtil.getResultPreDir(test.getTestId()));
+            boolean endfile = false;
+            int currentCount = 0;
+            int totalCaseCount = caseFileList.size();
+
+            for (int i = 0; i < totalCaseCount; i++) {
+                if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
+                    break;
+                } else if (processMonitor.getCurrentstate() == processMonitor.Status_Starting) {
+                    processMonitor.setCurrentstate(processMonitor.Status_Started);
+                }
+                endfile = i == totalCaseCount - 1;
+                String caseFile = (String) caseFileList.get(i);
+                currentCount++;
+                NumberFormat format = NumberFormat.getPercentInstance();
+                format.setMinimumFractionDigits(2);
+                float ratio = (float) currentCount / totalCaseCount * 100;
+                String completeRatio = format.format((ratio / 100.0));
+                printMessage(
+                        "Testing "
+                                + caseFile
+                                + " ("
+                                + currentCount
+                                + "/"
+                                + totalCaseCount
+                                + " "
+                                + completeRatio
+                                + ")",
+                        true,
+                        false);
+
+                CaseResult caseResult = test.getCaseResultFromMap(caseFile);
+                if (caseResult == null || !caseResult.isShouldRun()) {
+                    processMonitor.setCompleteFile(processMonitor.getCompleteFile() + 1);
+                    processMonitor.setFailedFile(processMonitor.getFailedFile() + 1);
+                    continue;
+                }
+
+                int testType = caseResult.getType();
+                processMonitor.setCurrentfiletype(testType);
+                executeSqlFile(test, caseResult);
+                processMonitor.setCompleteFile(processMonitor.getCompleteFile() + 1);
+                if (saveEveryone) {
+                    saveTempResults(caseFile);
+                    if (test.getType() == Test.TYPE_FUNCTION) {
+                        if (test.getRunMode() == Test.MODE_RESULT
+                                || test.getRunMode() == Test.MODE_NO_RESULT) {
+                            saveResults(caseFile);
+                        } else if (test.getRunMode() == Test.MODE_MAKE_ANSWER) {
+                            saveAnswers(caseFile);
+                        }
+                    }
+                    caseResult.setResult("");
+                }
+
+                boolean isSucc = caseResult.isSuccessFul();
+                if (!isSucc) {
+                    List<File> coreFileList =
+                            CommonFileUtile.getCoreFiles(
+                                    CubridUtil.getCubridPath(), test.getAllCoreList());
+                    if (coreFileList != null && coreFileList.size() > 0) {
+                        test.putCoreCaseIntoMap(caseFile, coreFileList);
+                        caseResult.setHasCore(true);
+                    }
+                }
+                printMessage(isSucc ? " [OK]" : " [NOK]", false, true);
+                if (ErrorInterruptUtil.isCaseRunError(this, caseFile)) {
+                    this.onMessage("[ERROR]: Run case interrupt error!");
+                    break;
+                }
+            }
+            if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping) return;
+            if ((test.getType() == Test.TYPE_FUNCTION)) {
+                if (saveEveryone) {
+                    if (test.getRunMode() != Test.MODE_RUN) {
+                        TestUtil.makeSummary(test, test.getCatMap());
+                        TestUtil.makeSummaryInfo(test, test.getCatMap(), null);
+                        TestUtil.saveResultSummary(test, test.getCatMap());
+                    }
+                } else {
+                    saveTempResults(test);
+                    TestUtil.makeSummary(test, test.getCatMap());
+                    TestUtil.makeSummaryInfo(test, test.getCatMap(), null);
+                    TestUtil.saveResult(test, test.getCatMap());
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            LogUtil.log(logId, LogUtil.getExceptionMessage(e));
+            processMonitor.doException();
+        }
+    }
+
+    /**
+     * create the directory for test answer.
+     *
+     * @param test
+     */
+    private void createAnswerDirs(Test test) {
+        List<String> caseFileList = test.getCaseFileList();
+        this.onMessage("*********create answer dirs...");
+        for (int i = 0; i < caseFileList.size(); i++) {
+            String caseFile = (String) caseFileList.get(i);
+            if (TestUtil.getTestType(caseFile) == CaseResult.TYPE_SQL
+                    || TestUtil.getTestType(caseFile) == CaseResult.TYPE_GROOVY) {
+                CaseResult caseResult = (CaseResult) test.getCaseResultFromMap(caseFile);
+                FileUtil.createDir(FileUtil.getDirPath(caseResult.getAnswerFile()));
+            }
+        }
+    }
+
+    /**
+     * create directory for test result .
+     *
+     * @param test
+     */
+    private void createResultDirs(Test test) {
+        List<String> caseFileList = test.getCaseFileList();
+        this.onMessage("*********create result dirs...");
+        for (int i = 0; i < caseFileList.size(); i++) {
+            String caseFile = (String) caseFileList.get(i);
+            String resultPath = TestUtil.getResultDir(test, caseFile);
+            FileUtil.createDir(resultPath);
+            test.addResultDir(resultPath);
+        }
+    }
+
+    /**
+     * save the temporary result .
+     *
+     * @param test
+     */
+    private void saveTempResults(Test test) {
+        this.onMessage("*********save temp results...");
+        List<String> caseFileList = test.getCaseFileList();
+        for (int i = 0; i < caseFileList.size(); i++) {
+            String caseFile = (String) caseFileList.get(i);
+            saveTempResults(caseFile);
+        }
+    }
+
+    /**
+     * save the temporary result.
+     *
+     * @param caseFile
+     */
+    private void saveTempResults(String caseFile) {
+        CaseResult caseResult = (CaseResult) test.getCaseResultFromMap(caseFile);
+        if (caseResult.getType() == CaseResult.TYPE_SQL
+                || caseResult.getType() == CaseResult.TYPE_GROOVY) {
+            String caseDir = caseResult.getCaseDir();
+            String resultFile = caseDir + "/" + caseResult.getCaseName() + ".result";
+            FileUtil.writeToFile(resultFile, caseResult.getResult());
+        }
+    }
+
+    /**
+     * save the result file .
+     *
+     * @param test
+     */
+    private void saveResults(Test test) {
+        LogUtil.log(logId, "*********save results...");
+        this.onMessage("*********save results...");
+        List<String> caseFileList = test.getCaseFileList();
+        if (caseFileList.size() == 0) {
+            return;
+        }
+
+        try {
+            for (int i = 0; i < caseFileList.size(); i++) {
+
+                String caseFile = (String) caseFileList.get(i);
+                saveResults(caseFile);
+                CaseResult temp_caseresult = test.getCaseResultFromMap(caseFile);
+                TestUtil.saveResult(temp_caseresult, test.getCodeset());
+            }
+        } catch (Exception e) {
+            LogUtil.log(logId, LogUtil.getExceptionMessage(e));
+        }
+
+        TestUtil.makeSummary(test, test.getCatMap());
+        TestUtil.makeSummaryInfo(test, test.getCatMap(), null);
+        TestUtil.saveResult(test, test.getCatMap());
+    }
+
+    /**
+     * save the result file .
+     *
+     * @param caseFile
+     */
+    private synchronized void saveResults(String caseFile) {
+        CaseResult caseResult = (CaseResult) test.getCaseResultFromMap(caseFile);
+        if (!caseResult.isShouldRun()) {
+            return;
+        }
+        if (caseResult.getType() == CaseResult.TYPE_SQL
+                || caseResult.getType() == CaseResult.TYPE_GROOVY) {
+            String result = caseResult.getResult();
+            String answer = FileUtil.readFile(caseResult.getAnswerFile());
+            result = result.replaceAll("\r", "").replaceAll("\n", "");
+            answer = answer.replaceAll("\r", "").replaceAll("\n", "");
+            TestCaseSummary fs = new TestCaseSummary();
+
+            if (!answer.equals(result)) {
+                fs.setTestResult("fail");
+                caseResult.setSuccessFul(false);
+                TestUtil.saveResult(caseResult, test.getCodeset());
+                processMonitor.setFailedFile(processMonitor.getFailedFile() + 1);
+            } else {
+                processMonitor.setSuccessFile(processMonitor.getSuccessFile() + 1);
+                fs.setTestResult("success");
+            }
+
+            if (test.isNeedSummaryXML()) {
+                String caseFileDir = "";
+                String answerFileDir = "";
+                String ansFile = StringUtil.replaceSlashBasedSystem(caseResult.getAnswerFile());
+                String rootPath = test.getScenarioRootPath();
+                String testType = test.getTestType();
+
+                int rootPathLength = rootPath.length();
+                caseFileDir =
+                        testType
+                                + File.separator
+                                + StringUtil.replaceSlashBasedSystem(caseFile)
+                                        .substring(rootPathLength);
+                answerFileDir = testType + File.separator + ansFile.substring(rootPathLength);
+
+                fs.setCaseFile(StringUtil.replaceSlash(caseFileDir));
+                fs.setAnswerFile(StringUtil.replaceSlash(answerFileDir));
+                fs.setElapseTime(String.valueOf(caseResult.getTotalTime()));
+                TestUtil.copyCaseAnswerFile(caseResult);
+                FileUtil.writeDataToFileWithHandle(test.getFileHandle(), fs.toXmlString());
+            }
+
+        } else {
+            int position = caseFile.indexOf(".sh");
+            String resultFile = caseFile.substring(0, position) + ".result";
+            boolean isOk = isScriptCaseOk(resultFile);
+            if (!isOk) {
+                caseResult.setSuccessFul(false);
+                TestUtil.saveResult(caseResult, TestUtil.DEFAULT_CODESET);
+                processMonitor.setFailedFile(processMonitor.getFailedFile() + 1);
+            } else {
+
+                processMonitor.setSuccessFile(processMonitor.getSuccessFile() + 1);
+            }
+        }
+    }
+
+    public void saveCoreCallStackFile(String caseFile, List<File> coreFileList) {
+        CaseResult caseResult = (CaseResult) test.getCaseResultFromMap(caseFile);
+        String caseResultDir = caseResult.getResultDir();
+        String coreFile = caseResultDir + File.separator + caseResult.getCaseName() + ".err";
+        StringBuffer headerText = new StringBuffer();
+        StringBuffer bodyText = new StringBuffer();
+        int coreFileListSize = coreFileList == null ? 0 : coreFileList.size();
+        String rootCoreBackupDir = EnvGetter.getenv("CORE_BACKUP_DIR");
+        if (coreFileListSize != 0) {
+            headerText.append("SUMMARY:");
+            headerText.append(System.getProperty("line.separator"));
+            if (rootCoreBackupDir != null && rootCoreBackupDir.length() > 0) {
+                headerText.append(
+                        "CORE_DIR:" + rootCoreBackupDir + File.separator + test.getTestId());
+                headerText.append(System.getProperty("line.separator"));
+            } else {
+                headerText.append("CORE_DIR:" + CubridUtil.getCubridPath());
+                headerText.append(System.getProperty("line.separator"));
+            }
+        }
+
+        for (int i = 0; i < coreFileList.size(); i++) {
+            File coreFileName = coreFileList.get(i);
+            try {
+                String[] callStackInfo = AnalyzerMain.fetchCoreFullStack(coreFileName);
+                String coreName = coreFileName.getName();
+                if (callStackInfo != null && callStackInfo.length > 1) {
+                    headerText.append(
+                            coreName
+                                    + " ["
+                                    + callStackInfo[2]
+                                    + "] "
+                                    + callStackInfo[0]
+                                    + System.getProperty("line.separator"));
+                    bodyText.append(
+                            System.getProperty("line.separator")
+                                    + "=================="
+                                    + coreName
+                                    + "=================="
+                                    + System.getProperty("line.separator"));
+                    bodyText.append("");
+                    bodyText.append(callStackInfo[1]);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        CommonFileUtile.writeFile(headerText.toString() + bodyText.toString(), coreFile);
+    }
+
+    /**
+     * save the answer file .
+     *
+     * @param test
+     */
+    private void saveAnswers(Test test) {
+        this.onMessage("*********save answers...");
+        List<String> caseFileList = test.getCaseFileList();
+        for (int i = 0; i < caseFileList.size(); i++) {
+            String caseFile = (String) caseFileList.get(i);
+            saveAnswers(caseFile);
+        }
+    }
+
+    /**
+     * save the answer file .
+     *
+     * @param caseFile
+     */
+    private void saveAnswers(String caseFile) {
+        CaseResult caseResult = (CaseResult) test.getCaseResultFromMap(caseFile);
+        if (caseResult.getType() == CaseResult.TYPE_SQL
+                || caseResult.getType() == CaseResult.TYPE_GROOVY) {
+            FileUtil.writeToFile(caseResult.getAnswerFile(), caseResult.getResult());
+        }
+    }
+
+    /**
+     * determine the case file is correct or not .
+     *
+     * @param resultFile
+     * @return
+     */
+    private boolean isScriptCaseOk(String resultFile) {
+        boolean isOk = true;
+
+        BufferedReader reader = null;
+        try {
+            File file = new File(resultFile);
+            if (!file.exists()) {
+                return false;
+            }
+
+            reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+            String line = reader.readLine();
+            while (line != null) {
+                String[] subCaseData = line.split(":");
+                if (subCaseData.length < 2 || !subCaseData[1].trim().equalsIgnoreCase("ok")) {
+                    return false;
+                }
+
+                line = reader.readLine();
+            }
+        } catch (Exception e) {
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+
+        return isOk;
+    }
+
+    // this function is in order to make sure to execute set names before do
+    // each sql file testing
+    public void resetConnection(CubridConnection cubCon, Test test) {
+        String charset_sql = "";
+        Statement stmt = null;
+        ResultSet rs = null;
+        Connection conn = null;
+        cubCon.isAvlible();
+        conn = cubCon.getConn();
+
+        if (test.getReset_scripts() == null
+                || (test.getReset_scripts()).length() == 0
+                || "".equalsIgnoreCase((test.getReset_scripts()).trim())) {
+            if (test.getAutocommit() != null
+                    && test.getAutocommit().length() != 0
+                    && conn != null
+                    && !"medium".equalsIgnoreCase(test.getTestType())) {
+                try {
+                    conn.setAutoCommit(Boolean.valueOf(test.getAutocommit()));
+                    resetHoldCas(conn);
+                } catch (SQLException e) {
+                    String exceptionMessage =
+                            TestUtil.TEST_CONFIG
+                                    + " file:"
+                                    + test.getCharset_file()
+                                    + System.getProperty("line.separator");
+                    this.onMessage(exceptionMessage);
+                    e.printStackTrace();
+                }
+                return;
+            } else {
+                return;
+            }
+        }
+
+        charset_sql = test.getReset_scripts() + TestUtil.SQL_END;
+        try {
+            if (test.getAutocommit() != null) {
+                conn.setAutoCommit(Boolean.valueOf(test.getAutocommit()));
+            }
+
+            // reset hold cas
+            resetHoldCas(conn);
+            stmt = conn.createStatement();
+            stmt.execute(charset_sql);
+        } catch (SQLException e) {
+            String exceptionMessage =
+                    TestUtil.TEST_CONFIG
+                            + " file:"
+                            + test.getCharset_file()
+                            + System.getProperty("line.separator");
+            String msg = "Set System Parameter Error: ";
+            this.onMessage(msg + exceptionMessage);
+        } finally {
+            if (rs != null) {
+                try {
+                    rs.close();
+                } catch (SQLException e) {
+                    // TODO Auto-generated catch block
+                    this.onMessage(e.getMessage());
+                }
+            }
+            if (stmt != null) {
+                try {
+                    stmt.close();
+                } catch (SQLException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private void resetHoldCas(Connection conn) {
+        String holdcas = test.getHoldcas();
+        try {
+            if ("on".equalsIgnoreCase(holdcas)) {
+                Method method =
+                        conn.getClass().getMethod("setCASChangeMode", new Class[] {int.class});
+                method.invoke(conn, new Object[] {CUBRIDConnection.CAS_CHANGE_MODE_KEEP});
+            } else if ("off".equalsIgnoreCase(holdcas)) {
+                Method method =
+                        conn.getClass().getMethod("setCASChangeMode", new Class[] {int.class});
+                method.invoke(conn, new Object[] {CUBRIDConnection.CAS_CHANGE_MODE_AUTO});
+            }
+        } catch (Exception e) {
+            String message = "Exception: the current version can't support hold cas!";
+            this.onMessage(message);
+        }
+    }
+
+    public void checkServerStatus(CubridConnection cubCon) {
+        int timer = 0;
+        while (true) {
+            // timeout length is 180 seconds, if server will not alive after 180
+            // second, test will go on
+            if (isAliveForServerStatus(cubCon) || timer >= 180) {
+                String message = "";
+                if (timer >= 180) {
+                    message = "Server still cann't recovery dead, so timeout was execute!";
+                } else {
+                    message = "Server was recoveryed at " + timer + "seconds!";
+                }
+
+                this.onMessage(message);
+                break;
+            } else {
+                // sleep 5 seconds to check server status again
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    this.onMessage(e.getMessage());
+                }
+                timer += 5;
+                String message =
+                        "Server status is not alive, CQT will try to check it again after  "
+                                + timer
+                                + " seconds!!";
+                this.onMessage(message);
+            }
+        }
+    }
+
+    public boolean isAliveForServerStatus(CubridConnection cubCon) {
+        boolean status = false;
+        String sql = "SELECT 1;";
+        Statement stmt = null;
+        ResultSet rs = null;
+        Connection conn = null;
+        int value = 0;
+        cubCon.isAvlible();
+        conn = cubCon.getConn();
+
+        try {
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery(sql);
+            while (rs.next()) {
+                value = rs.getInt(1);
+                if (value == 1) {
+                    return true;
+                }
+            }
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            if (rs != null) {
+                try {
+                    rs.close();
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            if (stmt != null) {
+                try {
+                    stmt.close();
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        return status;
+    }
+
+    /**
+     * execute the sql test .
+     *
+     * @param test
+     * @param caseResult
+     * @return
+     */
+    private String executeSqlFile(Test test, CaseResult caseResult) {
+        ArrayList<Connection> ConnList = new ArrayList<Connection>();
+        if (test == null || caseResult == null) {
+            return null;
+        }
+        if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
+            return null;
+        }
+
+        String caseFile = caseResult.getCaseFile();
+        StringBuilder result = new StringBuilder();
+        List<Sql> sqlList =
+                SQLParser.parseSqlFile(caseFile, test.getCodeset(), test.isNeedDebugHint());
+        if (sqlList == null) {
+            return null;
+        }
+
+        // clear connection id list for each sql file
+        if (!test.getConnIDList().isEmpty()) {
+            test.getConnIDList().clear();
+        }
+
+        for (int i = 0; i < test.getSqlRunTime(); i++) {
+            this.onMessage(
+                    (new StringBuilder())
+                            .append("Now Running File  ..... \t")
+                            .append(caseFile)
+                            .toString());
+            if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
+                return null;
+            }
+            try {
+                test.setDbId(test.getDbId(caseFile));
+
+                String dbId = test.getDbId();
+                String connId = test.getConnId();
+                CubridConnection cubridConnection =
+                        dao.getCubridConnection(dbId, connId, test.getType());
+
+                test.getConnIDList().put(connId, cubridConnection);
+
+                // check if CQT need check server status when start each file
+                // test executing
+                if (test.isNeedCheckServerStatus()) {
+                    checkServerStatus(cubridConnection);
+                }
+
+                // set db charset for test
+                resetConnection(cubridConnection, test);
+
+                long startTime = System.currentTimeMillis();
+                for (int k = 0; k < sqlList.size(); k++) {
+                    if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
+                        return null;
+                    }
+                    Sql sql = (Sql) sqlList.get(k);
+                    if (sql == null) {
+                        continue;
+                    }
+
+                    // isQueryPlan from two ways, one is "--@queryplan" in sql
+                    // file, another is "XXX.queryPlan" file whose name is same
+                    // as sql file
+
+                    String thisConnId = sql.getConnId();
+                    if (!thisConnId.equals("") && !thisConnId.equals(connId)) {
+                        cubridConnection =
+                                dao.getCubridConnection(dbId, thisConnId, test.getType());
+                        if (!test.getConnIDList().containsKey(thisConnId)) {
+                            test.getConnIDList().put(thisConnId, cubridConnection);
+                            // set connection reset for test
+                            resetConnection(cubridConnection, test);
+                        }
+                    }
+
+                    String script = sql.getScript();
+                    cubridConnection.isAvlible();
+                    Connection conn = cubridConnection.getConn();
+                    ConnList.add(conn);
+
+                    // ===============2010-10-20==========================
+                    // int pos = script.indexOf("autocommit ");
+                    // if (pos != -1) {
+                    // String onOff = script.substring(pos
+                    // + "autocommit ".length());
+                    // conn.setAutoCommit(onOff.indexOf("on") != -1);
+                    // String message = "@" + test.getConnId()
+                    // + ": autocommit " + onOff;
+                    // this.onMessage(message);
+                    // } else {
+                    // String message = "@" + test.getDbId() + "/"
+                    // + test.getConnId() + ":" + sql.getScript();
+                    // this.onMessage(message);
+                    //
+                    // dao.execute(conn, sql, caseResult.isPrintQueryPlan());
+                    //
+                    // if (i == 0) {
+                    // result
+                    // .append("===================================================");
+                    // result.append(System.getProperty("line.separator"));
+                    //
+                    // result.append(sql.getResult());
+                    // }
+                    // }
+                    // ===============2010-10-20==========================
+
+                    // ===============replace above=======================
+                    boolean isOn = isPropOn(TestUtil.AUTOCOMMIT, script);
+                    boolean isOff = isPropOff(TestUtil.AUTOCOMMIT, script);
+                    boolean isHoldCasOn = isPropOn(TestUtil.HOLDCAS, script);
+                    boolean isHoldCasOff = isPropOff(TestUtil.HOLDCAS, script);
+                    boolean isServerMessageOn = isPropOn(TestUtil.SERVER_MESSAGE, script);
+                    boolean isServerMessageOff = isPropOff(TestUtil.SERVER_MESSAGE, script);
+
+                    if (isOn) {
+                        conn.setAutoCommit(isOn);
+                        String message = "@" + test.getConnId() + ": autocommit " + isOn;
+                        this.onMessage(message);
+                    } else if (isOff) {
+                        conn.setAutoCommit(!isOff);
+                        String message = "@" + test.getConnId() + ": autocommit " + !isOff;
+                        this.onMessage(message);
+                    } else if (isHoldCasOn) {
+                        try {
+                            String message = "@" + test.getConnId() + ": hold cas " + isHoldCasOn;
+
+                            Method method =
+                                    conn.getClass()
+                                            .getMethod("setCASChangeMode", new Class[] {int.class});
+                            method.invoke(
+                                    conn, new Object[] {CUBRIDConnection.CAS_CHANGE_MODE_KEEP});
+
+                            this.onMessage(message);
+                        } catch (Exception e) {
+                            String message =
+                                    "Exception: the current version can't support hold cas!";
+                            this.onMessage(message);
+                        }
+                    } else if (isHoldCasOff) {
+                        try {
+                            String message = "@" + test.getConnId() + ": hold cas " + isHoldCasOff;
+                            Method method =
+                                    conn.getClass()
+                                            .getMethod("setCASChangeMode", new Class[] {int.class});
+                            method.invoke(
+                                    conn, new Object[] {CUBRIDConnection.CAS_CHANGE_MODE_AUTO});
+                            this.onMessage(message);
+                        } catch (Exception e) {
+                            String message =
+                                    "Exception: the current version can't support hold cas!";
+                            this.onMessage(message);
+                        }
+                    } else if (isServerMessageOn) {
+                        try {
+                            String message =
+                                    "@"
+                                            + test.getConnId()
+                                            + ": server message "
+                                            + isServerMessageOn;
+                            this.onMessage(message);
+                            test.setServerMessage("on");
+                            // TODO: DBMS_OUTPUT.enable ()
+                            Sql enableSql =
+                                    new Sql(connId, "CALL enable(20000)", null, true); // TODO: set
+                            // size of
+                            // enable
+                            dao.execute(conn, enableSql, false);
+                        } catch (Exception e) {
+                            String message =
+                                    "Exception: the current version can't support DBMS_OUTPUT!";
+                            this.onMessage(message);
+                        }
+                    } else if (isServerMessageOff) {
+                        try {
+                            String message =
+                                    "@"
+                                            + test.getConnId()
+                                            + ": server message "
+                                            + isServerMessageOff;
+                            this.onMessage(message);
+
+                            test.setServerMessage("off");
+                            // TODO: DBMS_OUTPUT.disable()
+                            Sql disableSql = new Sql(connId, "CALL disable()", null, true);
+                            dao.execute(conn, disableSql, false);
+                        } catch (Exception e) {
+                            String message =
+                                    "Exception: the current version can't support DBMS_OUTPUT!";
+                            this.onMessage(message);
+                        }
+                    } else {
+                        String message =
+                                "@"
+                                        + test.getDbId()
+                                        + "/"
+                                        + test.getConnId()
+                                        + ":"
+                                        + sql.getScript();
+                        this.onMessage(message);
+
+                        // System.out.println ("script = " + sql.getScript());
+
+                        dao.execute(conn, sql, caseResult.isPrintQueryPlan());
+
+                        if (i == 0) {
+                            result.append("===================================================");
+                            result.append(System.getProperty("line.separator"));
+
+                            result.append(sql.getResult());
+                        }
+                    }
+
+                    cubridConnection.free();
+                }
+
+                long totalTime = System.currentTimeMillis() - startTime;
+                caseResult.setTotalTime(totalTime);
+                caseResult.setSiteRunTimes(1);
+            } catch (Exception e) {
+                if (i == 0) {
+                    result.append(e.getMessage() + System.getProperty("line.separator"));
+                }
+                this.onMessage(e.getMessage());
+            } finally {
+                if (i == 0) {
+                    caseResult.setResult(result.toString());
+                    caseResult.setSiteRunTimes(1);
+                }
+            }
+
+            Statement stmt;
+            ResultSet rs;
+            int charset;
+            String sql;
+
+            for (Connection conn1 : ConnList) {
+                try {
+                    conn1.commit();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
+            if (test.isQaview()) {
+                for (Connection conn : ConnList) {
+                    try {
+
+                        if (conn.getAutoCommit() == false)
+                            this.onMessage(
+                                    "[QA REVIEW] FOGOT TO RESET AUTOCOMMIT"
+                                            + " ("
+                                            + caseFile
+                                            + ")");
+
+                        conn.setAutoCommit(true);
+
+                        stmt = conn.createStatement();
+
+                        sql =
+                                "select class_name,class_type from db_class where is_system_class<>'YES'";
+                        rs = stmt.executeQuery(sql);
+                        while (rs.next()) {
+                            this.onMessage(
+                                    "[QA REVIEW] FOGOT TO DELETE "
+                                            + rs.getString(1)
+                                            + " with "
+                                            + rs.getString(2)
+                                            + " type"
+                                            + " ("
+                                            + caseFile
+                                            + ")");
+                        }
+                        rs.close();
+
+                        sql = "select name from db_serial";
+                        rs = stmt.executeQuery(sql);
+                        while (rs.next()) {
+                            this.onMessage(
+                                    "[QA REVIEW] FOGOT TO DELETE serial "
+                                            + rs.getString(1)
+                                            + " ("
+                                            + caseFile
+                                            + ")");
+                        }
+                        rs.close();
+
+                        sql = "select name from db_trigger";
+                        rs = stmt.executeQuery(sql);
+                        while (rs.next()) {
+                            this.onMessage(
+                                    "[QA REVIEW] FOGOT TO DELETE trigger "
+                                            + rs.getString(1)
+                                            + " ("
+                                            + caseFile
+                                            + ")");
+                        }
+                        rs.close();
+
+                        sql = "select name from db_user where name not in ('DBA', 'PUBLIC');";
+                        rs = stmt.executeQuery(sql);
+                        while (rs.next()) {
+                            this.onMessage(
+                                    "[QA REVIEW] FOGOT TO DELETE user "
+                                            + rs.getString(1)
+                                            + " ("
+                                            + caseFile
+                                            + ")");
+                        }
+                        rs.close();
+
+                        sql = "select sp_name from db_stored_procedure";
+                        rs = stmt.executeQuery(sql);
+                        while (rs.next()) {
+                            this.onMessage(
+                                    "[QA REVIEW] FOGOT TO DELETE SP "
+                                            + rs.getString(1)
+                                            + " ("
+                                            + caseFile
+                                            + ")");
+                        }
+                        rs.close();
+
+                        sql = "select USER";
+                        rs = stmt.executeQuery(sql);
+                        String user;
+                        while (rs.next()) {
+                            user = rs.getString(1);
+                            if (!user.equalsIgnoreCase("DBA")) {
+                                this.onMessage(
+                                        "[QA REVIEW] FOGOT TO RECOVERY USER: "
+                                                + user
+                                                + " ("
+                                                + caseFile
+                                                + ")");
+                            }
+                        }
+                        rs.close();
+
+                        rs = stmt.executeQuery("SELECT charset from db_root");
+                        rs.next();
+                        charset = rs.getInt(1);
+                        rs.close();
+
+                        String collation;
+                        sql = "select collation('a')";
+                        try {
+                            rs = stmt.executeQuery(sql);
+                            rs.next();
+                            collation = rs.getString(1);
+                        } catch (Exception e) {
+                            if (rs != null) rs.close();
+                            if (stmt != null) stmt.close();
+                            continue;
+                        }
+
+                        if (charset == 4) {
+                            if (!collation.equalsIgnoreCase("euckr_bin")) {
+                                this.onMessage(
+                                        "[QA REVIEW] FOGOT TO RECOVERY collation: "
+                                                + collation
+                                                + " ("
+                                                + caseFile
+                                                + ")");
+                            }
+                        } else if (charset == 5) {
+                            if (!collation.equalsIgnoreCase("utf8_bin")) {
+                                this.onMessage(
+                                        "[QA REVIEW] FOGOT TO RECOVERY collation: "
+                                                + collation
+                                                + " ("
+                                                + caseFile
+                                                + ")");
+                            }
+                        } else if (charset == 3) {
+                            if (!collation.equalsIgnoreCase("iso88591_bin")) {
+                                this.onMessage(
+                                        "[QA REVIEW] FOGOT TO RECOVERY collation: "
+                                                + collation
+                                                + " ("
+                                                + caseFile
+                                                + ")");
+                            }
+                        } else {
+                            if (!collation.equalsIgnoreCase("iso88591_bin")) {
+                                this.onMessage(
+                                        "[QA REVIEW] FOGOT TO RECOVERY collation: "
+                                                + collation
+                                                + " ("
+                                                + caseFile
+                                                + ")");
+                            }
+                        }
+
+                        if (charset == 4) {
+                            stmt.executeUpdate("SET NAMES euckr collate euckr_bin");
+                        } else if (charset == 5) {
+                            stmt.executeUpdate("SET NAMES utf8 collate utf8_bin");
+                        } else if (charset == 3) {
+                            stmt.executeUpdate("SET NAMES iso88591 collate iso88591_bin");
+                        } else {
+                            stmt.executeUpdate("SET NAMES iso88591 collate iso88591_bin");
+                        }
+
+                        stmt.close();
+
+                    } catch (SQLException e) {
+                        this.onMessage(e.getMessage());
+                    }
+                }
+            }
+        }
+        return caseResult.toString();
+    }
+
+    /**
+     * determine if Database is normal.
+     *
+     * @param test
+     * @return
+     */
+    @SuppressWarnings("deprecation")
+    private boolean checkDb(Test test) {
+        boolean flag = true;
+        if (hasSql && !dao.isDbOk()) {
+            flag = false;
+        }
+        return flag;
+    }
+
+    /** */
+    protected void init() {
+        long startTime = System.currentTimeMillis();
+        startTime = System.currentTimeMillis();
+        String dbVersion = configureUtil.getProperty("dbversion");
+        String dbBuild = configureUtil.getProperty("dbbuildnumber");
+        test.setDbVersion(dbVersion);
+        test.setDbBuild(dbBuild);
+        LogUtil.log(logId, "[time]getProperties:" + (System.currentTimeMillis() - startTime));
+
+        startTime = System.currentTimeMillis();
+    }
+
+    public ProcessMonitor getProcessMonitor() {
+        return processMonitor;
+    }
+
+    /**
+     * this inner class created by anson cheung,it used for execute sql muti-thread
+     *
+     * @author Administrator
+     */
+    class MutiSqlEx extends Thread {
+        private Test test;
+        private int index;
+
+        private CaseResult caseResult;
+
+        public void setTest(Test test) {
+            this.test = test;
+        }
+
+        public void setCaseResult(CaseResult caseResult) {
+            this.caseResult = caseResult;
+        }
+
+        public CaseResult getCaseResult() {
+            return caseResult;
+        }
+
+        private ConsoleBO bo;
+
+        public void setBo(ConsoleBO bo) {
+            this.bo = bo;
+        }
+
+        public MutiSqlEx(String name) {
+            super(name);
+        }
+
+        @Override
+        public void run() {
+            List<Connection> ConnList = new ArrayList<Connection>();
+            if (test == null
+                    || caseResult == null
+                    || processMonitor.getCurrentstate() == processMonitor.Status_Stoping
+                    || processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
+                return;
+            }
+            String caseFile = caseResult.getCaseFile();
+            StringBuilder result = new StringBuilder();
+            List<Sql> sqlList =
+                    SQLParser.parseSqlFile(caseFile, test.getCodeset(), test.isNeedDebugHint());
+
+            String dbId = test.getDbId();
+            String connId = test.getConnId();
+            CubridConnection cubridConnection =
+                    dao.getCubridConnection(dbId, connId, test.getType());
+
+            // check if CQT need check server status when start each file test
+            // executing
+            if (test.isNeedCheckServerStatus()) {
+                checkServerStatus(cubridConnection);
+            }
+
+            // set db charset for test
+            resetConnection(cubridConnection, test);
+
+            if (sqlList == null) {
+                return;
+            }
+            try {
+                test.setDbId(test.getDbId(caseFile));
+                long startTime = System.currentTimeMillis();
+                for (int k = 0; k < sqlList.size(); k++) {
+                    if (processMonitor.getCurrentstate() == processMonitor.Status_Stoping
+                            || processMonitor.getCurrentstate() == processMonitor.Status_Stoping) {
+                        return;
+                    }
+                    Sql sql = (Sql) sqlList.get(k);
+                    if (sql == null) {
+                        continue;
+                    }
+
+                    String script = sql.getScript();
+                    // String dbId = test.getDbId();
+                    // String connId = test.getConnId();
+                    String ThreadConnId = connId;
+                    String thisConnId = sql.getConnId();
+                    if (!thisConnId.equals("") && !thisConnId.equals(connId)) {
+                        ThreadConnId = thisConnId;
+                        cubridConnection =
+                                dao.getCubridConnection(dbId, ThreadConnId, index, test.getType());
+                        resetConnection(cubridConnection, test);
+                    }
+
+                    cubridConnection.isAvlible();
+                    Connection conn = cubridConnection.getConn();
+                    ConnList.add(conn);
+                    boolean isOn = isPropOn(TestUtil.AUTOCOMMIT, script);
+                    boolean isOff = isPropOff(TestUtil.AUTOCOMMIT, script);
+                    boolean isHoldCasOn = isPropOn(TestUtil.HOLDCAS, script);
+                    boolean isHoldCasOff = isPropOff(TestUtil.HOLDCAS, script);
+                    boolean isServerMessageOn = isPropOn(TestUtil.SERVER_MESSAGE, script);
+                    boolean isServerMessageOff = isPropOff(TestUtil.SERVER_MESSAGE, script);
+
+                    if (isOn) {
+                        conn.setAutoCommit(isOn);
+                        String message = "@" + test.getConnId() + ": autocommit " + isOn;
+                        bo.onMessage("[THREAD:" + index + "]" + message);
+                    } else if (isOff) {
+                        conn.setAutoCommit(!isOff);
+                        String message = "@" + test.getConnId() + ": autocommit " + !isOff;
+                        bo.onMessage("[THREAD:" + index + "]" + message);
+                    } else if (isHoldCasOn) {
+                        try {
+                            String message = "@" + test.getConnId() + ": hold cas " + isHoldCasOn;
+
+                            Method method =
+                                    conn.getClass()
+                                            .getMethod("setCASChangeMode", new Class[] {int.class});
+                            method.invoke(
+                                    conn, new Object[] {CUBRIDConnection.CAS_CHANGE_MODE_KEEP});
+
+                            bo.onMessage("--- hold cas -- " + isHoldCasOn);
+                        } catch (Exception e) {
+                            String message =
+                                    "Exception: the current version can't support hold cas!";
+                            bo.onMessage(message);
+                        }
+                    } else if (isHoldCasOff) {
+                        try {
+                            String message = "@" + test.getConnId() + ": hold cas " + isHoldCasOff;
+                            Method method =
+                                    conn.getClass()
+                                            .getMethod("setCASChangeMode", new Class[] {int.class});
+                            method.invoke(
+                                    conn, new Object[] {CUBRIDConnection.CAS_CHANGE_MODE_AUTO});
+                            bo.onMessage("--- hold cas -- " + isHoldCasOff);
+                        } catch (Exception e) {
+                            String message =
+                                    "Exception: the current version can't support hold cas!";
+                            bo.onMessage(message);
+                        }
+                    } else if (isServerMessageOn) {
+                        try {
+                            String message =
+                                    "@"
+                                            + test.getConnId()
+                                            + ": server message "
+                                            + isServerMessageOn;
+                            bo.onMessage(message);
+
+                            Sql enableSql =
+                                    new Sql(
+                                            connId,
+                                            "CALL DBMS_OUTPUT.enable(20000)",
+                                            null,
+                                            true); // TODO: set
+                            // size of
+                            // enable
+                            dao.execute(conn, enableSql, false);
+                        } catch (Exception e) {
+                            String message =
+                                    "Exception: the current version can't support DBMS_OUTPUT!";
+                            bo.onMessage(message);
+                        }
+                    } else if (isServerMessageOff) {
+                        try {
+                            String message =
+                                    "@"
+                                            + test.getConnId()
+                                            + ": server message "
+                                            + isServerMessageOff;
+                            bo.onMessage(message);
+                            Sql disableSql =
+                                    new Sql(connId, "CALL DBMS_OUTPUT.disable()", null, true);
+                            dao.execute(conn, disableSql, false);
+                        } catch (Exception e) {
+                            String message =
+                                    "Exception: the current version can't support DBMS_OUTPUT!";
+                            bo.onMessage(message);
+                        }
+                    } else {
+                        // System.out.println("--- use default autocommit -- " +
+                        // conn.getAutoCommit());
+                        String message =
+                                "@"
+                                        + test.getDbId()
+                                        + "/"
+                                        + test.getConnId()
+                                        + ":"
+                                        + sql.getScript();
+                        bo.onMessage("[THREAD:" + index + "]" + message);
+
+                        // System.out.println ("script = " + sql.getScript());
+
+                        dao.execute(conn, sql, caseResult.isPrintQueryPlan());
+                        result.append("===================================================");
+                        result.append(System.getProperty("line.separator"));
+                        result.append(sql.getResult());
+                    }
+
+                    cubridConnection.free();
+                }
+                long totalTime = System.currentTimeMillis() - startTime;
+                caseResult.setTotalTime(totalTime);
+
+            } catch (Exception e) {
+
+                result.append(e.getMessage() + System.getProperty("line.separator"));
+
+                e.printStackTrace();
+            } finally {
+                caseResult.setResult(result.toString());
+                caseResult.setSiteRunTimes(test.getSiteRunTimes());
+            }
+            for (Connection conn : ConnList) {
+                try {
+                    conn.commit();
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        public void setIndex(int index) {
+            this.index = index;
+        }
+    }
+
+    public Test getTest() {
+        return test;
+    }
+
+    private boolean isPropOn(String prop, String sql) {
+        String tmp = sql.trim();
+        String regex = prop + "\\s+on\\s*;?";
+        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(tmp);
+        return matcher.find();
+    }
+
+    private boolean isPropOff(String prop, String sql) {
+        String tmp = sql.trim();
+        String regex = prop + "\\s+off\\s*;?";
+        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(tmp);
+        return matcher.find();
+    }
 }

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
@@ -1039,8 +1039,8 @@ public class ConsoleBO extends Executor {
 					boolean isOff = isPropOff(TestUtil.AUTOCOMMIT, script);
 					boolean isHoldCasOn = isPropOn(TestUtil.HOLDCAS, script);
 					boolean isHoldCasOff = isPropOff(TestUtil.HOLDCAS, script);
-					boolean isServerOutputOn = isPropOn(TestUtil.SERVER_OUTPUT, script);
-					boolean isServerOutputOff = isPropOff(TestUtil.SERVER_OUTPUT, script);
+					boolean isServerMessageOn = isPropOn(TestUtil.SERVER_MESSAGE, script);
+					boolean isServerMessageOff = isPropOff(TestUtil.SERVER_MESSAGE, script);
 
 					if (isOn) {
 						conn.setAutoCommit(isOn);
@@ -1072,11 +1072,11 @@ public class ConsoleBO extends Executor {
 							String message = "Exception: the current version can't support hold cas!";
 							this.onMessage(message);
 						}
-					} else if (isServerOutputOn) {
+					} else if (isServerMessageOn) {
 						try {
-							String message = "@" + test.getConnId() + ": server output " + isServerOutputOn;
+							String message = "@" + test.getConnId() + ": server message " + isServerMessageOn;
 							this.onMessage(message);
-							test.setServerOutput("on");
+							test.setServerMessage("on");
 							// TODO: DBMS_OUTPUT.enable ()
 							Sql enableSql = new Sql(connId, "CALL enable(20000)", null, true); // TODO: set
 																								// size of
@@ -1086,12 +1086,12 @@ public class ConsoleBO extends Executor {
 							String message = "Exception: the current version can't support DBMS_OUTPUT!";
 							this.onMessage(message);
 						}
-					} else if (isServerOutputOff) {
+					} else if (isServerMessageOff) {
 						try {
-							String message = "@" + test.getConnId() + ": server output " + isServerOutputOff;
+							String message = "@" + test.getConnId() + ": server message " + isServerMessageOff;
 							this.onMessage(message);
 
-							test.setServerOutput("off");
+							test.setServerMessage("off");
 							// TODO: DBMS_OUTPUT.disable()
 							Sql disableSql = new Sql(connId, "CALL disable()", null, true);
 							dao.execute(conn, disableSql, false);
@@ -1397,8 +1397,8 @@ public class ConsoleBO extends Executor {
 					boolean isOff = isPropOff(TestUtil.AUTOCOMMIT, script);
 					boolean isHoldCasOn = isPropOn(TestUtil.HOLDCAS, script);
 					boolean isHoldCasOff = isPropOff(TestUtil.HOLDCAS, script);
-					boolean isServerOutputOn = isPropOn(TestUtil.SERVER_OUTPUT, script);
-					boolean isServerOutputOff = isPropOn(TestUtil.SERVER_OUTPUT, script);
+					boolean isServerMessageOn = isPropOn(TestUtil.SERVER_MESSAGE, script);
+					boolean isServerMessageOff = isPropOff(TestUtil.SERVER_MESSAGE, script);
 
 					if (isOn) {
 						conn.setAutoCommit(isOn);
@@ -1430,9 +1430,9 @@ public class ConsoleBO extends Executor {
 							String message = "Exception: the current version can't support hold cas!";
 							bo.onMessage(message);
 						}
-					} else if (isServerOutputOn) {
+					} else if (isServerMessageOn) {
 						try {
-							String message = "@" + test.getConnId() + ": server output " + isServerOutputOn;
+							String message = "@" + test.getConnId() + ": server message " + isServerMessageOn;
 							bo.onMessage(message);
 
 							Sql enableSql = new Sql(connId, "CALL DBMS_OUTPUT.enable(20000)", null, true); // TODO: set
@@ -1443,9 +1443,9 @@ public class ConsoleBO extends Executor {
 							String message = "Exception: the current version can't support DBMS_OUTPUT!";
 							bo.onMessage(message);
 						}
-					} else if (isServerOutputOff) {
+					} else if (isServerMessageOff) {
 						try {
-							String message = "@" + test.getConnId() + ": server output " + isServerOutputOff;
+							String message = "@" + test.getConnId() + ": server message " + isServerMessageOff;
 							bo.onMessage(message);
 							Sql disableSql = new Sql(connId, "CALL DBMS_OUTPUT.disable()", null, true);
 							dao.execute(conn, disableSql, false);

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -306,7 +306,7 @@ public class ConsoleDAO extends Executor {
         }
 
         // Print Output messages
-        if (test.getServerOutput().equalsIgnoreCase("on")) {
+        if (test.getServerMessage().equalsIgnoreCase("on")) {
             String messages = getServerOutputMessage(conn);
             sql.setResult(sql.getResult() + System.getProperty("line.separator") + messages);
         }
@@ -768,6 +768,16 @@ public class ConsoleDAO extends Executor {
                                 + System.getProperty("line.separator"));
             } else {
                 message.append("Error:" + e.getErrorCode() + System.getProperty("line.separator"));
+                if (test.getServerMessage().equalsIgnoreCase("on")) {
+                    String errmsg = e.getMessage();
+                    if (errmsg != null) {
+                        int idx = errmsg.indexOf("[CAS INFO");
+                        if (idx >= 0) {
+                            errmsg = errmsg.substring(0, idx);
+                        }
+                    }
+                    message.append(errmsg + System.getProperty("line.separator"));
+                }
             }
         }
         return message.toString();

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -723,7 +723,7 @@ public class ConsoleDAO extends Executor {
                 executeCall(conn, getLine);
                 List<SqlParam> paramList = getLine.getParamList();
                 if (((Integer) paramList.get(1).getValue()) == 0) {
-                        /* status */
+                    /* status */
                     message.append(
                             ((String) paramList.get(0).getValue())
                                     + System.getProperty("line.separator")); /* message */

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/PropertiesUtil.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/PropertiesUtil.java
@@ -1,29 +1,31 @@
 /**
  * Copyright (c) 2016, Search Solution Corporation. All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions are met:
- * 
- *   * Redistributions of source code must retain the above copyright notice, 
- *     this list of conditions and the following disclaimer.
- * 
- *   * Redistributions in binary form must reproduce the above copyright 
- *     notice, this list of conditions and the following disclaimer in 
- *     the documentation and/or other materials provided with the distribution.
- * 
- *   * Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products 
- *     derived from this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
- * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ *
+ * <p>Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * <p>* Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * <p>* Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * <p>* Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.navercorp.cubridqa.cqt.console.util;
 
+import com.navercorp.cubridqa.cqt.console.bean.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -34,262 +36,271 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
 import org.dom4j.Document;
 import org.dom4j.Element;
 import org.dom4j.io.SAXReader;
 
-import com.navercorp.cubridqa.cqt.console.bean.Test;
-
 public class PropertiesUtil {
 
-	private static String propertiesFilePath = EnvGetter.getenv("CTP_HOME") + File.separator + TestUtil.CONFIG_NAME + File.separator + "local.properties";
+    private static String propertiesFilePath =
+            EnvGetter.getenv("CTP_HOME")
+                    + File.separator
+                    + TestUtil.CONFIG_NAME
+                    + File.separator
+                    + "local.properties";
 
-	public static String getValue(String key) {
-		if (propertiesFilePath != null && new File(propertiesFilePath) != null && new File(propertiesFilePath).exists()) {
-			return getValue(key, propertiesFilePath);
-		} else {
-			return "";
-		}
-	}
+    public static String getValue(String key) {
+        if (propertiesFilePath != null
+                && new File(propertiesFilePath) != null
+                && new File(propertiesFilePath).exists()) {
+            return getValue(key, propertiesFilePath);
+        } else {
+            return "";
+        }
+    }
 
-	public static String getValueWithDefault(String key, String defaultValue) {
-		String value = getValue(key);
-		return value == null ? defaultValue : value;
-	}
+    public static String getValueWithDefault(String key, String defaultValue) {
+        String value = getValue(key);
+        return value == null ? defaultValue : value;
+    }
 
-	public static void setValue(String key, String value) {
-		if (propertiesFilePath != null && new File(propertiesFilePath) != null && new File(propertiesFilePath).exists()) {
-			setValue(key, value, propertiesFilePath);
-		}
-	}
+    public static void setValue(String key, String value) {
+        if (propertiesFilePath != null
+                && new File(propertiesFilePath) != null
+                && new File(propertiesFilePath).exists()) {
+            setValue(key, value, propertiesFilePath);
+        }
+    }
 
-	public static void initConfig(String configFile, Test test) throws Exception {
-		SAXReader reader = new SAXReader();
-		String val = "";
-		String script = "";
-		if (configFile == null || test == null) {
-			throw new Exception("Test configuration file is null or Test object creation fail!");
-		}
+    public static void initConfig(String configFile, Test test) throws Exception {
+        SAXReader reader = new SAXReader();
+        String val = "";
+        String script = "";
+        if (configFile == null || test == null) {
+            throw new Exception("Test configuration file is null or Test object creation fail!");
+        }
 
-		Document document = reader.read(configFile);
-		Element root = document.getRootElement();
-		List rmd = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.RUN_MODE);
-		if (!rmd.isEmpty()) {
-			Element run_mode = (Element) rmd.get(0);
-			val = run_mode.getText();
-			test.setRun_mode(val);
-		}
+        Document document = reader.read(configFile);
+        Element root = document.getRootElement();
+        List rmd = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.RUN_MODE);
+        if (!rmd.isEmpty()) {
+            Element run_mode = (Element) rmd.get(0);
+            val = run_mode.getText();
+            test.setRun_mode(val);
+        }
 
-		List rmdSuffix = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.RUN_MODE_SECONDARY);
-		if (!rmdSuffix.isEmpty()) {
-			Element run_mode_suffix = (Element) rmdSuffix.get(0);
-			val = run_mode_suffix.getText();
-			test.setRunModeSecondary(val);
-		}
+        List rmdSuffix = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.RUN_MODE_SECONDARY);
+        if (!rmdSuffix.isEmpty()) {
+            Element run_mode_suffix = (Element) rmdSuffix.get(0);
+            val = run_mode_suffix.getText();
+            test.setRunModeSecondary(val);
+        }
 
-		List ac = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.AUTOCOMMIT);
-		if (!ac.isEmpty()) {
-			Element autocommit = (Element) ac.get(0);
-			val = autocommit.getText();
-			test.setAutocommit(val);
-		}
+        List ac = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.AUTOCOMMIT);
+        if (!ac.isEmpty()) {
+            Element autocommit = (Element) ac.get(0);
+            val = autocommit.getText();
+            test.setAutocommit(val);
+        }
 
-		List hc = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.HOLDCAS);
-		if (!hc.isEmpty()) {
-			Element autocommit = (Element) hc.get(0);
-			val = autocommit.getText();
-			test.setHoldcas(val);
-		}
+        List hc = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.HOLDCAS);
+        if (!hc.isEmpty()) {
+            Element autocommit = (Element) hc.get(0);
+            val = autocommit.getText();
+            test.setHoldcas(val);
+        }
 
-		List sol = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.SERVER_MESSAGE);
-		if (!sol.isEmpty()) {
-			Element so = (Element) sol.get(0);
-			val = so.getText();
-			test.setServerMessage(val);
-		}
+        List sol = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.SERVER_MESSAGE);
+        if (!sol.isEmpty()) {
+            Element so = (Element) sol.get(0);
+            val = so.getText();
+            test.setServerMessage(val);
+        }
 
-		List checkAlive = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.CHECK_SERVER_STATUS);
-		if (!checkAlive.isEmpty()) {
-			Element serverStatus = (Element) checkAlive.get(0);
-			val = serverStatus.getText();
-			test.setNeedCheckServerStatus(Boolean.parseBoolean(val));
-		}
+        List checkAlive = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.CHECK_SERVER_STATUS);
+        if (!checkAlive.isEmpty()) {
+            Element serverStatus = (Element) checkAlive.get(0);
+            val = serverStatus.getText();
+            test.setNeedCheckServerStatus(Boolean.parseBoolean(val));
+        }
 
-		List urlProperties = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.URL_PROPERTIES);
-		if (!urlProperties.isEmpty()) {
-			Element urlProp = (Element) urlProperties.get(0);
-			val = urlProp.getText();
-			test.setUrlProperties(val);
-		}
+        List urlProperties = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.URL_PROPERTIES);
+        if (!urlProperties.isEmpty()) {
+            Element urlProp = (Element) urlProperties.get(0);
+            val = urlProp.getText();
+            test.setUrlProperties(val);
+        }
 
-		List needXmlSummary = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.NEED_XML_SUMMARY);
-		if (!needXmlSummary.isEmpty()) {
-			Element needXml = (Element) needXmlSummary.get(0);
-			val = needXml.getText();
-			test.setNeedSummaryXML(Boolean.parseBoolean(val));
-		}
+        List needXmlSummary = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.NEED_XML_SUMMARY);
+        if (!needXmlSummary.isEmpty()) {
+            Element needXml = (Element) needXmlSummary.get(0);
+            val = needXml.getText();
+            test.setNeedSummaryXML(Boolean.parseBoolean(val));
+        }
 
-		List needAnswerInSummary = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.NEED_ANSWER_In_Summary);
-		if (!needAnswerInSummary.isEmpty()) {
-			Element needAnswer = (Element) needAnswerInSummary.get(0);
-			val = needAnswer.getText();
-			test.setNeedAnswerInSummary(Boolean.parseBoolean(val));
-		}
+        List needAnswerInSummary =
+                root.selectNodes(TestUtil.ROOT_NODE + TestUtil.NEED_ANSWER_In_Summary);
+        if (!needAnswerInSummary.isEmpty()) {
+            Element needAnswer = (Element) needAnswerInSummary.get(0);
+            val = needAnswer.getText();
+            test.setNeedAnswerInSummary(Boolean.parseBoolean(val));
+        }
 
-		List addHint = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.ADD_DEBUG_HINT);
-		if (!addHint.isEmpty()) {
-			Element serverStatus = (Element) addHint.get(0);
-			val = serverStatus.getText();
-			test.setNeedDebugHint(Boolean.parseBoolean(val));
-		}
+        List addHint = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.ADD_DEBUG_HINT);
+        if (!addHint.isEmpty()) {
+            Element serverStatus = (Element) addHint.get(0);
+            val = serverStatus.getText();
+            test.setNeedDebugHint(Boolean.parseBoolean(val));
+        }
 
-		List rt = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.RESET);
-		if (!rt.isEmpty()) {
-			Element el = (Element) rt.get(0);
-			List nodes = el.elements();
-			for (Iterator iters = nodes.iterator(); iters.hasNext();) {
-				Element item = (Element) iters.next();
-				script += item.getTextTrim() + TestUtil.SQL_END + System.getProperty("line.separator");
-			}
+        List rt = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.RESET);
+        if (!rt.isEmpty()) {
+            Element el = (Element) rt.get(0);
+            List nodes = el.elements();
+            for (Iterator iters = nodes.iterator(); iters.hasNext(); ) {
+                Element item = (Element) iters.next();
+                script +=
+                        item.getTextTrim()
+                                + TestUtil.SQL_END
+                                + System.getProperty("line.separator");
+            }
+        }
+        test.setReset_scripts(script);
+    }
 
-		}
-		test.setReset_scripts(script);
-	}
+    /**
+     * get the value from property file .
+     *
+     * @param key
+     * @param propertiesPath
+     * @return
+     */
+    public static String getValue(String key, String propertiesPath) {
+        Properties p = new Properties();
+        InputStream is = null;
+        try {
+            is = new FileInputStream(new File(propertiesPath));
+            p.load(is);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        } finally {
+            try {
+                is.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        if (p.containsKey(key)) {
+            String value = p.getProperty(key);
+            if (value != null) {
+                return value.replaceAll("\\:", ":").trim();
+            } else {
+                return value;
+            }
+        }
+        return null;
+    }
 
-	/**
-	 * get the value from property file .
-	 * 
-	 * @param key
-	 * @param propertiesPath
-	 * @return
-	 */
-	public static String getValue(String key, String propertiesPath) {
-		Properties p = new Properties();
-		InputStream is = null;
-		try {
-			is = new FileInputStream(new File(propertiesPath));
-			p.load(is);
-		} catch (IOException e) {
-			e.printStackTrace();
-			return null;
-		} finally {
-			try {
-				is.close();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-		if (p.containsKey(key)) {
-			String value = p.getProperty(key);
-			if (value != null) {
-				return value.replaceAll("\\:", ":").trim();
-			} else {
-				return value;
-			}
-		}
-		return null;
-	}
+    /**
+     * add the key value map to the property file
+     *
+     * @param key
+     * @param value
+     * @param propertiesPath
+     */
+    public static void setValue(String key, String value, String propertiesPath) {
+        if (!new File(propertiesPath).exists()) {
+            try {
+                new File(propertiesPath).createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        Properties p = new Properties();
+        InputStream is = null;
+        FileOutputStream os = null;
+        try {
+            is = new FileInputStream(new File(propertiesPath));
+            p.load(is);
+            p.setProperty(key, value.replaceAll("\\\\:", ":"));
+            os = new FileOutputStream(propertiesPath);
+            p.store(os, "");
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                is.close();
+                os.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 
-	/**
-	 * add the key value map to the property file
-	 * 
-	 * @param key
-	 * @param value
-	 * @param propertiesPath
-	 */
-	public static void setValue(String key, String value, String propertiesPath) {
-		if (!new File(propertiesPath).exists()) {
-			try {
-				new File(propertiesPath).createNewFile();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-		Properties p = new Properties();
-		InputStream is = null;
-		FileOutputStream os = null;
-		try {
-			is = new FileInputStream(new File(propertiesPath));
-			p.load(is);
-			p.setProperty(key, value.replaceAll("\\\\:", ":"));
-			os = new FileOutputStream(propertiesPath);
-			p.store(os, "");
-		} catch (Exception e) {
-			e.printStackTrace();
-		} finally {
-			try {
-				is.close();
-				os.close();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-	}
+    /**
+     * remove the property load from a file and save it to the file.
+     *
+     * @param propertiesPath
+     * @param key
+     */
+    public static void removeProperty(String propertiesPath, String key) {
+        Properties p = new Properties();
+        InputStream is = null;
+        FileOutputStream os = null;
+        try {
+            is = new FileInputStream(new File(propertiesPath));
+            p.load(is);
+            if (!p.containsKey(key)) {
+                return;
+            }
+            p.remove(key);
+            os = new FileOutputStream(propertiesPath);
+            p.store(os, "");
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                is.close();
+                os.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 
-	/**
-	 * remove the property load from a file and save it to the file.
-	 * 
-	 * @param propertiesPath
-	 * @param key
-	 */
-	public static void removeProperty(String propertiesPath, String key) {
-		Properties p = new Properties();
-		InputStream is = null;
-		FileOutputStream os = null;
-		try {
-			is = new FileInputStream(new File(propertiesPath));
-			p.load(is);
-			if (!p.containsKey(key)) {
-				return;
-			}
-			p.remove(key);
-			os = new FileOutputStream(propertiesPath);
-			p.store(os, "");
-		} catch (Exception e) {
-			e.printStackTrace();
-		} finally {
-			try {
-				is.close();
-				os.close();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-	}
+    /**
+     * load the qa tools configuration file .
+     *
+     * @return
+     */
+    public static Map<String, String> loadProperties() {
+        HashMap<String, String> ret = new HashMap<String, String>();
+        InputStream is = null;
+        try {
+            is = new FileInputStream(new File(propertiesFilePath));
+            Properties p = new Properties();
+            p.load(is);
 
-	/**
-	 * load the qa tools configuration file .
-	 * 
-	 * @return
-	 */
-	public static Map<String, String> loadProperties() {
-		HashMap<String, String> ret = new HashMap<String, String>();
-		InputStream is = null;
-		try {
-			is = new FileInputStream(new File(propertiesFilePath));
-			Properties p = new Properties();
-			p.load(is);
-
-			Iterator iter = p.keySet().iterator();
-			while (iter.hasNext()) {
-				String key = (String) iter.next();
-				String value = p.getProperty(key);
-				if (value != null) {
-					value = value.replaceAll("\\:", ":");
-					ret.put(key, value);
-				}
-			}
-		} catch (IOException e) {
-			e.printStackTrace();
-			return null;
-		} finally {
-			try {
-				is.close();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-		return ret;
-	}
+            Iterator iter = p.keySet().iterator();
+            while (iter.hasNext()) {
+                String key = (String) iter.next();
+                String value = p.getProperty(key);
+                if (value != null) {
+                    value = value.replaceAll("\\:", ":");
+                    ret.put(key, value);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        } finally {
+            try {
+                is.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return ret;
+    }
 }

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/PropertiesUtil.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/PropertiesUtil.java
@@ -102,11 +102,11 @@ public class PropertiesUtil {
 			test.setHoldcas(val);
 		}
 
-		List sol = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.SERVER_OUTPUT);
+		List sol = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.SERVER_MESSAGE);
 		if (!sol.isEmpty()) {
 			Element so = (Element) sol.get(0);
 			val = so.getText();
-			test.setServerOutput(val);
+			test.setServerMessage(val);
 		}
 
 		List checkAlive = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.CHECK_SERVER_STATUS);

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/TestUtil.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/TestUtil.java
@@ -78,7 +78,7 @@ public class TestUtil {
 
 	public static final String HOLDCAS = "holdcas";
 
-	public static final String SERVER_OUTPUT = "server-output";
+	public static final String SERVER_MESSAGE = "server-message";
 
 	public static final String AUTOCOMMIT = "autocommit";
 

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/TestUtil.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/TestUtil.java
@@ -1,29 +1,36 @@
 /**
  * Copyright (c) 2016, Search Solution Corporation. All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions are met:
- * 
- *   * Redistributions of source code must retain the above copyright notice, 
- *     this list of conditions and the following disclaimer.
- * 
- *   * Redistributions in binary form must reproduce the above copyright 
- *     notice, this list of conditions and the following disclaimer in 
- *     the documentation and/or other materials provided with the distribution.
- * 
- *   * Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products 
- *     derived from this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
- * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ *
+ * <p>Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * <p>* Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * <p>* Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * <p>* Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.navercorp.cubridqa.cqt.console.util;
 
+import com.navercorp.cubridqa.cqt.common.CommonUtils;
+import com.navercorp.cubridqa.cqt.console.bean.CaseResult;
+import com.navercorp.cubridqa.cqt.console.bean.Summary;
+import com.navercorp.cubridqa.cqt.console.bean.SummaryInfo;
+import com.navercorp.cubridqa.cqt.console.bean.SystemModel;
+import com.navercorp.cubridqa.cqt.console.bean.Test;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -42,956 +49,987 @@ import java.util.Map;
 import java.util.Random;
 import java.util.StringTokenizer;
 
-import com.navercorp.cubridqa.cqt.common.CommonUtils;
-import com.navercorp.cubridqa.cqt.console.bean.CaseResult;
-import com.navercorp.cubridqa.cqt.console.bean.Summary;
-import com.navercorp.cubridqa.cqt.console.bean.SummaryInfo;
-import com.navercorp.cubridqa.cqt.console.bean.SystemModel;
-import com.navercorp.cubridqa.cqt.console.bean.Test;
-import com.navercorp.cubridqa.cqt.console.util.EnvGetter;
-import com.navercorp.cubridqa.cqt.console.util.PropertiesUtil;
-import com.navercorp.cubridqa.cqt.console.util.XstreamHelper;
-
 public class TestUtil {
 
-	public static Map<String, String[]> SCENARIOMAP;
+    public static Map<String, String[]> SCENARIOMAP;
 
-	public static final String SCENARIO = "/scenario/";
+    public static final String SCENARIO = "/scenario/";
 
-	public static final String RESULT = "/sql/result/";
+    public static final String RESULT = "/sql/result/";
 
-	public static final String CASEFLAG = "cases";
+    public static final String CASEFLAG = "cases";
 
-	public static final String OTHER_ANSWERS = "answers";
+    public static final String OTHER_ANSWERS = "answers";
 
-	public static String OTHER_ANSWERS_32 = "answers32";
+    public static String OTHER_ANSWERS_32 = "answers32";
 
-	public static String DEFAULT_CODESET = "UTF-8";
+    public static String DEFAULT_CODESET = "UTF-8";
 
-	public static final String CONFIG_NAME = "sql/configuration";
+    public static final String CONFIG_NAME = "sql/configuration";
 
-	public static final String TEST_CONFIG = "test_config";
+    public static final String TEST_CONFIG = "test_config";
 
-	public static final String RUN_MODE = "run_mode";
+    public static final String RUN_MODE = "run_mode";
 
-	public static final String RUN_MODE_SECONDARY = "run_mode_secondary";
+    public static final String RUN_MODE_SECONDARY = "run_mode_secondary";
 
-	public static final String HOLDCAS = "holdcas";
+    public static final String HOLDCAS = "holdcas";
 
-	public static final String SERVER_MESSAGE = "server-message";
+    public static final String SERVER_MESSAGE = "server-message";
 
-	public static final String AUTOCOMMIT = "autocommit";
+    public static final String AUTOCOMMIT = "autocommit";
 
-	public static final String CHECK_SERVER_STATUS = "check_server_status";
+    public static final String CHECK_SERVER_STATUS = "check_server_status";
 
-	public static final String URL_PROPERTIES = "url_properties";
+    public static final String URL_PROPERTIES = "url_properties";
 
-	public static final String ADD_DEBUG_HINT = "add_debug_hint";
+    public static final String ADD_DEBUG_HINT = "add_debug_hint";
 
-	public static final String NEED_XML_SUMMARY = "need_xml_summary";
+    public static final String NEED_XML_SUMMARY = "need_xml_summary";
 
-	public static final String NEED_ANSWER_In_Summary = "need_answer_in_summary";
+    public static final String NEED_ANSWER_In_Summary = "need_answer_in_summary";
 
-	public static final String HINT_PREFIX = "/*+ RECOMPILE QASRC(";
+    public static final String HINT_PREFIX = "/*+ RECOMPILE QASRC(";
 
-	public static final String APPEND_HINT_PREFIX = " QASRC(";
+    public static final String APPEND_HINT_PREFIX = " QASRC(";
 
-	public static final String APPEND_HINT_SUFFIX = " ) ";
+    public static final String APPEND_HINT_SUFFIX = " ) ";
 
-	public static final String HINT_SUFFIX = ") */";
+    public static final String HINT_SUFFIX = ") */";
 
-	public static final String RESET = "reset";
+    public static final String RESET = "reset";
 
-	public static final String ROOT_NODE = "/test/";
+    public static final String ROOT_NODE = "/test/";
 
-	public static final String SQL_END = ";";
+    public static final String SQL_END = ";";
 
-	public static final String TOTAL_SUMMARY_FILE = "/main.info";
+    public static final String TOTAL_SUMMARY_FILE = "/main.info";
 
-	public static final String SUMMARYLIST_FILE = "/summary.xml";
+    public static final String SUMMARYLIST_FILE = "/summary.xml";
 
-	public static final String ScenarioTypes = ".sql";
+    public static final String ScenarioTypes = ".sql";
 
-	public static String getAnswer4SQLAndOther(String filePath) {
-		String filename = FileUtil.getDir(StringUtil.replaceSlashBasedSystem(filePath));
-		if (filename.endsWith(File.separator + CASEFLAG)) {
-			filename = filename.replaceAll("\\\\", "/").replaceAll("/cases", "/" + TestUtil.OTHER_ANSWERS_32);
-		}
+    public static String getAnswer4SQLAndOther(String filePath) {
+        String filename = FileUtil.getDir(StringUtil.replaceSlashBasedSystem(filePath));
+        if (filename.endsWith(File.separator + CASEFLAG)) {
+            filename =
+                    filename.replaceAll("\\\\", "/")
+                            .replaceAll("/cases", "/" + TestUtil.OTHER_ANSWERS_32);
+        }
 
-		if (FileUtil.isFileExist(filename)) {
-			return OTHER_ANSWERS_32;
-		} else {
-			return OTHER_ANSWERS;
-		}
-	}
+        if (FileUtil.isFileExist(filename)) {
+            return OTHER_ANSWERS_32;
+        } else {
+            return OTHER_ANSWERS;
+        }
+    }
 
-	public static String getCharsetFile(String fileName) {
-		String fName = "";
-		fName = EnvGetter.getenv("CTP_HOME") + File.separator + CONFIG_NAME + File.separator + TEST_CONFIG + File.separator + fileName;
-		return fName;
-	}
+    public static String getCharsetFile(String fileName) {
+        String fName = "";
+        fName =
+                EnvGetter.getenv("CTP_HOME")
+                        + File.separator
+                        + CONFIG_NAME
+                        + File.separator
+                        + TEST_CONFIG
+                        + File.separator
+                        + fileName;
+        return fName;
+    }
 
-	public static final String SUMMARY_KEY = "Summary";
+    public static final String SUMMARY_KEY = "Summary";
 
-	static {
-		SCENARIOMAP = new Hashtable<String, String[]>();
+    static {
+        SCENARIOMAP = new Hashtable<String, String[]>();
 
-		String scenarionTypes = PropertiesUtil.getValue("scenariontypes");
-		if (scenarionTypes != null) {
-			String[] types = scenarionTypes.split(";");
-			for (int i = 0; i < types.length; i++) {
-				String type = types[i];
-				if (type == null) {
-					continue;
-				}
-				type = type.trim();
-				int position = type.indexOf("(");
-				if (position > 0) {
-					String dirName = type.substring(0, position);
-					String fileType = type.substring(position);
-
-					fileType = fileType.replaceAll("\\(", "").replaceAll("\\)", "");
-					String[] postfixes = fileType.split(",");
-					SCENARIOMAP.put(dirName, postfixes);
-				}
-			}
-		}
-	}
-
-	/**
-	 * get the testid through type and name .
-	 * 
-	 * @param type
-	 * @param name
-	 * @return
-	 */
-	public static String getTestId(String type, String name) {
-		StringBuilder ret = new StringBuilder();
-
-		if (type == null || type.trim().equals("")) {
-			type = "common";
-		}
-		ret.append(type);
-
-		String os = SystemUtil.getOS();
-		ret.append("_" + os);
-
-		if (name != null && !name.trim().equals("")) {
-			ret.append("_" + name);
-		}
-
-		String date = "";
-		// long s = System.currentTimeMillis();
-		// date = Long.toString(s);
-		SimpleDateFormat sdf = new SimpleDateFormat("ddHHmmss");
-		Random rand = new Random();
-		try {
-			date = sdf.format(new Date());
-		} catch (Exception e) {
-		}
-		ret.append("_" + date + rand.nextInt(99));
-
-		String version = PropertiesUtil.getValue("dbversion");
-		ret.append("_" + version);
-
-		ret.append("." + (PropertiesUtil.getValue("dbbuildnumber")));
-
-		return ret.toString();
-	}
-
-	/**
-	 * 
-	 * @return
-	 */
-	public static String getYearDirName() {
-		return "y" + Calendar.getInstance().get(Calendar.YEAR);
-	}
-
-	/**
-	 * 
-	 * @return
-	 */
-	public static String getMonthDirName() {
-		return "m" + (Calendar.getInstance().get(Calendar.MONTH) + 1);
-	}
-
-	public static String getResultDir(String resID) {
-		String res_dir = "";
-		res_dir = EnvGetter.getenv("CTP_HOME") + RESULT + getYearDirName() + File.separator + getMonthDirName() + File.separator + resID;
-
-		res_dir = StringUtil.replaceSlashBasedSystem(res_dir);
-		return res_dir;
-	}
-
-	/**
-	 * get the test file type through case file .
-	 * 
-	 * @param caseFile
-	 * @return
-	 */
-	public static int getTestType(String caseFile) {
-		if (caseFile == null) {
-			return -1;
-		}
-
-		int ret = -1;
-		caseFile = caseFile.toLowerCase();
-		if (caseFile.endsWith(".sql")) {
-			ret = CaseResult.TYPE_SQL;
-		} else if (caseFile.endsWith(".sh")) {
-			ret = CaseResult.TYPE_SCRIPT;
-		} else if (caseFile.endsWith(".grv")) {
-			ret = CaseResult.TYPE_GROOVY;
-		}
-		return ret;
-	}
-
-	/**
-	 * get the result directory through the case file and Test.
-	 * 
-	 * @param test
-	 * @param caseFile
-	 * @return
-	 */
-	public static String getResultDir(Test test, String caseFile) {
-		if (test == null || caseFile == null || caseFile.trim().equals("")) {
-			return null;
-		}
-		String ret = null;
-		String scenarioRoot = test.getScenarioRootPath();
-		int rootLength = scenarioRoot.length();
-		String scenarioSuffer = caseFile.substring(rootLength);
-		ret = StringUtil.replaceSlashBasedSystem(test.getResult_dir() + File.separator + test.getTestType() + File.separator + scenarioSuffer);
-
-		int pos = ret.lastIndexOf(File.separator + CASEFLAG);
-		if (pos != -1) {
-			ret = ret.substring(0, pos);
-		}
-		if (ret != null && ret.endsWith("/")) {
-			ret = ret.substring(0, ret.length() - 1);
-		}
-		return ret;
-	}
-
-	/**
-	 * get the result directory through testId
-	 * 
-	 * @param testId
-	 * @return
-	 */
-	public static String getResultPreDir(String testId) {
-		if (testId == null) {
-			return null;
-		}
-		return getYearDirName() + "/" + getMonthDirName() + "/" + testId;
-	}
-
-	/**
-	 * get the answer file directory through the case file .
-	 * 
-	 * @param caseFile
-	 * @return
-	 */
-	public static String getAnswerDir(String caseFile) {
-		int testType = TestUtil.getTestType(caseFile);
-		String ret = FileUtil.getDir(caseFile);
-		if (testType == CaseResult.TYPE_SQL || testType == CaseResult.TYPE_GROOVY) {
-			int position = ret.lastIndexOf(CASEFLAG);
-			if (position != -1) {
-				ret = ret.substring(0, position) + getAnswer4SQLAndOther(caseFile);
-			}
-		}
-
-		return StringUtil.replaceSlashBasedSystem(ret);
-	}
-
-	/**
-	 * get the answer file name through case file .
-	 * 
-	 * @param caseFile
-	 * @return
-	 */
-	public static String getAnswerFile(String caseFile) {
-		String answerDir = getAnswerDir(caseFile);
-		String caseName = FileUtil.getFileName(caseFile);
-		return StringUtil.replaceSlashBasedSystem(answerDir + File.separator + caseName + ".answer");
-	}
-
-	/**
-	 * get the post-fix through case file name.
-	 * 
-	 * @param file
-	 * @return
-	 */
-	public static String[] getCaseFilePostFix(String file) {
-		if (file == null) {
-			return null;
-		}
-		String[] ret = new String[] { TestUtil.ScenarioTypes };
-		return ret;
-	}
-	
-	public static List<String> getExcludedFileList(String file){
-		List<String> ret = new ArrayList<String>();
-		if(file == null){
-			return ret;
-		}
-		
-		try {
-			ret = CommonUtils.getLineList(file);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		
-		return ret;
-	}
-	
-	/*
-	 * filter out the excluded case file 
-	 * @param fileList
-	 * @param filter file
-	 * @param scenarioRootPath case root path
-	 */
-	public static void filterExcludedCaseFile(List<String> fileList, String filter, String scenarioRootPath){
-		if (scenarioRootPath == null ||filter == null || fileList == null) {
-			return;
-		}
-		
-		Iterator<String> sListIterator = fileList.iterator();
-		List<String> excludeFileList = TestUtil.getExcludedFileList(filter);
-		if(excludeFileList == null || excludeFileList.size() == 0) return;
-		
-		while(sListIterator.hasNext()){  
-		    String caseFile = sListIterator.next();  
-		    String caseRalativePath = caseFile.substring(scenarioRootPath.length());
-		    for(int j=0; j<excludeFileList.size();j++){
-				if(CommonUtils.containPath(caseRalativePath, excludeFileList.get(j).trim())){
-					sListIterator.remove(); 
-					break;
-				}
-			}
-		} 
-	}
-
-	/**
-	 * get all the cases file .
-	 * 
-	 * @param test
-	 * @param filePath
-	 * @param fileList
-	 * @param postFixes
-	 * @throws Exception
-	 */
-	public static void getCaseFiles(Test test, String filePath, List<String> fileList, String[] postFixes) throws Exception {
-		if (filePath == null || postFixes == null || fileList == null) {
-			return;
-		}
-
-		String localPath = StringUtil.replaceSlashBasedSystem(filePath);
-		
-		File dir = new File(localPath);
-		if (!dir.exists()) {
-			return;
-		}
-
-		String path = localPath;
-
-		if (!path.endsWith(File.separator)) {
-			path = path + File.separator;
-		}
-
-		int positionAnswers = path.indexOf(File.separator + getAnswer4SQLAndOther(filePath) + File.separator);
-
-		if (positionAnswers != -1) {
-			return;
-		}
-
-		if (!dir.isDirectory()) {
-			for (int i = 0; i < postFixes.length; i++) {
-				String postfix = postFixes[i];
-				if (postfix == null) {
-					continue;
-				}
-				if (filePath.endsWith(postfix)) {
-					fileList.add(filePath);
-					if (test != null && postfix.equalsIgnoreCase(".sql")) {
-						String db = test.getDbId();
-						if (db != null && !db.trim().equals("")) {
-							test.putCaseDbToMap(filePath, test.getDbId());
-						} else {
-							throw new Exception("-10001");
-						}
-					}
-				}
-			}
-		} else {
-			String dirPath = filePath;
-			String separator = (dirPath.endsWith("/")) ? "" : "/";
-			String[] files = dir.list();
-
-			Arrays.sort(files);
-			for (int i = 0; i < files.length; i++) {
-				String file = dirPath + separator + files[i];
-				File child = new File(file);
-				//System.out.println("child.getName: " + child.getName());
-				if (child.isDirectory() && (!("common".equals(child.getName()) || getAnswer4SQLAndOther(filePath).equals(child.getName())))) {
-					getCaseFiles(test, file, fileList, postFixes);
-				} else {
-					for (int k = 0; k < postFixes.length; k++) {
-						String postfix = postFixes[k];
-						if (postfix == null) {
-							continue;
-						}
-						if (file.endsWith(postfix)) {
-							fileList.add(file);
-							if (test != null && postfix.equalsIgnoreCase(".sql")) {
-								String db = test.getDbId();
-								if (db != null && !db.trim().equals("")) {
-									test.putCaseDbToMap(file, test.getDbId());
-								} else {
-									throw new Exception("-10001");
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * generate the summary info .
-	 * 
-	 * @param test
-	 * @param currentLayer
-	 */
-	public static void makeSummary(Test test, Map currentLayer) {
-		List<String> dirPath = test.getDirPath();
-
-		Summary summary = (Summary) currentLayer.get(SUMMARY_KEY);
-
-		if (summary == null) {
-			Iterator iter = currentLayer.keySet().iterator();
-			while (iter.hasNext()) {
-				String key = (String) iter.next();
-				Map nextLayer = (Map) currentLayer.get(key);
-				dirPath.add(key);
-				makeSummary(test, nextLayer);
-			}
-			if (dirPath.size() > 0) {
-				dirPath.remove(dirPath.size() - 1);
-			}
-
-			StringBuilder currentDir = new StringBuilder();
-			for (int i = 0; i < dirPath.size(); i++) {
-				currentDir.append(dirPath.get(i).toString() + "/");
-			}
-			String resultDir = currentDir.toString();
-
-			if (test.getRunMode() == Test.MODE_NO_RESULT) {
-				resultDir = TestUtil.resultDirToScenarioDir(resultDir);
-			}
-			if (resultDir.endsWith("/")) {
-				resultDir = resultDir.substring(0, resultDir.length() - 1);
-			}
-			if (SystemUtil.getOS().indexOf("window") == -1) {
-				resultDir = "/" + resultDir;
-			}
-
-			if (resultDir.indexOf(test.getTestId()) == -1) {
-				return;
-			}
-
-			summary = new Summary();
-			currentLayer.put(SUMMARY_KEY, summary);
-			summary.setResultDir(resultDir);
-			if (resultDir.equalsIgnoreCase("")) {
-
-			} else {
-
-			}
-			if (dirPath.size() > 0) {
-				if (dirPath.get(dirPath.size() - 1).equalsIgnoreCase("site")) {
-					summary.setSiteRunTimes(test.getSiteRunTimes());
-				} else {
-					summary.setSiteRunTimes(1);
-				}
-			}
-
-			String catPath = TestUtil.getTestCatBasedOnResultDir(resultDir, test);
-			summary.setCatPath(catPath);
-			iter = currentLayer.keySet().iterator();
-			while (iter.hasNext()) {
-				String key = (String) iter.next();
-				if (SUMMARY_KEY.equals(key)) {
-					continue;
-				}
-
-				Object nextLayer = currentLayer.get(key);
-				Summary childSummary = (Summary) ((Map) nextLayer).get(SUMMARY_KEY);
-				if (dirPath.size() > 0) {
-					if (dirPath.get(dirPath.size() - 1).equalsIgnoreCase("site")) {
-						summary.setSiteRunTimes(test.getSiteRunTimes());
-					} else {
-						summary.setSiteRunTimes(1);
-					}
-				}
-				summary.setTotalCount(summary.getTotalCount() + childSummary.getTotalCount());
-				summary.setSuccessCount(summary.getSuccessCount() + childSummary.getSuccessCount());
-				summary.setFailCount(summary.getFailCount() + childSummary.getFailCount());
-				summary.setTotalTime(summary.getTotalTime() + childSummary.getTotalTime());
-				summary.getChildSummaryMap().put(childSummary.getResultDir(), childSummary);
-
-				summary.getCaseList().addAll(childSummary.getCaseList());
-			}
-
-			test.setSummary(summary);
-		} else {
-			dirPath.clear();
-			if (summary != null) {
-				test.setSummary(summary);
-				List<CaseResult> caseList = summary.getCaseList();
-				for (int i = 0; i < caseList.size(); i++) {
-					CaseResult caseResult = (CaseResult) caseList.get(i);
-					summary.setTotalCount(summary.getTotalCount() + 1);
-					if (!caseResult.isShouldRun()) {
-						continue;
-					}
-					if (!caseResult.isSuccessFul()) {
-						summary.setFailCount(summary.getFailCount() + 1);
-					} else {
-						summary.setSuccessCount(summary.getSuccessCount() + 1);
-					}
-					summary.setTotalTime(summary.getTotalTime() + caseResult.getTotalTime());
-				}
-				String resultDir = summary.getResultDir();
-				if (test.getRunMode() == Test.MODE_NO_RESULT) {
-					resultDir = TestUtil.resultDirToScenarioDir(resultDir);
-				}
-				summary.setResultDir(resultDir);
-				if (resultDir != null) {
-					StringTokenizer token = new StringTokenizer(StringUtil.replaceSlash(resultDir), "/");
-					while (token.hasMoreTokens()) {
-						String dir = token.nextToken();
-						dirPath.add(dir);
-					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * save the summary info to file .
-	 * 
-	 * @param test
-	 * @param currentLayer
-	 */
-	public static void saveResultSummary(Test test, Map currentLayer) {
-		Iterator iter = currentLayer.keySet().iterator();
-		while (iter.hasNext()) {
-			String key = (String) iter.next();
-			if (key.equals(SUMMARY_KEY)) {
-				Summary summary = (Summary) currentLayer.get(key);
-				SummaryInfo summaryInfo = test.getSummaryInfoFromMap(summary.getResultDir());
-
-				FileUtil.writeToFile(summary.getResultDir() + "/summary_info", summary.toString());
-				SummaryInfo parent = summaryInfo.getParent();
-				summaryInfo.setParent(null);
-				String testType = test.getTestType();
-				if (testType.equalsIgnoreCase(summaryInfo.getCatPath()) && !testType.equalsIgnoreCase(test.getTestTypeAlias())) {
-					summaryInfo.setCatPath(test.getTestTypeAlias());
-				}
-				String xml = XstreamHelper.toXml(summaryInfo);
-				FileUtil.writeToFile(summaryInfo.getResultDir() + "/summary.info", xml);
-				summaryInfo.setParent(parent);
-
-				if (test.getRunMode() == Test.MODE_RESULT) {
-					if (summary.getType() == Summary.TYPE_BOTTOM) {
-
-					}
-				}
-			} else {
-				Map nextLayer = (Map) currentLayer.get(key);
-				saveResultSummary(test, nextLayer);
-			}
-		}
-	}
-
-	public static void saveSummaryMainInfo(Test test, Summary summary) {
-		String collect_info = "";
-		collect_info += "build:" + PropertiesUtil.getValue("dbversion") + "." + PropertiesUtil.getValue("dbbuildnumber") + System.getProperty("line.separator");
-		collect_info += "version:" + test.getTestBit() + System.getProperty("line.separator");
-		collect_info += "os:" + SystemUtil.getOS() + System.getProperty("line.separator");
-		collect_info += "category:" + test.getTestTypeAlias() + System.getProperty("line.separator");
-		collect_info += "elapse_time:" + summary.getTotalTime() + System.getProperty("line.separator");
-		collect_info += "success:" + summary.getSuccessCount() + System.getProperty("line.separator");
-		collect_info += "fail:" + summary.getFailCount() + System.getProperty("line.separator");
-		collect_info += "total:" + summary.getTotalCount() + System.getProperty("line.separator");
-		int execut_count = summary.getFailCount() + summary.getSuccessCount();
-		collect_info += "execute_case:" + execut_count + System.getProperty("line.separator");
-		collect_info += "totalTime:" + summary.getTotalTime() + System.getProperty("line.separator");
-		DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		Date date = new Date();
-		collect_info += "end_time:" + dateFormat.format(date) + System.getProperty("line.separator");
-		collect_info += "result_path:" + test.getResult_dir() + System.getProperty("line.separator");
-		FileUtil.writeToFile(test.getResult_dir() + TOTAL_SUMMARY_FILE, collect_info);
-
-	}
-
-	/**
-	 * save the result to file .
-	 * 
-	 * @param test
-	 * @param currentLayer
-	 */
-	public static void saveResult(Test test, Map currentLayer) {
-		Iterator iter = currentLayer.keySet().iterator();
-		while (iter.hasNext()) {
-			String key = (String) iter.next();
-			if (key.equals(SUMMARY_KEY)) {
-				Summary summary = (Summary) currentLayer.get(key);
-				SummaryInfo summaryInfo = test.getSummaryInfoFromMap(summary.getResultDir());
-				FileUtil.writeToFile(summary.getResultDir() + "/summary_info", summary.toString());
-				SummaryInfo parent = summaryInfo.getParent();
-				summaryInfo.setParent(null);
-				String xml = XstreamHelper.toXml(summaryInfo);
-				FileUtil.writeToFile(summaryInfo.getResultDir() + "/summary.info", xml);
-				summaryInfo.setParent(parent);
-
-				if (test.getRunMode() == Test.MODE_RESULT) {
-					if (summary.getType() == Summary.TYPE_BOTTOM) {
-						List<CaseResult> caseList = summary.getCaseList();
-						for (int i = 0; i < caseList.size(); i++) {
-							CaseResult caseResult = (CaseResult) caseList.get(i);
-							saveResult(caseResult, test.getCodeset());
-						}
-
-					}
-				}
-			} else {
-				Map nextLayer = (Map) currentLayer.get(key);
-
-				saveResult(test, nextLayer);
-
-			}
-		}
-	}
-
-	/**
-	 * write the case execute result to file .
-	 * 
-	 * @param caseResult
-	 */
-	public static void saveResult(CaseResult caseResult, String charset) {
-		if (!caseResult.isSuccessFul()) {
-			String resultFile = caseResult.getResultDir() + "/" + caseResult.getCaseName() + ".result";
-			if (caseResult.getType() == CaseResult.TYPE_SQL) {
-				FileUtil.writeToFile(resultFile, caseResult.getResult(), charset);
-			} else {
-				String tempResultFile = caseResult.getCaseDir() + "/" + caseResult.getCaseName() + ".result";
-				FileUtil.copyFile(tempResultFile, resultFile);
-			}
-		}
-	}
-
-	public static void copyCaseAnswerFile(CaseResult caseResult) {
-		if (!caseResult.isSuccessFul()) {
-			String targetSqlFile = caseResult.getResultDir() + "/" + caseResult.getCaseName() + ".sql";
-			String targetAnswerFile = caseResult.getResultDir() + "/" + caseResult.getCaseName() + ".answer";
-			if (caseResult.getType() == CaseResult.TYPE_SQL) {
-				FileUtil.writeSQLFileIntoResultFolder(caseResult.getCaseFile(), targetSqlFile);
-				FileUtil.writeSQLFileIntoResultFolder(caseResult.getAnswerFile(), targetAnswerFile);
-			}
-		}
-	}
-
-	/**
-	 * 
-	 * @param test
-	 * @param currentLayer
-	 * @param parent
-	 */
-	public static void makeSummaryInfo(Test test, Map currentLayer, SummaryInfo parent) {
-		if (test.getRunMode() != Test.MODE_RESULT) {
-			return;
-		}
-
-		if (test == null || currentLayer == null) {
-			return;
-		}
-
-		SummaryInfo summaryInfo = new SummaryInfo();
-		if (parent == null) {
-			Summary summary = null;
-			String name = null;
-
-			test.setSummaryInfo(summaryInfo);
-			summary = test.getSummary();
-			name = test.getTestId();
-			int position = name.indexOf("_");
-			if (position != -1) {
-				name = name.substring(position + 1);
-			}
-			position = name.indexOf("_");
-			if (position != -1) {
-				name = name.substring(position + 1);
-			}
-			try {
-				summaryInfo.setName(name);
-				summaryInfo.setVersion(test.getVersion());
-				summaryInfo.setResultDir(summary.getResultDir());
-				summaryInfo.setCatPath(summary.getCatPath());
-				summaryInfo.setTotalCount(summary.getTotalCount());
-				summaryInfo.setSuccessCount(summary.getSuccessCount());
-				summaryInfo.setSiteRunTimes(summary.getSiteRunTimes());
-				summaryInfo.setFailCount(summary.getFailCount());
-				summaryInfo.setCatPath(summary.getCatPath());
-				summaryInfo.setTotalTime(summary.getTotalTime());
-				test.putSummaryInfoToMap(summaryInfo.getResultDir(), summaryInfo);
-			} catch (Exception e) {
-				System.out.println("no sql case, please check the directory!");
-			}
-		} else {
-			summaryInfo.setParent(parent);
-			parent.addChild(summaryInfo);
-
-		}
-		Iterator iter = currentLayer.keySet().iterator();
-		while (iter.hasNext()) {
-			String key = (String) iter.next();
-			if (key.equals(SUMMARY_KEY)) {
-				Summary summary = (Summary) currentLayer.get(key);
-
-				if (summaryInfo.getName() == null) {
-					String catPath = summary.getCatPath();
-					String name = catPath;
-					int position = catPath.lastIndexOf("/");
-					if (position != -1) {
-						name = catPath.substring(position + 1);
-					}
-					summaryInfo.setName(name);
-				}
-				summaryInfo.setResultDir(summary.getResultDir());
-				summaryInfo.setCatPath(summary.getCatPath());
-				summaryInfo.setSiteRunTimes(summary.getSiteRunTimes());
-				summaryInfo.setTotalCount(summary.getTotalCount());
-				summaryInfo.setSuccessCount(summary.getSuccessCount());
-				summaryInfo.setFailCount(summary.getFailCount());
-				summaryInfo.setCatPath(summary.getCatPath());
-				summaryInfo.setTotalTime(summary.getTotalTime());
-				test.putSummaryInfoToMap(summaryInfo.getResultDir(), summaryInfo);
-
-				// if test build is debug build, change catpat of the last
-				// second one to [sql|medium|site|shell]_debug to show on qahome
-				// page
-				String site_type = null;
-				String tmp = null;
-
-				if (test.getDbId().indexOf("kcc") != -1) {
-					site_type = "kcc";
-				} else if (test.getDbId().indexOf("neis05") != -1) {
-					site_type = "neis05";
-				} else if (test.getDbId().indexOf("neis08") != -1) {
-					site_type = "neis08";
-				}
-
-				if (test.isDebug()) {
-					String cat = summary.getCatPath();
-					// this should fully match with condition to make this
-					// changes
-					if ("sql".equals(cat) || "medium".equals(cat) || "shell".equals(cat)) {
-						tmp = cat + "_debug";
-						summaryInfo.setCatPath(tmp);
-					} else if ("site".equals(cat)) {
-						tmp = site_type + "_debug";
-						summaryInfo.setCatPath(tmp);
-					}
-				}
-
-				if (summary.getType() == Summary.TYPE_BOTTOM) {
-					List<CaseResult> caseList = summary.getCaseList();
-					// comment out save summary collection function
-					// saveSummaryMainInfo(test, summary);
-
-					for (int i = 0; i < caseList.size(); i++) {
-						CaseResult caseResult = (CaseResult) caseList.get(i);
-						String caseFile = caseResult.getCaseFile();
-						CaseResult result = new CaseResult();
-						result.setCaseFile(caseFile);
-						if (test.isNeedAnswerInSummary()) {
-							String answerFile = caseResult.getAnswerFile();
-							result.setAnswerFile(answerFile);
-						}
-						result.setSuccessFul(caseResult.isSuccessFul());
-						result.setHasCore(caseResult.isHasCore());
-						result.setTotalTime(caseResult.getTotalTime());
-						result.setSiteRunTimes(caseResult.getSiteRunTimes());
-						if (!caseResult.isShouldRun()) {
-							summaryInfo.addNotRunCase(caseResult);
-						} else if (caseResult.isSuccessFul()) {
-							summaryInfo.addOkCase(result);
-						} else {
-							summaryInfo.addNokCase(result);
-						}
-					}
-				}
-			} else {
-				Map nextLayer = (Map) currentLayer.get(key);
-				makeSummaryInfo(test, nextLayer, summaryInfo);
-			}
-		}
-	}
-
-	public static Map getCatMap(Test test, String file) {
-		if (test == null || file == null) {
-			return null;
-		}
-
-		Map currentLayer = test.getCatMap();
-		String[] keys = TestUtil.getCatPath(file, test);
-		for (int i = 0; i < keys.length; i++) {
-			String key = keys[i];
-			Map nextLayer = (Map) currentLayer.get(key);
-			if (nextLayer == null) {
-				nextLayer = new Hashtable();
-				currentLayer.put(key, nextLayer);
-			}
-			currentLayer = nextLayer;
-		}
-
-		return currentLayer;
-	}
-
-	public static String resultDirToScenarioDir(String resultDir) {
-		if (resultDir == null) {
-			return null;
-		}
-
-		String ret = resultDir;
-		int positionResult = ret.indexOf(RESULT);
-		if (positionResult != -1) {
-			String dir = ret.substring(0, positionResult) + SCENARIO;
-			int position = getTypePosition(ret);
-			if (position != -1) {
-				ret = dir + ret.substring(position);
-			}
-		}
-		return ret;
-	}
-
-	public static String getCaseSummary(String summaryFile) {
-		StringBuilder sb = new StringBuilder();
-		try {
-			BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(new File(summaryFile)), "UTF-8"));
-			int lineNum = 0;
-			String line = reader.readLine();
-			while (line != null) {
-				lineNum++;
-				if (lineNum > 4) {
-					sb.append(line + System.getProperty("line.separator"));
-				}
-
-				line = reader.readLine();
-			}
-			reader.close();
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-		return sb.toString();
-	}
-
-	public static String getTestCatBasedOnResultDir(String resDir, Test test) {
-		if (resDir == null) {
-			return null;
-		}
-
-		String ret;
-		String resultRootDir = test.getResult_dir();
-		int resultRootDirLength = resultRootDir.length();
-
-		ret = resDir.substring(resultRootDirLength);
-
-		if (ret != null && (ret.startsWith("/") || ret.startsWith("\\"))) {
-			ret = ret.substring(1);
-		}
-
-		int pos = ret.lastIndexOf(File.separator + CASEFLAG);
-		if (pos != -1) {
-			ret = ret.substring(0, pos);
-		}
-
-		if (ret.endsWith(File.separator)) {
-			ret = ret.substring(0, ret.length() - 1);
-		}
-
-		return ret;
-
-	}
-
-	public static String getTestCatPath(String file, Test test) {
-		if (file == null) {
-			return null;
-		}
-
-		String ret;
-		String scenarioRoot = test.getScenarioRootPath();
-		int rootLength = scenarioRoot.length();
-		String scenarioSuffer = file.substring(rootLength);
-		ret = StringUtil.replaceSlashBasedSystem(test.getTestType() + File.separator + scenarioSuffer);
-
-		int pos = ret.lastIndexOf(File.separator + CASEFLAG);
-		if (pos != -1) {
-			ret = ret.substring(0, pos);
-		}
-
-		if (ret.endsWith(File.separator)) {
-			ret = ret.substring(0, ret.length() - 1);
-		}
-		return ret;
-	}
-
-	public static boolean isPrintQueryPlan(String caseFile) {
-		boolean flag = false;
-		if (caseFile == null || caseFile.trim().equals("")) {
-			return false;
-		}
-
-		int position = caseFile.lastIndexOf(".");
-		if (position == -1) {
-			return false;
-		}
-		SystemModel systemModel = (SystemModel) XstreamHelper.fromXml(EnvGetter.getenv("CTP_HOME") + File.separator + "sql/configuration/System.xml");
-		if (systemModel.isQueryPlan()) {
-			flag = true;
-		} else {
-			String fileName = caseFile.substring(0, position) + ".queryPlan";
-			File file = new File(fileName);
-			flag = file.exists();
-		}
-		return flag;
-	}
-
-	private static String[] getCatPath(String file, Test test) {
-		String path = getTestCatPath(file, test);
-		String standardPath = StringUtil.replaceSlash(path);
-		String[] keys = standardPath.split("/");
-		return keys;
-	}
-
-	public static int getTypePosition(String file) {
-		if (file == null) {
-			return -1;
-		}
-		int ret = -1;
-		Iterator iter = SCENARIOMAP.keySet().iterator();
-		while (iter.hasNext()) {
-			String dirName = (String) iter.next();
-			ret = file.indexOf("/" + dirName + "/");
-			if (ret != -1) {
-				break;
-			}
-		}
-		return ret;
-	}
-
+        String scenarionTypes = PropertiesUtil.getValue("scenariontypes");
+        if (scenarionTypes != null) {
+            String[] types = scenarionTypes.split(";");
+            for (int i = 0; i < types.length; i++) {
+                String type = types[i];
+                if (type == null) {
+                    continue;
+                }
+                type = type.trim();
+                int position = type.indexOf("(");
+                if (position > 0) {
+                    String dirName = type.substring(0, position);
+                    String fileType = type.substring(position);
+
+                    fileType = fileType.replaceAll("\\(", "").replaceAll("\\)", "");
+                    String[] postfixes = fileType.split(",");
+                    SCENARIOMAP.put(dirName, postfixes);
+                }
+            }
+        }
+    }
+
+    /**
+     * get the testid through type and name .
+     *
+     * @param type
+     * @param name
+     * @return
+     */
+    public static String getTestId(String type, String name) {
+        StringBuilder ret = new StringBuilder();
+
+        if (type == null || type.trim().equals("")) {
+            type = "common";
+        }
+        ret.append(type);
+
+        String os = SystemUtil.getOS();
+        ret.append("_" + os);
+
+        if (name != null && !name.trim().equals("")) {
+            ret.append("_" + name);
+        }
+
+        String date = "";
+        // long s = System.currentTimeMillis();
+        // date = Long.toString(s);
+        SimpleDateFormat sdf = new SimpleDateFormat("ddHHmmss");
+        Random rand = new Random();
+        try {
+            date = sdf.format(new Date());
+        } catch (Exception e) {
+        }
+        ret.append("_" + date + rand.nextInt(99));
+
+        String version = PropertiesUtil.getValue("dbversion");
+        ret.append("_" + version);
+
+        ret.append("." + (PropertiesUtil.getValue("dbbuildnumber")));
+
+        return ret.toString();
+    }
+
+    /** @return */
+    public static String getYearDirName() {
+        return "y" + Calendar.getInstance().get(Calendar.YEAR);
+    }
+
+    /** @return */
+    public static String getMonthDirName() {
+        return "m" + (Calendar.getInstance().get(Calendar.MONTH) + 1);
+    }
+
+    public static String getResultDir(String resID) {
+        String res_dir = "";
+        res_dir =
+                EnvGetter.getenv("CTP_HOME")
+                        + RESULT
+                        + getYearDirName()
+                        + File.separator
+                        + getMonthDirName()
+                        + File.separator
+                        + resID;
+
+        res_dir = StringUtil.replaceSlashBasedSystem(res_dir);
+        return res_dir;
+    }
+
+    /**
+     * get the test file type through case file .
+     *
+     * @param caseFile
+     * @return
+     */
+    public static int getTestType(String caseFile) {
+        if (caseFile == null) {
+            return -1;
+        }
+
+        int ret = -1;
+        caseFile = caseFile.toLowerCase();
+        if (caseFile.endsWith(".sql")) {
+            ret = CaseResult.TYPE_SQL;
+        } else if (caseFile.endsWith(".sh")) {
+            ret = CaseResult.TYPE_SCRIPT;
+        } else if (caseFile.endsWith(".grv")) {
+            ret = CaseResult.TYPE_GROOVY;
+        }
+        return ret;
+    }
+
+    /**
+     * get the result directory through the case file and Test.
+     *
+     * @param test
+     * @param caseFile
+     * @return
+     */
+    public static String getResultDir(Test test, String caseFile) {
+        if (test == null || caseFile == null || caseFile.trim().equals("")) {
+            return null;
+        }
+        String ret = null;
+        String scenarioRoot = test.getScenarioRootPath();
+        int rootLength = scenarioRoot.length();
+        String scenarioSuffer = caseFile.substring(rootLength);
+        ret =
+                StringUtil.replaceSlashBasedSystem(
+                        test.getResult_dir()
+                                + File.separator
+                                + test.getTestType()
+                                + File.separator
+                                + scenarioSuffer);
+
+        int pos = ret.lastIndexOf(File.separator + CASEFLAG);
+        if (pos != -1) {
+            ret = ret.substring(0, pos);
+        }
+        if (ret != null && ret.endsWith("/")) {
+            ret = ret.substring(0, ret.length() - 1);
+        }
+        return ret;
+    }
+
+    /**
+     * get the result directory through testId
+     *
+     * @param testId
+     * @return
+     */
+    public static String getResultPreDir(String testId) {
+        if (testId == null) {
+            return null;
+        }
+        return getYearDirName() + "/" + getMonthDirName() + "/" + testId;
+    }
+
+    /**
+     * get the answer file directory through the case file .
+     *
+     * @param caseFile
+     * @return
+     */
+    public static String getAnswerDir(String caseFile) {
+        int testType = TestUtil.getTestType(caseFile);
+        String ret = FileUtil.getDir(caseFile);
+        if (testType == CaseResult.TYPE_SQL || testType == CaseResult.TYPE_GROOVY) {
+            int position = ret.lastIndexOf(CASEFLAG);
+            if (position != -1) {
+                ret = ret.substring(0, position) + getAnswer4SQLAndOther(caseFile);
+            }
+        }
+
+        return StringUtil.replaceSlashBasedSystem(ret);
+    }
+
+    /**
+     * get the answer file name through case file .
+     *
+     * @param caseFile
+     * @return
+     */
+    public static String getAnswerFile(String caseFile) {
+        String answerDir = getAnswerDir(caseFile);
+        String caseName = FileUtil.getFileName(caseFile);
+        return StringUtil.replaceSlashBasedSystem(
+                answerDir + File.separator + caseName + ".answer");
+    }
+
+    /**
+     * get the post-fix through case file name.
+     *
+     * @param file
+     * @return
+     */
+    public static String[] getCaseFilePostFix(String file) {
+        if (file == null) {
+            return null;
+        }
+        String[] ret = new String[] {TestUtil.ScenarioTypes};
+        return ret;
+    }
+
+    public static List<String> getExcludedFileList(String file) {
+        List<String> ret = new ArrayList<String>();
+        if (file == null) {
+            return ret;
+        }
+
+        try {
+            ret = CommonUtils.getLineList(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return ret;
+    }
+
+    /*
+     * filter out the excluded case file
+     * @param fileList
+     * @param filter file
+     * @param scenarioRootPath case root path
+     */
+    public static void filterExcludedCaseFile(
+            List<String> fileList, String filter, String scenarioRootPath) {
+        if (scenarioRootPath == null || filter == null || fileList == null) {
+            return;
+        }
+
+        Iterator<String> sListIterator = fileList.iterator();
+        List<String> excludeFileList = TestUtil.getExcludedFileList(filter);
+        if (excludeFileList == null || excludeFileList.size() == 0) return;
+
+        while (sListIterator.hasNext()) {
+            String caseFile = sListIterator.next();
+            String caseRalativePath = caseFile.substring(scenarioRootPath.length());
+            for (int j = 0; j < excludeFileList.size(); j++) {
+                if (CommonUtils.containPath(caseRalativePath, excludeFileList.get(j).trim())) {
+                    sListIterator.remove();
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * get all the cases file .
+     *
+     * @param test
+     * @param filePath
+     * @param fileList
+     * @param postFixes
+     * @throws Exception
+     */
+    public static void getCaseFiles(
+            Test test, String filePath, List<String> fileList, String[] postFixes)
+            throws Exception {
+        if (filePath == null || postFixes == null || fileList == null) {
+            return;
+        }
+
+        String localPath = StringUtil.replaceSlashBasedSystem(filePath);
+
+        File dir = new File(localPath);
+        if (!dir.exists()) {
+            return;
+        }
+
+        String path = localPath;
+
+        if (!path.endsWith(File.separator)) {
+            path = path + File.separator;
+        }
+
+        int positionAnswers =
+                path.indexOf(File.separator + getAnswer4SQLAndOther(filePath) + File.separator);
+
+        if (positionAnswers != -1) {
+            return;
+        }
+
+        if (!dir.isDirectory()) {
+            for (int i = 0; i < postFixes.length; i++) {
+                String postfix = postFixes[i];
+                if (postfix == null) {
+                    continue;
+                }
+                if (filePath.endsWith(postfix)) {
+                    fileList.add(filePath);
+                    if (test != null && postfix.equalsIgnoreCase(".sql")) {
+                        String db = test.getDbId();
+                        if (db != null && !db.trim().equals("")) {
+                            test.putCaseDbToMap(filePath, test.getDbId());
+                        } else {
+                            throw new Exception("-10001");
+                        }
+                    }
+                }
+            }
+        } else {
+            String dirPath = filePath;
+            String separator = (dirPath.endsWith("/")) ? "" : "/";
+            String[] files = dir.list();
+
+            Arrays.sort(files);
+            for (int i = 0; i < files.length; i++) {
+                String file = dirPath + separator + files[i];
+                File child = new File(file);
+                // System.out.println("child.getName: " + child.getName());
+                if (child.isDirectory()
+                        && (!("common".equals(child.getName())
+                                || getAnswer4SQLAndOther(filePath).equals(child.getName())))) {
+                    getCaseFiles(test, file, fileList, postFixes);
+                } else {
+                    for (int k = 0; k < postFixes.length; k++) {
+                        String postfix = postFixes[k];
+                        if (postfix == null) {
+                            continue;
+                        }
+                        if (file.endsWith(postfix)) {
+                            fileList.add(file);
+                            if (test != null && postfix.equalsIgnoreCase(".sql")) {
+                                String db = test.getDbId();
+                                if (db != null && !db.trim().equals("")) {
+                                    test.putCaseDbToMap(file, test.getDbId());
+                                } else {
+                                    throw new Exception("-10001");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * generate the summary info .
+     *
+     * @param test
+     * @param currentLayer
+     */
+    public static void makeSummary(Test test, Map currentLayer) {
+        List<String> dirPath = test.getDirPath();
+
+        Summary summary = (Summary) currentLayer.get(SUMMARY_KEY);
+
+        if (summary == null) {
+            Iterator iter = currentLayer.keySet().iterator();
+            while (iter.hasNext()) {
+                String key = (String) iter.next();
+                Map nextLayer = (Map) currentLayer.get(key);
+                dirPath.add(key);
+                makeSummary(test, nextLayer);
+            }
+            if (dirPath.size() > 0) {
+                dirPath.remove(dirPath.size() - 1);
+            }
+
+            StringBuilder currentDir = new StringBuilder();
+            for (int i = 0; i < dirPath.size(); i++) {
+                currentDir.append(dirPath.get(i).toString() + "/");
+            }
+            String resultDir = currentDir.toString();
+
+            if (test.getRunMode() == Test.MODE_NO_RESULT) {
+                resultDir = TestUtil.resultDirToScenarioDir(resultDir);
+            }
+            if (resultDir.endsWith("/")) {
+                resultDir = resultDir.substring(0, resultDir.length() - 1);
+            }
+            if (SystemUtil.getOS().indexOf("window") == -1) {
+                resultDir = "/" + resultDir;
+            }
+
+            if (resultDir.indexOf(test.getTestId()) == -1) {
+                return;
+            }
+
+            summary = new Summary();
+            currentLayer.put(SUMMARY_KEY, summary);
+            summary.setResultDir(resultDir);
+            if (resultDir.equalsIgnoreCase("")) {
+
+            } else {
+
+            }
+            if (dirPath.size() > 0) {
+                if (dirPath.get(dirPath.size() - 1).equalsIgnoreCase("site")) {
+                    summary.setSiteRunTimes(test.getSiteRunTimes());
+                } else {
+                    summary.setSiteRunTimes(1);
+                }
+            }
+
+            String catPath = TestUtil.getTestCatBasedOnResultDir(resultDir, test);
+            summary.setCatPath(catPath);
+            iter = currentLayer.keySet().iterator();
+            while (iter.hasNext()) {
+                String key = (String) iter.next();
+                if (SUMMARY_KEY.equals(key)) {
+                    continue;
+                }
+
+                Object nextLayer = currentLayer.get(key);
+                Summary childSummary = (Summary) ((Map) nextLayer).get(SUMMARY_KEY);
+                if (dirPath.size() > 0) {
+                    if (dirPath.get(dirPath.size() - 1).equalsIgnoreCase("site")) {
+                        summary.setSiteRunTimes(test.getSiteRunTimes());
+                    } else {
+                        summary.setSiteRunTimes(1);
+                    }
+                }
+                summary.setTotalCount(summary.getTotalCount() + childSummary.getTotalCount());
+                summary.setSuccessCount(summary.getSuccessCount() + childSummary.getSuccessCount());
+                summary.setFailCount(summary.getFailCount() + childSummary.getFailCount());
+                summary.setTotalTime(summary.getTotalTime() + childSummary.getTotalTime());
+                summary.getChildSummaryMap().put(childSummary.getResultDir(), childSummary);
+
+                summary.getCaseList().addAll(childSummary.getCaseList());
+            }
+
+            test.setSummary(summary);
+        } else {
+            dirPath.clear();
+            if (summary != null) {
+                test.setSummary(summary);
+                List<CaseResult> caseList = summary.getCaseList();
+                for (int i = 0; i < caseList.size(); i++) {
+                    CaseResult caseResult = (CaseResult) caseList.get(i);
+                    summary.setTotalCount(summary.getTotalCount() + 1);
+                    if (!caseResult.isShouldRun()) {
+                        continue;
+                    }
+                    if (!caseResult.isSuccessFul()) {
+                        summary.setFailCount(summary.getFailCount() + 1);
+                    } else {
+                        summary.setSuccessCount(summary.getSuccessCount() + 1);
+                    }
+                    summary.setTotalTime(summary.getTotalTime() + caseResult.getTotalTime());
+                }
+                String resultDir = summary.getResultDir();
+                if (test.getRunMode() == Test.MODE_NO_RESULT) {
+                    resultDir = TestUtil.resultDirToScenarioDir(resultDir);
+                }
+                summary.setResultDir(resultDir);
+                if (resultDir != null) {
+                    StringTokenizer token =
+                            new StringTokenizer(StringUtil.replaceSlash(resultDir), "/");
+                    while (token.hasMoreTokens()) {
+                        String dir = token.nextToken();
+                        dirPath.add(dir);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * save the summary info to file .
+     *
+     * @param test
+     * @param currentLayer
+     */
+    public static void saveResultSummary(Test test, Map currentLayer) {
+        Iterator iter = currentLayer.keySet().iterator();
+        while (iter.hasNext()) {
+            String key = (String) iter.next();
+            if (key.equals(SUMMARY_KEY)) {
+                Summary summary = (Summary) currentLayer.get(key);
+                SummaryInfo summaryInfo = test.getSummaryInfoFromMap(summary.getResultDir());
+
+                FileUtil.writeToFile(summary.getResultDir() + "/summary_info", summary.toString());
+                SummaryInfo parent = summaryInfo.getParent();
+                summaryInfo.setParent(null);
+                String testType = test.getTestType();
+                if (testType.equalsIgnoreCase(summaryInfo.getCatPath())
+                        && !testType.equalsIgnoreCase(test.getTestTypeAlias())) {
+                    summaryInfo.setCatPath(test.getTestTypeAlias());
+                }
+                String xml = XstreamHelper.toXml(summaryInfo);
+                FileUtil.writeToFile(summaryInfo.getResultDir() + "/summary.info", xml);
+                summaryInfo.setParent(parent);
+
+                if (test.getRunMode() == Test.MODE_RESULT) {
+                    if (summary.getType() == Summary.TYPE_BOTTOM) {}
+                }
+            } else {
+                Map nextLayer = (Map) currentLayer.get(key);
+                saveResultSummary(test, nextLayer);
+            }
+        }
+    }
+
+    public static void saveSummaryMainInfo(Test test, Summary summary) {
+        String collect_info = "";
+        collect_info +=
+                "build:"
+                        + PropertiesUtil.getValue("dbversion")
+                        + "."
+                        + PropertiesUtil.getValue("dbbuildnumber")
+                        + System.getProperty("line.separator");
+        collect_info += "version:" + test.getTestBit() + System.getProperty("line.separator");
+        collect_info += "os:" + SystemUtil.getOS() + System.getProperty("line.separator");
+        collect_info +=
+                "category:" + test.getTestTypeAlias() + System.getProperty("line.separator");
+        collect_info +=
+                "elapse_time:" + summary.getTotalTime() + System.getProperty("line.separator");
+        collect_info +=
+                "success:" + summary.getSuccessCount() + System.getProperty("line.separator");
+        collect_info += "fail:" + summary.getFailCount() + System.getProperty("line.separator");
+        collect_info += "total:" + summary.getTotalCount() + System.getProperty("line.separator");
+        int execut_count = summary.getFailCount() + summary.getSuccessCount();
+        collect_info += "execute_case:" + execut_count + System.getProperty("line.separator");
+        collect_info +=
+                "totalTime:" + summary.getTotalTime() + System.getProperty("line.separator");
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        Date date = new Date();
+        collect_info +=
+                "end_time:" + dateFormat.format(date) + System.getProperty("line.separator");
+        collect_info +=
+                "result_path:" + test.getResult_dir() + System.getProperty("line.separator");
+        FileUtil.writeToFile(test.getResult_dir() + TOTAL_SUMMARY_FILE, collect_info);
+    }
+
+    /**
+     * save the result to file .
+     *
+     * @param test
+     * @param currentLayer
+     */
+    public static void saveResult(Test test, Map currentLayer) {
+        Iterator iter = currentLayer.keySet().iterator();
+        while (iter.hasNext()) {
+            String key = (String) iter.next();
+            if (key.equals(SUMMARY_KEY)) {
+                Summary summary = (Summary) currentLayer.get(key);
+                SummaryInfo summaryInfo = test.getSummaryInfoFromMap(summary.getResultDir());
+                FileUtil.writeToFile(summary.getResultDir() + "/summary_info", summary.toString());
+                SummaryInfo parent = summaryInfo.getParent();
+                summaryInfo.setParent(null);
+                String xml = XstreamHelper.toXml(summaryInfo);
+                FileUtil.writeToFile(summaryInfo.getResultDir() + "/summary.info", xml);
+                summaryInfo.setParent(parent);
+
+                if (test.getRunMode() == Test.MODE_RESULT) {
+                    if (summary.getType() == Summary.TYPE_BOTTOM) {
+                        List<CaseResult> caseList = summary.getCaseList();
+                        for (int i = 0; i < caseList.size(); i++) {
+                            CaseResult caseResult = (CaseResult) caseList.get(i);
+                            saveResult(caseResult, test.getCodeset());
+                        }
+                    }
+                }
+            } else {
+                Map nextLayer = (Map) currentLayer.get(key);
+
+                saveResult(test, nextLayer);
+            }
+        }
+    }
+
+    /**
+     * write the case execute result to file .
+     *
+     * @param caseResult
+     */
+    public static void saveResult(CaseResult caseResult, String charset) {
+        if (!caseResult.isSuccessFul()) {
+            String resultFile =
+                    caseResult.getResultDir() + "/" + caseResult.getCaseName() + ".result";
+            if (caseResult.getType() == CaseResult.TYPE_SQL) {
+                FileUtil.writeToFile(resultFile, caseResult.getResult(), charset);
+            } else {
+                String tempResultFile =
+                        caseResult.getCaseDir() + "/" + caseResult.getCaseName() + ".result";
+                FileUtil.copyFile(tempResultFile, resultFile);
+            }
+        }
+    }
+
+    public static void copyCaseAnswerFile(CaseResult caseResult) {
+        if (!caseResult.isSuccessFul()) {
+            String targetSqlFile =
+                    caseResult.getResultDir() + "/" + caseResult.getCaseName() + ".sql";
+            String targetAnswerFile =
+                    caseResult.getResultDir() + "/" + caseResult.getCaseName() + ".answer";
+            if (caseResult.getType() == CaseResult.TYPE_SQL) {
+                FileUtil.writeSQLFileIntoResultFolder(caseResult.getCaseFile(), targetSqlFile);
+                FileUtil.writeSQLFileIntoResultFolder(caseResult.getAnswerFile(), targetAnswerFile);
+            }
+        }
+    }
+
+    /**
+     * @param test
+     * @param currentLayer
+     * @param parent
+     */
+    public static void makeSummaryInfo(Test test, Map currentLayer, SummaryInfo parent) {
+        if (test.getRunMode() != Test.MODE_RESULT) {
+            return;
+        }
+
+        if (test == null || currentLayer == null) {
+            return;
+        }
+
+        SummaryInfo summaryInfo = new SummaryInfo();
+        if (parent == null) {
+            Summary summary = null;
+            String name = null;
+
+            test.setSummaryInfo(summaryInfo);
+            summary = test.getSummary();
+            name = test.getTestId();
+            int position = name.indexOf("_");
+            if (position != -1) {
+                name = name.substring(position + 1);
+            }
+            position = name.indexOf("_");
+            if (position != -1) {
+                name = name.substring(position + 1);
+            }
+            try {
+                summaryInfo.setName(name);
+                summaryInfo.setVersion(test.getVersion());
+                summaryInfo.setResultDir(summary.getResultDir());
+                summaryInfo.setCatPath(summary.getCatPath());
+                summaryInfo.setTotalCount(summary.getTotalCount());
+                summaryInfo.setSuccessCount(summary.getSuccessCount());
+                summaryInfo.setSiteRunTimes(summary.getSiteRunTimes());
+                summaryInfo.setFailCount(summary.getFailCount());
+                summaryInfo.setCatPath(summary.getCatPath());
+                summaryInfo.setTotalTime(summary.getTotalTime());
+                test.putSummaryInfoToMap(summaryInfo.getResultDir(), summaryInfo);
+            } catch (Exception e) {
+                System.out.println("no sql case, please check the directory!");
+            }
+        } else {
+            summaryInfo.setParent(parent);
+            parent.addChild(summaryInfo);
+        }
+        Iterator iter = currentLayer.keySet().iterator();
+        while (iter.hasNext()) {
+            String key = (String) iter.next();
+            if (key.equals(SUMMARY_KEY)) {
+                Summary summary = (Summary) currentLayer.get(key);
+
+                if (summaryInfo.getName() == null) {
+                    String catPath = summary.getCatPath();
+                    String name = catPath;
+                    int position = catPath.lastIndexOf("/");
+                    if (position != -1) {
+                        name = catPath.substring(position + 1);
+                    }
+                    summaryInfo.setName(name);
+                }
+                summaryInfo.setResultDir(summary.getResultDir());
+                summaryInfo.setCatPath(summary.getCatPath());
+                summaryInfo.setSiteRunTimes(summary.getSiteRunTimes());
+                summaryInfo.setTotalCount(summary.getTotalCount());
+                summaryInfo.setSuccessCount(summary.getSuccessCount());
+                summaryInfo.setFailCount(summary.getFailCount());
+                summaryInfo.setCatPath(summary.getCatPath());
+                summaryInfo.setTotalTime(summary.getTotalTime());
+                test.putSummaryInfoToMap(summaryInfo.getResultDir(), summaryInfo);
+
+                // if test build is debug build, change catpat of the last
+                // second one to [sql|medium|site|shell]_debug to show on qahome
+                // page
+                String site_type = null;
+                String tmp = null;
+
+                if (test.getDbId().indexOf("kcc") != -1) {
+                    site_type = "kcc";
+                } else if (test.getDbId().indexOf("neis05") != -1) {
+                    site_type = "neis05";
+                } else if (test.getDbId().indexOf("neis08") != -1) {
+                    site_type = "neis08";
+                }
+
+                if (test.isDebug()) {
+                    String cat = summary.getCatPath();
+                    // this should fully match with condition to make this
+                    // changes
+                    if ("sql".equals(cat) || "medium".equals(cat) || "shell".equals(cat)) {
+                        tmp = cat + "_debug";
+                        summaryInfo.setCatPath(tmp);
+                    } else if ("site".equals(cat)) {
+                        tmp = site_type + "_debug";
+                        summaryInfo.setCatPath(tmp);
+                    }
+                }
+
+                if (summary.getType() == Summary.TYPE_BOTTOM) {
+                    List<CaseResult> caseList = summary.getCaseList();
+                    // comment out save summary collection function
+                    // saveSummaryMainInfo(test, summary);
+
+                    for (int i = 0; i < caseList.size(); i++) {
+                        CaseResult caseResult = (CaseResult) caseList.get(i);
+                        String caseFile = caseResult.getCaseFile();
+                        CaseResult result = new CaseResult();
+                        result.setCaseFile(caseFile);
+                        if (test.isNeedAnswerInSummary()) {
+                            String answerFile = caseResult.getAnswerFile();
+                            result.setAnswerFile(answerFile);
+                        }
+                        result.setSuccessFul(caseResult.isSuccessFul());
+                        result.setHasCore(caseResult.isHasCore());
+                        result.setTotalTime(caseResult.getTotalTime());
+                        result.setSiteRunTimes(caseResult.getSiteRunTimes());
+                        if (!caseResult.isShouldRun()) {
+                            summaryInfo.addNotRunCase(caseResult);
+                        } else if (caseResult.isSuccessFul()) {
+                            summaryInfo.addOkCase(result);
+                        } else {
+                            summaryInfo.addNokCase(result);
+                        }
+                    }
+                }
+            } else {
+                Map nextLayer = (Map) currentLayer.get(key);
+                makeSummaryInfo(test, nextLayer, summaryInfo);
+            }
+        }
+    }
+
+    public static Map getCatMap(Test test, String file) {
+        if (test == null || file == null) {
+            return null;
+        }
+
+        Map currentLayer = test.getCatMap();
+        String[] keys = TestUtil.getCatPath(file, test);
+        for (int i = 0; i < keys.length; i++) {
+            String key = keys[i];
+            Map nextLayer = (Map) currentLayer.get(key);
+            if (nextLayer == null) {
+                nextLayer = new Hashtable();
+                currentLayer.put(key, nextLayer);
+            }
+            currentLayer = nextLayer;
+        }
+
+        return currentLayer;
+    }
+
+    public static String resultDirToScenarioDir(String resultDir) {
+        if (resultDir == null) {
+            return null;
+        }
+
+        String ret = resultDir;
+        int positionResult = ret.indexOf(RESULT);
+        if (positionResult != -1) {
+            String dir = ret.substring(0, positionResult) + SCENARIO;
+            int position = getTypePosition(ret);
+            if (position != -1) {
+                ret = dir + ret.substring(position);
+            }
+        }
+        return ret;
+    }
+
+    public static String getCaseSummary(String summaryFile) {
+        StringBuilder sb = new StringBuilder();
+        try {
+            BufferedReader reader =
+                    new BufferedReader(
+                            new InputStreamReader(
+                                    new FileInputStream(new File(summaryFile)), "UTF-8"));
+            int lineNum = 0;
+            String line = reader.readLine();
+            while (line != null) {
+                lineNum++;
+                if (lineNum > 4) {
+                    sb.append(line + System.getProperty("line.separator"));
+                }
+
+                line = reader.readLine();
+            }
+            reader.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return sb.toString();
+    }
+
+    public static String getTestCatBasedOnResultDir(String resDir, Test test) {
+        if (resDir == null) {
+            return null;
+        }
+
+        String ret;
+        String resultRootDir = test.getResult_dir();
+        int resultRootDirLength = resultRootDir.length();
+
+        ret = resDir.substring(resultRootDirLength);
+
+        if (ret != null && (ret.startsWith("/") || ret.startsWith("\\"))) {
+            ret = ret.substring(1);
+        }
+
+        int pos = ret.lastIndexOf(File.separator + CASEFLAG);
+        if (pos != -1) {
+            ret = ret.substring(0, pos);
+        }
+
+        if (ret.endsWith(File.separator)) {
+            ret = ret.substring(0, ret.length() - 1);
+        }
+
+        return ret;
+    }
+
+    public static String getTestCatPath(String file, Test test) {
+        if (file == null) {
+            return null;
+        }
+
+        String ret;
+        String scenarioRoot = test.getScenarioRootPath();
+        int rootLength = scenarioRoot.length();
+        String scenarioSuffer = file.substring(rootLength);
+        ret =
+                StringUtil.replaceSlashBasedSystem(
+                        test.getTestType() + File.separator + scenarioSuffer);
+
+        int pos = ret.lastIndexOf(File.separator + CASEFLAG);
+        if (pos != -1) {
+            ret = ret.substring(0, pos);
+        }
+
+        if (ret.endsWith(File.separator)) {
+            ret = ret.substring(0, ret.length() - 1);
+        }
+        return ret;
+    }
+
+    public static boolean isPrintQueryPlan(String caseFile) {
+        boolean flag = false;
+        if (caseFile == null || caseFile.trim().equals("")) {
+            return false;
+        }
+
+        int position = caseFile.lastIndexOf(".");
+        if (position == -1) {
+            return false;
+        }
+        SystemModel systemModel =
+                (SystemModel)
+                        XstreamHelper.fromXml(
+                                EnvGetter.getenv("CTP_HOME")
+                                        + File.separator
+                                        + "sql/configuration/System.xml");
+        if (systemModel.isQueryPlan()) {
+            flag = true;
+        } else {
+            String fileName = caseFile.substring(0, position) + ".queryPlan";
+            File file = new File(fileName);
+            flag = file.exists();
+        }
+        return flag;
+    }
+
+    private static String[] getCatPath(String file, Test test) {
+        String path = getTestCatPath(file, test);
+        String standardPath = StringUtil.replaceSlash(path);
+        String[] keys = standardPath.split("/");
+        return keys;
+    }
+
+    public static int getTypePosition(String file) {
+        if (file == null) {
+            return -1;
+        }
+        int ret = -1;
+        Iterator iter = SCENARIOMAP.keySet().iterator();
+        while (iter.hasNext()) {
+            String dirName = (String) iter.next();
+            ret = file.indexOf("/" + dirName + "/");
+            if (ret != -1) {
+                break;
+            }
+        }
+        return ret;
+    }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1184

- Error messages are obtained from the e.getMessage() where e is the SQLError raised when running a SQL statement fails. 
  - The error messages seem to have a suffix beginning with '[CAS INFO'. This suffix is dropped before printing.