### PR TITLE
[CUBRIDQA-1184] print error messages too when server-message flag is on

### DIFF
--- a/CTP/sql/configuration/test_config/test_D_euckr_C_euckr_bin.xml
+++ b/CTP/sql/configuration/test_config/test_D_euckr_C_euckr_bin.xml
@@ -10,7 +10,7 @@
     <client_charset>euckr_bin</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_euckr_C_iso88591_bin.xml
+++ b/CTP/sql/configuration/test_config/test_D_euckr_C_iso88591_bin.xml
@@ -10,7 +10,7 @@
     <client_charset>iso88591_bin</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_euckr_C_iso88591_en_ci.xml
+++ b/CTP/sql/configuration/test_config/test_D_euckr_C_iso88591_en_ci.xml
@@ -10,7 +10,7 @@
     <client_charset>iso88591_en_ci</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_euckr_C_utf8_bin.xml
+++ b/CTP/sql/configuration/test_config/test_D_euckr_C_utf8_bin.xml
@@ -10,7 +10,7 @@
     <client_charset>utf8_bin</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_euckr_C_utf8_en_ci.xml
+++ b/CTP/sql/configuration/test_config/test_D_euckr_C_utf8_en_ci.xml
@@ -10,7 +10,7 @@
     <client_charset>utf8_en_ci</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_iso88591_C_euckr_bin.xml
+++ b/CTP/sql/configuration/test_config/test_D_iso88591_C_euckr_bin.xml
@@ -10,7 +10,7 @@
     <client_charset>euckr_bin</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_iso88591_C_iso88591_en_ci.xml
+++ b/CTP/sql/configuration/test_config/test_D_iso88591_C_iso88591_en_ci.xml
@@ -10,7 +10,7 @@
     <client_charset>iso88591_en_ci</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_iso88591_C_utf8_bin.xml
+++ b/CTP/sql/configuration/test_config/test_D_iso88591_C_utf8_bin.xml
@@ -10,7 +10,7 @@
     <client_charset>utf8_bin</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_iso88591_C_utf8_en_ci.xml
+++ b/CTP/sql/configuration/test_config/test_D_iso88591_C_utf8_en_ci.xml
@@ -10,7 +10,7 @@
     <client_charset>utf8_en_ci</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_utf8_C_euckr_bin.xml
+++ b/CTP/sql/configuration/test_config/test_D_utf8_C_euckr_bin.xml
@@ -10,7 +10,7 @@
     <client_charset>euckr_bin</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_utf8_C_iso88591_bin.xml
+++ b/CTP/sql/configuration/test_config/test_D_utf8_C_iso88591_bin.xml
@@ -10,7 +10,7 @@
     <client_charset>iso88591_bin</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_utf8_C_iso88591_en_ci.xml
+++ b/CTP/sql/configuration/test_config/test_D_utf8_C_iso88591_en_ci.xml
@@ -10,7 +10,7 @@
     <client_charset>iso88591_en_ci</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_utf8_C_utf8_bin.xml
+++ b/CTP/sql/configuration/test_config/test_D_utf8_C_utf8_bin.xml
@@ -10,7 +10,7 @@
     <client_charset>utf8_bin</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_D_utf8_C_utf8_en_ci.xml
+++ b/CTP/sql/configuration/test_config/test_D_utf8_C_utf8_en_ci.xml
@@ -10,7 +10,7 @@
     <client_charset>utf8_en_ci</client_charset>
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_default.xml
+++ b/CTP/sql/configuration/test_config/test_default.xml
@@ -10,7 +10,7 @@
     <!--<client_charset>utf8</client_charset> -->
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <check_server_status>true</check_server_status>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>

--- a/CTP/sql/configuration/test_config/test_default_small.xml
+++ b/CTP/sql/configuration/test_config/test_default_small.xml
@@ -10,7 +10,7 @@
     <!--<client_charset>utf8</client_charset> -->
     <autocommit>true</autocommit>
     <holdcas>off</holdcas>
-    <server-output>off</server-output>
+    <server-message>off</server-message>
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>
    <reset>

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/common/SQLParser.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/common/SQLParser.java
@@ -76,7 +76,7 @@ public class SQLParser {
                     } else {
                         String controlCmd = getControlCommand(line);
                         if (controlCmd != null) {
-                            // control command : either hodcas or server-output
+                            // control command : either hodcas or server-message
                             Sql sql = new Sql("", controlCmd, null, false);
                             list.add(sql);
                         }
@@ -148,7 +148,7 @@ public class SQLParser {
     private static String getControlCommand(String line) {
         if (line.startsWith("--+")) {
             String s = line.replaceAll(" ", "").toLowerCase();
-            if (s.startsWith("--+holdcas") || s.startsWith("--+server-output")) {
+            if (s.startsWith("--+holdcas") || s.startsWith("--+server-message")) {
                 return line.trim() + System.getProperty("line.separator");
             }
         }

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Test.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Test.java
@@ -92,7 +92,7 @@ public class Test {
 
 	private String autocommit = "";
 
-	private String serverOutput = "off";
+	private String serverMessage = "off";
 
 	private boolean needSummaryXML = false;
 
@@ -205,12 +205,12 @@ public class Test {
 		this.holdcas = holdcas;
 	}
 
-	public String getServerOutput() {
-		return serverOutput;
+	public String getServerMessage() {
+		return serverMessage;
 	}
 	
-	public void setServerOutput (String so) {
-		this.serverOutput = so;
+	public void setServerMessage (String so) {
+		this.serverMessage = so;
 	}
 
 	public String getReset_scripts() {

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
@@ -1039,8 +1039,8 @@ public class ConsoleBO extends Executor {
 					boolean isOff = isPropOff(TestUtil.AUTOCOMMIT, script);
 					boolean isHoldCasOn = isPropOn(TestUtil.HOLDCAS, script);
 					boolean isHoldCasOff = isPropOff(TestUtil.HOLDCAS, script);
-					boolean isServerOutputOn = isPropOn(TestUtil.SERVER_OUTPUT, script);
-					boolean isServerOutputOff = isPropOff(TestUtil.SERVER_OUTPUT, script);
+					boolean isServerMessageOn = isPropOn(TestUtil.SERVER_MESSAGE, script);
+					boolean isServerMessageOff = isPropOff(TestUtil.SERVER_MESSAGE, script);
 
 					if (isOn) {
 						conn.setAutoCommit(isOn);
@@ -1072,11 +1072,11 @@ public class ConsoleBO extends Executor {
 							String message = "Exception: the current version can't support hold cas!";
 							this.onMessage(message);
 						}
-					} else if (isServerOutputOn) {
+					} else if (isServerMessageOn) {
 						try {
-							String message = "@" + test.getConnId() + ": server output " + isServerOutputOn;
+							String message = "@" + test.getConnId() + ": server message " + isServerMessageOn;
 							this.onMessage(message);
-							test.setServerOutput("on");
+							test.setServerMessage("on");
 							// TODO: DBMS_OUTPUT.enable ()
 							Sql enableSql = new Sql(connId, "CALL enable(20000)", null, true); // TODO: set
 																								// size of
@@ -1086,12 +1086,12 @@ public class ConsoleBO extends Executor {
 							String message = "Exception: the current version can't support DBMS_OUTPUT!";
 							this.onMessage(message);
 						}
-					} else if (isServerOutputOff) {
+					} else if (isServerMessageOff) {
 						try {
-							String message = "@" + test.getConnId() + ": server output " + isServerOutputOff;
+							String message = "@" + test.getConnId() + ": server message " + isServerMessageOff;
 							this.onMessage(message);
 
-							test.setServerOutput("off");
+							test.setServerMessage("off");
 							// TODO: DBMS_OUTPUT.disable()
 							Sql disableSql = new Sql(connId, "CALL disable()", null, true);
 							dao.execute(conn, disableSql, false);
@@ -1397,8 +1397,8 @@ public class ConsoleBO extends Executor {
 					boolean isOff = isPropOff(TestUtil.AUTOCOMMIT, script);
 					boolean isHoldCasOn = isPropOn(TestUtil.HOLDCAS, script);
 					boolean isHoldCasOff = isPropOff(TestUtil.HOLDCAS, script);
-					boolean isServerOutputOn = isPropOn(TestUtil.SERVER_OUTPUT, script);
-					boolean isServerOutputOff = isPropOn(TestUtil.SERVER_OUTPUT, script);
+					boolean isServerMessageOn = isPropOn(TestUtil.SERVER_MESSAGE, script);
+					boolean isServerMessageOff = isPropOff(TestUtil.SERVER_MESSAGE, script);
 
 					if (isOn) {
 						conn.setAutoCommit(isOn);
@@ -1430,9 +1430,9 @@ public class ConsoleBO extends Executor {
 							String message = "Exception: the current version can't support hold cas!";
 							bo.onMessage(message);
 						}
-					} else if (isServerOutputOn) {
+					} else if (isServerMessageOn) {
 						try {
-							String message = "@" + test.getConnId() + ": server output " + isServerOutputOn;
+							String message = "@" + test.getConnId() + ": server message " + isServerMessageOn;
 							bo.onMessage(message);
 
 							Sql enableSql = new Sql(connId, "CALL DBMS_OUTPUT.enable(20000)", null, true); // TODO: set
@@ -1443,9 +1443,9 @@ public class ConsoleBO extends Executor {
 							String message = "Exception: the current version can't support DBMS_OUTPUT!";
 							bo.onMessage(message);
 						}
-					} else if (isServerOutputOff) {
+					} else if (isServerMessageOff) {
 						try {
-							String message = "@" + test.getConnId() + ": server output " + isServerOutputOff;
+							String message = "@" + test.getConnId() + ": server message " + isServerMessageOff;
 							bo.onMessage(message);
 							Sql disableSql = new Sql(connId, "CALL DBMS_OUTPUT.disable()", null, true);
 							dao.execute(conn, disableSql, false);

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -306,7 +306,7 @@ public class ConsoleDAO extends Executor {
         }
 
         // Print Output messages
-        if (test.getServerOutput().equalsIgnoreCase("on")) {
+        if (test.getServerMessage().equalsIgnoreCase("on")) {
             String messages = getServerOutputMessage(conn);
             sql.setResult(sql.getResult() + System.getProperty("line.separator") + messages);
         }
@@ -768,6 +768,16 @@ public class ConsoleDAO extends Executor {
                                 + System.getProperty("line.separator"));
             } else {
                 message.append("Error:" + e.getErrorCode() + System.getProperty("line.separator"));
+                if (test.getServerMessage().equalsIgnoreCase("on")) {
+                    String errmsg = e.getMessage();
+                    if (errmsg != null) {
+                        int idx = errmsg.indexOf("[CAS INFO");
+                        if (idx >= 0) {
+                            errmsg = errmsg.substring(0, idx);
+                        }
+                    }
+                    message.append(errmsg + System.getProperty("line.separator"));
+                }
             }
         }
         return message.toString();

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/PropertiesUtil.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/PropertiesUtil.java
@@ -102,11 +102,11 @@ public class PropertiesUtil {
 			test.setHoldcas(val);
 		}
 
-		List sol = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.SERVER_OUTPUT);
+		List sol = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.SERVER_MESSAGE);
 		if (!sol.isEmpty()) {
 			Element so = (Element) sol.get(0);
 			val = so.getText();
-			test.setServerOutput(val);
+			test.setServerMessage(val);
 		}
 
 		List checkAlive = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.CHECK_SERVER_STATUS);

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/TestUtil.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/TestUtil.java
@@ -78,7 +78,7 @@ public class TestUtil {
 
 	public static final String HOLDCAS = "holdcas";
 
-	public static final String SERVER_OUTPUT = "server-output";
+	public static final String SERVER_MESSAGE = "server-message";
 
 	public static final String AUTOCOMMIT = "autocommit";
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1184

- Error messages are obtained from e.getMessage() where e is the SQLError raised when the SQL execution fails
  - These error messages seem to end with '[CAS INFO ...' string, which is detached before printing.