### PR TITLE
[CUBRIDQA-1184] Fix regression in Circle CI caused by CTP is not built before executing ini.sh

### DIFF
--- a/CTP/bin/ini.sh
+++ b/CTP/bin/ini.sh
@@ -26,7 +26,22 @@
 
 export CTP_HOME=$(cd $(dirname $(readlink -f $0))/..; pwd)
 
+BUILD_DIR=$CTP_HOME/build
 JAVA_CPS=$CTP_HOME/common/lib/cubridqa-common.jar
+
+if [ ! -d "$BUILD_DIR" ] || [ ! -n "$(ls -A $BUILD_DIR)" ]
+then
+  cd $CTP_HOME && ant dist
+
+  if [ ! -d "$BUILD_DIR" ] || [ ! -n "$(ls -A $BUILD_DIR)" ]
+  then
+    echo "Building CTP has been failed. Please check Ant and Java environments!" && exit 1
+  fi
+
+  echo "CTP has been built successfully"
+
+  cd -
+fi
 
 if [ "$OSTYPE" == "cygwin" ]
 then


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1184

In cubridci (docker for CI), `ini.sh` is executed because of the `create_table_reuseoid ` config.
```
function run_test ()
{
  run_checkout
  ...

  CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no
  ...
```

The CTP should be built before ini.sh is executed.