### PR TITLE
[CBRD-25068] Increase session timeout value for isolation test due to performance degradation from memory monitoring

### DIFF
--- a/CTP/isolation/ctltool/qactl.c
+++ b/CTP/isolation/ctltool/qactl.c
@@ -88,7 +88,7 @@ extern int local_tm_isblocked (int tran_index);
 #define STRESSEXEC_TOKEN  STRESSEXEC_CMDNAME
 
 #define SLEEP_MSECS 10
-#define SHORT_DURATION_DEFAULT (30000)	/*  30 seconds */
+#define SHORT_DURATION_DEFAULT (50000)	/*  50 seconds */
 #define LONG_DURATION_DEFAULT (300000)	/* 300 seconds */
 
 #define VALID_CLIENT_ID(TBL, ID)  (((ID) > 0) && ((ID) <= (TBL)->slotsinuse))

--- a/CTP/isolation/ctltool/qactl.c
+++ b/CTP/isolation/ctltool/qactl.c
@@ -88,7 +88,7 @@ extern int local_tm_isblocked (int tran_index);
 #define STRESSEXEC_TOKEN  STRESSEXEC_CMDNAME
 
 #define SLEEP_MSECS 10
-#define SHORT_DURATION_DEFAULT (50000)	/*  50 seconds */
+#define SHORT_DURATION_DEFAULT (100000)	/*  100 seconds */
 #define LONG_DURATION_DEFAULT (300000)	/* 300 seconds */
 
 #define VALID_CLIENT_ID(TBL, ID)  (((ID) > 0) && ((ID) <= (TBL)->slotsinuse))


### PR DESCRIPTION
Due to memory monitoring, the performance of the debug mode has decreased, which is expected. In the Isolation debug test, the timeout for a session is set to 30 seconds, causing some queries to exceed this limit and resulting in failed test cases. To address this issue, the 'SHORT_DURATION_DEFAULT' value is increased from 30 seconds to 100 seconds.
(Setting it to 60 seconds still resulted in a failure. Changing it to 100 seconds.)

fail case list:
https://github.com/CUBRID/cubrid-testcases/blob/develop/isolation/_01_ReadCommitted/index_column/common_index/basic_sql/insert_insert_05.ctl
https://github.com/CUBRID/cubrid-testcases/blob/develop/isolation/_01_ReadCommitted/index_column/function_index/up_up_code_cov_01.ctl
https://github.com/CUBRID/cubrid-testcases/blob/develop/isolation/_06_features/cbrd_22705_online_index_parallel/_04_RepeatableRead_ReadCommitted/index_column/filter_index/basic_sql/insert_insert_01.ctl