### PR TITLE
[CUBRIDQA-1183] Modify to support empty space between parammeter and value

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -867,7 +867,7 @@ function change_db_section_parameter
        cp $CUBRID/conf/cubrid.conf $CUBRID/conf/cubrid.conf.org
   fi
 
-  change_config_section_parameter $sec $prm $CUBRID/conf/cubrid.conf
+  change_config_section_parameter $sec "$prm" $CUBRID/conf/cubrid.conf
 }
 
 # Restore DB .ini file from source file
@@ -949,7 +949,7 @@ function change_broker_section_parameter
         cp $CUBRID/conf/cubrid_broker.conf $CUBRID/conf/cubrid_broker.conf.org
     fi
 
-    change_config_section_parameter $sec $prm $CUBRID/conf/cubrid_broker.conf
+    change_config_section_parameter $sec "$prm" $CUBRID/conf/cubrid_broker.conf
 }
 
 # Usage:
@@ -964,7 +964,7 @@ function change_ha_section_parameter
         cp $CUBRID/conf/cubrid_ha.conf $CUBRID/conf/cubrid_ha.conf.org
     fi
     
-    change_config_section_parameter $sec $prm $CUBRID/conf/cubrid_ha.conf
+    change_config_section_parameter $sec "$prm" $CUBRID/conf/cubrid_ha.conf
 }
 
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1183

No problem :
change_broker_section_parameter %BROKER1 "MIN_NUM_APPL_SERVER=4000" 

Error : empty space "MIN_NUM_APPL_SERVER = 4000"
change_broker_section_parameter %BROKER1 "MIN_NUM_APPL_SERVER = 4000"

Fixed.


