### PR TITLE
[CBRD-24046] Modified format_query_plan as SUBQUERY_CACHE item was added to show trace results.

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -1030,6 +1030,9 @@ function format_query_plan
     sed -i 's/ioread: [0-9]*/ioread:?/g' $1
     sed -i 's/"time": [0-9]*/"time":?/g' $1
     sed -i 's/"fetch": [0-9]*/"fetch":?/g' $1
+    sed -i 's/hit: [0-9]*/hit:?/g' $1
+    sed -i 's/miss: [0-9]*/miss:?/g' $1
+    sed -i 's/size: [0-9]*/size:?/g' $1
 }
 
 function format_path_output


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-24046, https://github.com/CUBRID/cubrid-testcases-private-ex/pull/2230

show trace 결과에 SUBQUERY_CACHE 항목이 추가됨에 따라, plan 결과의 숫자를 마스킹하는 format_query_plan에 SUBQUERY_CACHE의 항목들을 추가하였음