### PR TITLE
[CBRD-25352] Add a user schema to your stored procedures for consistency with other objects.

### DIFF
--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
@@ -1078,7 +1078,7 @@ public class ConsoleBO extends Executor {
 							this.onMessage(message);
 							test.setServerMessage("on");
 							// TODO: DBMS_OUTPUT.enable ()
-							Sql enableSql = new Sql(connId, "CALL enable(20000)", null, true); // TODO: set
+							Sql enableSql = new Sql(connId, "CALL DBMS_OUTPUT.enable(20000)", null, true); // TODO: set
 																								// size of
 																								// enable
 							dao.execute(conn, enableSql, false);
@@ -1093,7 +1093,7 @@ public class ConsoleBO extends Executor {
 
 							test.setServerMessage("off");
 							// TODO: DBMS_OUTPUT.disable()
-							Sql disableSql = new Sql(connId, "CALL disable()", null, true);
+							Sql disableSql = new Sql(connId, "CALL DBMS_OUTPUT.disable()", null, true);
 							dao.execute(conn, disableSql, false);
 						} catch (Exception e) {
 							String message = "Exception: the current version can't support DBMS_OUTPUT!";

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -716,7 +716,7 @@ public class ConsoleDAO extends Executor {
         ArrayList<SqlParam> params = new ArrayList<SqlParam>();
         params.add(new SqlParam("OUT", 1, null, Types.VARCHAR));
         params.add(new SqlParam("OUT", 2, null, Types.INTEGER));
-        Sql getLine = new Sql(test.getConnId(), "CALL GET_LINE (?, ?);", params, true);
+        Sql getLine = new Sql(test.getConnId(), "CALL DBMS_OUTPUT.GET_LINE (?, ?);", params, true);
 
         try {
             while (true) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25352

Built-in PL/CSQL을 호출할 때는 'dbms_output.'을 붙여야 정상 실행됩니다. 
ex) 'call get_line;' -> 'call dbms_output.get_line;'