### PR TITLE
[CBRD-25352] Add a user schema to your stored procedures for consistency with other objects.

### DIFF
--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
@@ -1137,14 +1137,18 @@ public class ConsoleBO extends Executor {
                             test.setServerMessage("on");
                             // TODO: DBMS_OUTPUT.enable ()
                             Sql enableSql =
-                                    new Sql(connId, "CALL DBMS_OUTPUT.enable(50000)", null, true); // TODO: set
+                                    new Sql(
+                                            connId,
+                                            "CALL DBMS_OUTPUT.enable(50000)",
+                                            null,
+                                            true); // TODO: set
                             // size of
                             // enable
                             dao.execute(conn, enableSql, false);
                         } catch (Exception e) {
                             try {
                                 String message =
-                                        "@"     
+                                        "@"
                                                 + test.getConnId()
                                                 + ": server message "
                                                 + isServerMessageOn;
@@ -1152,7 +1156,11 @@ public class ConsoleBO extends Executor {
                                 test.setServerMessage("on");
                                 // TODO: DBMS_OUTPUT.enable ()
                                 Sql enableSql =
-                                        new Sql(connId, "CALL enable(50000)", null, true); // TODO: set
+                                        new Sql(
+                                                connId,
+                                                "CALL enable(50000)",
+                                                null,
+                                                true); // TODO: set
                                 // size of
                                 // enable
                                 dao.execute(conn, enableSql, false);
@@ -1173,7 +1181,8 @@ public class ConsoleBO extends Executor {
 
                             test.setServerMessage("off");
                             // TODO: DBMS_OUTPUT.disable()
-                            Sql disableSql = new Sql(connId, "CALL DBMS_OUTPUT.disable()", null, true);
+                            Sql disableSql =
+                                    new Sql(connId, "CALL DBMS_OUTPUT.disable()", null, true);
                             dao.execute(conn, disableSql, false);
                         } catch (Exception e) {
                             try {
@@ -1190,7 +1199,7 @@ public class ConsoleBO extends Executor {
                                 dao.execute(conn, disableSql, false);
                             } catch (Exception e2) {
                                 String message =
-                                    "Exception: the current version can't support DBMS_OUTPUT!";
+                                        "Exception: the current version can't support DBMS_OUTPUT!";
                                 this.onMessage(message);
                             }
                         }

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
@@ -1137,14 +1137,30 @@ public class ConsoleBO extends Executor {
                             test.setServerMessage("on");
                             // TODO: DBMS_OUTPUT.enable ()
                             Sql enableSql =
-                                    new Sql(connId, "CALL enable(50000)", null, true); // TODO: set
+                                    new Sql(connId, "CALL DBMS_OUTPUT.enable(50000)", null, true); // TODO: set
                             // size of
                             // enable
                             dao.execute(conn, enableSql, false);
                         } catch (Exception e) {
-                            String message =
-                                    "Exception: the current version can't support DBMS_OUTPUT!";
-                            this.onMessage(message);
+                            try {
+                                String message =
+                                        "@"     
+                                                + test.getConnId()
+                                                + ": server message "
+                                                + isServerMessageOn;
+                                this.onMessage(message);
+                                test.setServerMessage("on");
+                                // TODO: DBMS_OUTPUT.enable ()
+                                Sql enableSql =
+                                        new Sql(connId, "CALL enable(50000)", null, true); // TODO: set
+                                // size of
+                                // enable
+                                dao.execute(conn, enableSql, false);
+                            } catch (Exception e2) {
+                                String message =
+                                        "Exception: the current version can't support DBMS_OUTPUT!";
+                                this.onMessage(message);
+                            }
                         }
                     } else if (isServerMessageOff) {
                         try {
@@ -1157,12 +1173,26 @@ public class ConsoleBO extends Executor {
 
                             test.setServerMessage("off");
                             // TODO: DBMS_OUTPUT.disable()
-                            Sql disableSql = new Sql(connId, "CALL disable()", null, true);
+                            Sql disableSql = new Sql(connId, "CALL DBMS_OUTPUT.disable()", null, true);
                             dao.execute(conn, disableSql, false);
                         } catch (Exception e) {
-                            String message =
+                            try {
+                                String message =
+                                        "@"
+                                                + test.getConnId()
+                                                + ": server message "
+                                                + isServerMessageOff;
+                                this.onMessage(message);
+
+                                test.setServerMessage("off");
+                                // TODO: DBMS_OUTPUT.disable()
+                                Sql disableSql = new Sql(connId, "CALL disable()", null, true);
+                                dao.execute(conn, disableSql, false);
+                            } catch (Exception e2) {
+                                String message =
                                     "Exception: the current version can't support DBMS_OUTPUT!";
-                            this.onMessage(message);
+                                this.onMessage(message);
+                            }
                         }
                     } else {
                         String message =

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -716,7 +716,7 @@ public class ConsoleDAO extends Executor {
         ArrayList<SqlParam> params = new ArrayList<SqlParam>();
         params.add(new SqlParam("OUT", 1, null, Types.VARCHAR));
         params.add(new SqlParam("OUT", 2, null, Types.INTEGER));
-        Sql getLine = new Sql(test.getConnId(), "CALL GET_LINE (?, ?);", params, true);
+        Sql getLine = new Sql(test.getConnId(), "CALL DBMS_OUTPUT.GET_LINE (?, ?);", params, true);
 
         try {
             while (true) {
@@ -732,7 +732,23 @@ public class ConsoleDAO extends Executor {
                 }
             }
         } catch (Exception e) {
-            // error?
+            Sql getLine = new Sql(test.getConnId(), "CALL GET_LINE (?, ?);", params, true);
+            try {
+                while (true) {
+                    executeCall(conn, getLine);
+                    List<SqlParam> paramList = getLine.getParamList();
+                    if (((Integer) paramList.get(1).getValue()) == 0) {
+                        /* status */
+                        message.append(
+                                ((String) paramList.get(0).getValue())
+                                        + System.getProperty("line.separator")); /* message */
+                    } else {
+                        break;
+                    }
+                }
+            } catch (Exception e2) {
+                // error?
+            }
         }
 
         return message.toString();

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -732,7 +732,7 @@ public class ConsoleDAO extends Executor {
                 }
             }
         } catch (Exception e) {
-            Sql getLine = new Sql(test.getConnId(), "CALL GET_LINE (?, ?);", params, true);
+            getLine = new Sql(test.getConnId(), "CALL GET_LINE (?, ?);", params, true);
             try {
                 while (true) {
                     executeCall(conn, getLine);

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1449,11 +1449,11 @@ set_server_message (FILE * fp, char conn, bool on)
 
   if (on)
     {
-      sprintf (sql, "call enable(%d)", DBMS_OUTPUT_BUFFER_SIZE);
+      sprintf (sql, "call DBMS_OUTPUT.enable(%d)", DBMS_OUTPUT_BUFFER_SIZE);
     }
   else
     {
-      sprintf (sql, "call disable()");
+      sprintf (sql, "call DBMS_OUTPUT.disable()");
     }
 
   req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
@@ -1488,7 +1488,7 @@ get_server_output (FILE * fp, char conn)
 {
   int req = 0, res = 0;
   T_CCI_ERROR error;
-  static const char *sql = "call get_line(?, ?)";
+  static const char *sql = "call DBMS_OUTPUT.get_line(?, ?)";
   static char buff[DBMS_OUTPUT_BUFFER_SIZE];
   char *ret = NULL, *p, *str;
   int status, ind;

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1459,18 +1459,44 @@ set_server_message (FILE * fp, char conn, bool on)
   req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
   if (req < 0)
     {
-      fprintf (stdout, "Set Server-Message Error:%d\n", error.err_code);
-      fprintf (fp, "Set Server-Message Error:%d\n", error.err_code);
-      res = -1;
-      goto _END;
+      if (on)
+        {
+	  sprintf (sql, "call enable(%d)", DBMS_OUTPUT_BUFFER_SIZE);
+	}
+      else
+        {
+	  sprintf (sql, "call disable()");
+	}
+      
+      req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
+      if (req < 0)
+        {
+          fprintf (stdout, "Set Server-Message Error:%d\n", error.err_code);
+          fprintf (fp, "Set Server-Message Error:%d\n", error.err_code);
+          res = -1;
+          goto _END;
+	}
     }
 
   res = cci_execute (req, 0, 0, &error);
   if (res < 0)
     {
-      fprintf (stdout, "Set Server-Message Error:%d\n", error.err_code);
-      fprintf (fp, "Set Server-Message Error:%d\n", error.err_code);
-      goto _END;
+      if (on)
+        {
+	  sprintf (sql, "call enable(%d)", DBMS_OUTPUT_BUFFER_SIZE);
+	}
+      else
+        {
+	  sprintf (sql, "call disable()");
+	}
+      
+      res = cci_execute (req, 0, 0, &error);
+      if (res < 0)
+        {
+          fprintf (stdout, "Set Server-Message Error:%d\n", error.err_code);
+          fprintf (fp, "Set Server-Message Error:%d\n", error.err_code);
+          goto _END;
+	}
     }
 
   is_server_message_on = on;
@@ -1496,25 +1522,43 @@ get_server_output (FILE * fp, char conn)
   req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
   if (req < 0)
     {
-      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-      goto _END;
+      sql = "CALL GET_LINE (?, ?);"
+
+      req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
+      if (req < 0)
+        {
+          fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+          fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+          goto _END;
+        }
     }
 
   res = cci_register_out_param (req, 1);
   if (res < 0)
     {
-      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-      goto _END;
+      sql = "CALL GET_LINE (?, ?);"
+
+      res = cci_register_out_param (req, 1);
+      if (res < 0)
+        {
+          fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+          fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+          goto _END;
+	}
     }
 
   res = cci_register_out_param (req, 2);
   if (res < 0)
     {
-      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-      goto _END;
+      sql = "CALL GET_LINE (?, ?);"
+
+      res = cci_register_out_param (req, 2);
+      if (res < 0)
+        {
+          fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+          fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+          goto _END;
+	}
     }
 
   buff[0] = '\n';
@@ -1525,33 +1569,57 @@ get_server_output (FILE * fp, char conn)
       res = cci_execute (req, 0, 0, &error);
       if (res < 0)
 	{
-	  fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	  fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	  goto _END;
+	  sql = "CALL GET_LINE (?, ?);"
+
+	  res = cci_execute (req, 0, 0, &error);
+	  if (res < 0)
+	    {
+	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	      goto _END;
+	    }
 	}
 
       res = cci_cursor (req, 1, CCI_CURSOR_FIRST, &error);
       if (res == CCI_ER_NO_MORE_DATA)
 	{
-	  fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	  fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	  goto _END;
+	  sql = "CALL GET_LINE (?, ?);"
+
+	  res = cci_cursor (req, 1, CCI_CURSOR_FIRST, &error);
+	  if (res == CCI_ER_NO_MORE_DATA)
+	    {
+	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	      goto _END;
+	    }
 	}
 
       res = cci_fetch (req, &error);
       if (res < 0)
 	{
-	  fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	  fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	  goto _END;
+	  sql = "CALL GET_LINE (?, ?);"
+
+	  res = cci_fetch (req, &error);
+	  if (res < 0)
+	    {
+	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	      goto _END;
+	    }
 	}
 
       res = cci_get_data (req, 2, CCI_A_TYPE_INT, &status, &ind);
       if (res < 0)
 	{
-	  fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	  fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	  goto _END;
+	  sql = "CALL GET_LINE (?, ?);"
+
+	  res = cci_get_data (req, 2, CCI_A_TYPE_INT, &status, &ind);
+	  if (res < 0)
+	    {
+	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	      goto _END;
+	    }
 	}
 
       if (ind == 0 && status == 0)
@@ -1560,9 +1628,15 @@ get_server_output (FILE * fp, char conn)
 	  res = cci_get_data (req, 1, CCI_A_TYPE_STR, &str, &ind);
 	  if (res < 0)
 	    {
-	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	      goto _END;
+	      sql = "CALL GET_LINE (?, ?);"
+
+	      res = cci_get_data (req, 1, CCI_A_TYPE_STR, &str, &ind);
+	      if (res < 0)
+	        {
+	          fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	          fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	          goto _END;
+		}
 	    }
 
 	  assert (ind >= 0);
@@ -1586,9 +1660,15 @@ get_server_output (FILE * fp, char conn)
       res = cci_close_query_result (req, &error);
       if (res < 0)
 	{
-	  fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	  fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	  goto _END;
+	  sql = "CALL GET_LINE (?, ?);"
+
+	  res = cci_close_query_result (req, &error);
+	  if (res < 0)
+	    {
+	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	      goto _END;
+	    }
 	}
     }
 

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1481,22 +1481,9 @@ set_server_message (FILE * fp, char conn, bool on)
   res = cci_execute (req, 0, 0, &error);
   if (res < 0)
     {
-      if (on)
-        {
-	  sprintf (sql, "call enable(%d)", DBMS_OUTPUT_BUFFER_SIZE);
-	}
-      else
-        {
-	  sprintf (sql, "call disable()");
-	}
-      
-      res = cci_execute (req, 0, 0, &error);
-      if (res < 0)
-        {
-          fprintf (stdout, "Set Server-Message Error:%d\n", error.err_code);
-          fprintf (fp, "Set Server-Message Error:%d\n", error.err_code);
-          goto _END;
-	}
+      fprintf (stdout, "Set Server-Message Error:%d\n", error.err_code);
+      fprintf (fp, "Set Server-Message Error:%d\n", error.err_code);
+      goto _END;
     }
 
   is_server_message_on = on;
@@ -1536,29 +1523,17 @@ get_server_output (FILE * fp, char conn)
   res = cci_register_out_param (req, 1);
   if (res < 0)
     {
-      sql = "CALL GET_LINE (?, ?);"
-
-      res = cci_register_out_param (req, 1);
-      if (res < 0)
-        {
-          fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-          fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-          goto _END;
-	}
+      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+      goto _END;
     }
 
   res = cci_register_out_param (req, 2);
   if (res < 0)
     {
-      sql = "CALL GET_LINE (?, ?);"
-
-      res = cci_register_out_param (req, 2);
-      if (res < 0)
-        {
-          fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-          fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-          goto _END;
-	}
+      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+      goto _END;
     }
 
   buff[0] = '\n';
@@ -1569,57 +1544,33 @@ get_server_output (FILE * fp, char conn)
       res = cci_execute (req, 0, 0, &error);
       if (res < 0)
 	{
-	  sql = "CALL GET_LINE (?, ?);"
-
-	  res = cci_execute (req, 0, 0, &error);
-	  if (res < 0)
-	    {
-	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	      goto _END;
-	    }
+	  fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	  fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	  goto _END;
 	}
 
       res = cci_cursor (req, 1, CCI_CURSOR_FIRST, &error);
       if (res == CCI_ER_NO_MORE_DATA)
 	{
-	  sql = "CALL GET_LINE (?, ?);"
-
-	  res = cci_cursor (req, 1, CCI_CURSOR_FIRST, &error);
-	  if (res == CCI_ER_NO_MORE_DATA)
-	    {
-	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	      goto _END;
-	    }
+	  fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	  fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	  goto _END;
 	}
 
       res = cci_fetch (req, &error);
       if (res < 0)
 	{
-	  sql = "CALL GET_LINE (?, ?);"
-
-	  res = cci_fetch (req, &error);
-	  if (res < 0)
-	    {
-	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	      goto _END;
-	    }
+	  fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	  fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	  goto _END;
 	}
 
       res = cci_get_data (req, 2, CCI_A_TYPE_INT, &status, &ind);
       if (res < 0)
 	{
-	  sql = "CALL GET_LINE (?, ?);"
-
-	  res = cci_get_data (req, 2, CCI_A_TYPE_INT, &status, &ind);
-	  if (res < 0)
-	    {
-	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	      goto _END;
-	    }
+	  fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	  fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	  goto _END;
 	}
 
       if (ind == 0 && status == 0)
@@ -1628,15 +1579,9 @@ get_server_output (FILE * fp, char conn)
 	  res = cci_get_data (req, 1, CCI_A_TYPE_STR, &str, &ind);
 	  if (res < 0)
 	    {
-	      sql = "CALL GET_LINE (?, ?);"
-
-	      res = cci_get_data (req, 1, CCI_A_TYPE_STR, &str, &ind);
-	      if (res < 0)
-	        {
-	          fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	          fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	          goto _END;
-		}
+	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	      goto _END;
 	    }
 
 	  assert (ind >= 0);
@@ -1660,15 +1605,9 @@ get_server_output (FILE * fp, char conn)
       res = cci_close_query_result (req, &error);
       if (res < 0)
 	{
-	  sql = "CALL GET_LINE (?, ?);"
-
-	  res = cci_close_query_result (req, &error);
-	  if (res < 0)
-	    {
-	      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-	      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-	      goto _END;
-	    }
+	  fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+	  fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+	  goto _END;
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25352

Built-in PL/CSQL을 호출할 때는 'dbms_output.'을 붙여야 정상 실행됩니다.
ex) 'call get_line;' -> 'call dbms_output.get_line;'

해당 PR이 merge되면 기존 phase-0가 merge된 develop branch에 영향을 미칩니다.
따라서 phase-1가 merge될 때까지 임시로 catch 문 안에서 DBMS_OUTPUT. 을 제거한 Built-in PL/CSQL을 한 번 더 수행하도록 CTE를 수정했습니다.

향후 phase-1 feature branch가 merge 되면 다시 제거할 계획입니다.