### PR TITLE
[CBRD-25335] Print the join graph using the keyword '--@joingraph'

### DIFF
--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/common/SQLParser.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/common/SQLParser.java
@@ -75,8 +75,8 @@ public class SQLParser {
                     if ("--@queryplan".equals(line.trim())) {
                         isQueryplan = true;
                     } else if ("--@joingraph".equals(line.trim())) {
-			            isJoingraph = true;
-	                } else {
+                        isJoingraph = true;
+                    } else {
                         String controlCmd = getControlCommand(line);
                         if (controlCmd != null) {
                             // control command : either hodcas or server-message

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/common/SQLParser.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/common/SQLParser.java
@@ -61,6 +61,7 @@ public class SQLParser {
             boolean isCall = false;
             boolean isNewStatement = true;
             boolean isQueryplan = false;
+            boolean isJoingraph = false;
 
             LineScanner lineScanner = new LineScanner();
 
@@ -73,7 +74,9 @@ public class SQLParser {
 
                     if ("--@queryplan".equals(line.trim())) {
                         isQueryplan = true;
-                    } else {
+                    } else if ("--@joingraph".equals(line.trim())) {
+			            isJoingraph = true;
+	                } else {
                         String controlCmd = getControlCommand(line);
                         if (controlCmd != null) {
                             // control command : either hodcas or server-message
@@ -115,11 +118,13 @@ public class SQLParser {
                         // new sql
                         Sql sql = new Sql(connId, ret.toString(), paramList, isCall);
                         sql.setQueryplan(isQueryplan);
+                        sql.setJoingraph(isJoingraph);
                         list.add(sql);
 
                         // initialize state variables
                         isNewStatement = true;
                         isQueryplan = false;
+                        isJoingraph = false;
                         ret.setLength(0);
                         paramList = null;
                         isCall = false;

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Sql.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Sql.java
@@ -41,6 +41,9 @@ public class Sql {
     // add query plan for single sql statement
     private boolean isQueryplan = false;
 
+    // Only join graph xxx
+    private boolean isJoingraph = false;
+
     private int type;
 
     private String result = "";
@@ -159,5 +162,13 @@ public class Sql {
 
     public void setQueryplan(boolean isQueryplan) {
         this.isQueryplan = isQueryplan;
+    }
+
+    public boolean isJoingraph() {
+        return isJoingraph;
+    }
+
+    public void setJoingraph(boolean isJoingraph) {
+        this.isJoingraph = isJoingraph;
     }
 }

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -662,11 +662,16 @@ public class ConsoleDAO extends Executor {
             boolean isRs = st.execute(sql.getScript());
             getAllResult(st, isRs, sql);
             String script = sql.getScript().trim().toUpperCase();
-            if ((isPrintQueryPlan && script.startsWith("SELECT")) || sql.isQueryplan()) {
+            boolean isOnlyJoinGraph = sql.isJoingraph();
+            if (((isPrintQueryPlan && script.startsWith("SELECT")) || sql.isQueryplan()) || isOnlyJoinGraph) {
                 Method method = st.getClass().getMethod("getQueryplan", stringType);
                 String queryPlan = (String) method.invoke(st, new Object[] {sql.getScript()});
                 queryPlan = queryPlan + System.getProperty("line.separator");
-                queryPlan = StringUtil.replaceQureyPlan(queryPlan);
+                if (isOnlyJoinGraph) {
+                      queryPlan = StringUtil.replaceJoingraph(queryPlan);
+                } else {
+                      queryPlan = StringUtil.replaceQureyPlan(queryPlan);
+                }
                 sql.setResult(sql.getResult() + queryPlan);
                 method = null;
                 queryPlan = null;

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/StringUtil.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/StringUtil.java
@@ -211,6 +211,66 @@ public class StringUtil {
         return ret.toString();
     }
 
+   /**
+ *      * Show only the join graph. 
+ *           *
+ *                * @param queryPlan
+ *                     * @return
+ *                          */
+    public static String replaceJoingraph(String queryPlan) {
+        if (queryPlan == null) {
+            return null;
+        }
+
+        StringBuilder ret = new StringBuilder();
+
+        String flag = "default";
+        String separator = System.getProperty("line.separator");
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new StringReader(queryPlan));
+
+            String message = reader.readLine();
+            while (message != null) {
+                if (message.trim().equals("")) {
+                    message = reader.readLine();
+                    continue;
+                }
+
+                if (message.startsWith("Join graph edges:")) {
+                    flag = "edges";
+                    ret.append(message + separator);
+                    message = reader.readLine();
+                    continue;
+                } else if (message.startsWith("Join graph")) {
+                    flag = "default";
+                    ret.append(message + separator);
+                    message = reader.readLine();
+                    continue;
+                } else if (message.startsWith("Query plan:")) {
+                    break;
+                }
+               
+                // make chageable values hidden. 
+                if ("edges".equals(flag)) {
+                    message = message.replaceAll("sel [0-9]+\\.[0-9]+", "sel ?"); 
+                }
+                
+                ret.append(message + separator);
+                message = reader.readLine();
+            }
+        } catch (Exception e) {
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+        return ret.toString();
+    }
+
     /**
      * translate byte array to Hex String .
      *

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/StringUtil.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/StringUtil.java
@@ -212,11 +212,11 @@ public class StringUtil {
     }
 
    /**
- *      * Show only the join graph. 
- *           *
- *                * @param queryPlan
- *                     * @return
- *                          */
+    * Show only the join graph. 
+    *
+    * @param queryPlan
+    * @return
+    */
     public static String replaceJoingraph(String queryPlan) {
         if (queryPlan == null) {
             return null;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25335

https://github.com/CUBRID/cubrid-testcases/pull/1781 케이스를 지원
Join graph 결과를 sql testcase 에서 결과 출력이 가능하도록 지원

--@joingraph 키워드를 사용하면 optimization level 설정시
출력되는 Join graph .... 만 (query plan은 출력되지 않음) 확인되도록 수정합니다.

리뷰시 확인 사항
일정상 우선 이번 케이스에 지원하도록 수정합니다.
소스를 보면 prepare 구문에서도 추가할 필요가 있어보이나
확인하지 못해 TODO 로 남겨둡니다.
의견 부탁드립니다. 
