### PR TITLE
[CBRD-25352] When adding a user schema to a stored procedure, the way a built-in PL/SQL is called is changed, and the test tools need to be temporarily modified.

### DIFF
--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bo/ConsoleBO.java
@@ -1127,42 +1127,127 @@ public class ConsoleBO extends Executor {
                             this.onMessage(message);
                         }
                     } else if (isServerMessageOn) {
+                        /*temporary*/
+                        boolean phase_1_flag = false;
+
+                        Statement temp_stmt;
+                        conn.setAutoCommit(true);
+                        temp_stmt = conn.createStatement();
                         try {
-                            String message =
-                                    "@"
-                                            + test.getConnId()
-                                            + ": server message "
-                                            + isServerMessageOn;
-                            this.onMessage(message);
-                            test.setServerMessage("on");
-                            // TODO: DBMS_OUTPUT.enable ()
-                            Sql enableSql =
-                                    new Sql(connId, "CALL enable(50000)", null, true); // TODO: set
-                            // size of
-                            // enable
-                            dao.execute(conn, enableSql, false);
-                        } catch (Exception e) {
-                            String message =
-                                    "Exception: the current version can't support DBMS_OUTPUT!";
-                            this.onMessage(message);
+                            temp_stmt.executeQuery("call DBMS_OUTPUT.put_line('Temporary !!');");
+
+                            phase_1_flag = true;
+                        } catch (SQLException s) {
+                            phase_1_flag = false;
+                        }
+                        temp_stmt.close();
+
+                        if (phase_1_flag) {
+                            /* if phase-1 */
+                            try {
+                                String message =
+                                        "@"
+                                                + test.getConnId()
+                                                + ": server message "
+                                                + isServerMessageOn;
+                                this.onMessage(message);
+                                test.setServerMessage("on");
+                                // TODO: DBMS_OUTPUT.enable ()
+                                Sql enableSql =
+                                        new Sql(
+                                                connId,
+                                                "CALL DBMS_OUTPUT.enable(50000)",
+                                                null,
+                                                true); // TODO: set
+                                // size of
+                                // enable
+                                dao.execute(conn, enableSql, false);
+                            } catch (Exception e) {
+                                String message =
+                                        "Exception: the current version can't support DBMS_OUTPUT!";
+                                this.onMessage(message);
+                            }
+                        } else {
+                            /* if phase-0 */
+                            try {
+                                String message =
+                                        "@"
+                                                + test.getConnId()
+                                                + ": server message "
+                                                + isServerMessageOn;
+                                this.onMessage(message);
+                                test.setServerMessage("on");
+                                // TODO: DBMS_OUTPUT.enable ()
+                                Sql enableSql =
+                                        new Sql(
+                                                connId,
+                                                "CALL enable(50000)",
+                                                null,
+                                                true); // TODO: set
+                                // size of
+                                // enable
+                                dao.execute(conn, enableSql, false);
+                            } catch (Exception e) {
+                                String message =
+                                        "Exception: the current version can't support DBMS_OUTPUT!";
+                                this.onMessage(message);
+                            }
                         }
                     } else if (isServerMessageOff) {
-                        try {
-                            String message =
-                                    "@"
-                                            + test.getConnId()
-                                            + ": server message "
-                                            + isServerMessageOff;
-                            this.onMessage(message);
+                        /*temporary*/
+                        boolean phase_1_flag = false;
 
-                            test.setServerMessage("off");
-                            // TODO: DBMS_OUTPUT.disable()
-                            Sql disableSql = new Sql(connId, "CALL disable()", null, true);
-                            dao.execute(conn, disableSql, false);
-                        } catch (Exception e) {
-                            String message =
-                                    "Exception: the current version can't support DBMS_OUTPUT!";
-                            this.onMessage(message);
+                        Statement temp_stmt;
+                        conn.setAutoCommit(true);
+                        temp_stmt = conn.createStatement();
+                        try {
+                            temp_stmt.executeQuery("call DBMS_OUTPUT.put_line('Temporary !!');");
+
+                            phase_1_flag = true;
+                        } catch (SQLException s) {
+                            phase_1_flag = false;
+                        }
+                        temp_stmt.close();
+
+                        if (phase_1_flag) {
+                            /* if phase-1 */
+                            try {
+                                String message =
+                                        "@"
+                                                + test.getConnId()
+                                                + ": server message "
+                                                + isServerMessageOff;
+                                this.onMessage(message);
+
+                                test.setServerMessage("off");
+                                // TODO: DBMS_OUTPUT.disable()
+                                Sql disableSql =
+                                        new Sql(connId, "CALL DBMS_OUTPUT.disable()", null, true);
+                                dao.execute(conn, disableSql, false);
+                            } catch (Exception e) {
+                                String message =
+                                        "Exception: the current version can't support DBMS_OUTPUT!";
+                                this.onMessage(message);
+                            }
+                        } else {
+                            /* if phase-0 */
+                            try {
+                                String message =
+                                        "@"
+                                                + test.getConnId()
+                                                + ": server message "
+                                                + isServerMessageOff;
+                                this.onMessage(message);
+
+                                test.setServerMessage("off");
+                                // TODO: DBMS_OUTPUT.disable()
+                                Sql disableSql = new Sql(connId, "CALL disable()", null, true);
+                                dao.execute(conn, disableSql, false);
+                            } catch (Exception e) {
+                                String message =
+                                        "Exception: the current version can't support DBMS_OUTPUT!";
+                                this.onMessage(message);
+                            }
                         }
                     } else {
                         String message =

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -716,7 +716,7 @@ public class ConsoleDAO extends Executor {
         ArrayList<SqlParam> params = new ArrayList<SqlParam>();
         params.add(new SqlParam("OUT", 1, null, Types.VARCHAR));
         params.add(new SqlParam("OUT", 2, null, Types.INTEGER));
-        Sql getLine = new Sql(test.getConnId(), "CALL GET_LINE (?, ?);", params, true);
+        Sql getLine = new Sql(test.getConnId(), "CALL DBMS_OUTPUT.get_line (?, ?);", params, true);
 
         try {
             while (true) {
@@ -732,7 +732,24 @@ public class ConsoleDAO extends Executor {
                 }
             }
         } catch (Exception e) {
-            // error?
+            getLine = new Sql(test.getConnId(), "CALL get_line (?, ?);", params, true);
+
+            try {
+                while (true) {
+                    executeCall(conn, getLine);
+                    List<SqlParam> paramList = getLine.getParamList();
+                    if (((Integer) paramList.get(1).getValue()) == 0) {
+                        /* status */
+                        message.append(
+                                ((String) paramList.get(0).getValue())
+                                        + System.getProperty("line.separator")); /* message */
+                    } else {
+                        break;
+                    }
+                }
+            } catch (Exception e2) {
+                // error?
+            }
         }
 
         return message.toString();

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1446,23 +1446,37 @@ set_server_message (FILE * fp, char conn, bool on)
   char sql[20];
   int req, res = 0;
   T_CCI_ERROR error;
-
+  
+  /* if phase-1 */
   if (on)
     {
-      sprintf (sql, "call enable(%d)", DBMS_OUTPUT_BUFFER_SIZE);
+      sprintf (sql, "call DBMS_OUTPUT.enable(%d)", DBMS_OUTPUT_BUFFER_SIZE);
     }
   else
     {
-      sprintf (sql, "call disable()");
+      sprintf (sql, "call DBMS_OUTPUT.disable()");
     }
 
   req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
   if (req < 0)
     {
-      fprintf (stdout, "Set Server-Message Error:%d\n", error.err_code);
-      fprintf (fp, "Set Server-Message Error:%d\n", error.err_code);
-      res = -1;
-      goto _END;
+      /* if phase-0 */
+      if (on)
+        {
+          sprintf (sql, "call enable(%d)", DBMS_OUTPUT_BUFFER_SIZE);
+        }
+      else
+        {
+          sprintf (sql, "call disable()");
+        }
+      req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
+      if (req < 0)
+        {
+          fprintf (stdout, "Set Server-Message Error:%d\n", error.err_code);
+          fprintf (fp, "Set Server-Message Error:%d\n", error.err_code);
+          res = -1;
+          goto _END;
+	}
     }
 
   res = cci_execute (req, 0, 0, &error);
@@ -1488,17 +1502,25 @@ get_server_output (FILE * fp, char conn)
 {
   int req = 0, res = 0;
   T_CCI_ERROR error;
-  static const char *sql = "call get_line(?, ?)";
+  static const char *sql = "call DBMS_OUTPUT.get_line(?, ?)";
   static char buff[DBMS_OUTPUT_BUFFER_SIZE];
   char *ret = NULL, *p, *str;
   int status, ind;
-
+  
+  /* if phase-1 */
   req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
   if (req < 0)
     {
-      fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
-      fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
-      goto _END;
+      /* if phase-0 */
+      sql = "CALL GET_LINE (?, ?);"
+
+      req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
+      if (req < 0)
+        {
+          fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);
+          fprintf (fp, "Get Server-Output Error:%d\n", error.err_code);
+          goto _END;
+	}
     }
 
   res = cci_register_out_param (req, 1);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25352, CUBRID/cubrid#5258

**Purpose**

phase-1에서 Built-in PL/CSQL을 호출할 때는 'dbms_output.'을 붙여야 정상 실행됩니다.
ex) 
AS-IS (if phase-0)
    `CALL get_line;`

TO-BE (if phase-1)
    `CALL dbms_output.get_line;`

**Implementation**

N/A

**Remarks**

- 해당 PR이 merge되면 기존 phase-0가 merge된 develop branch에 영향을 미칩니다.
- 따라서 phase-1가 merge될 때까지 임시로 catch 문 안에서 DBMS_OUTPUT. 을 제거한 Built-in PL/CSQL을 한 번 더 수행하도록 CTE를 수정했습니다.
  - 향후 phase-1 feature branch가 merge 되면 다시 제거할 계획입니다.

- 이전 commit(#678)에서 testtools가 실패한 이유는 다음과 같습니다.
  - execute 함수가 Exception을 catch 하지 못하여 phase-0 방식으로 built-in pl/csql이 동작하지 못했습니다.