### PR TITLE
[CBRD-25352] Corrected typo in PL/SQL procedure call after adding user schema to SP.

### DIFF
--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1512,9 +1512,9 @@ get_server_output (FILE * fp, char conn)
   if (req < 0)
     {
       /* if phase-0 */
-      sql = "CALL GET_LINE (?, ?);"
+      static const char *sql2 = "CALL GET_LINE (?, ?)";
 
-      req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
+      req = cci_prepare (conn, sql2, CCI_PREPARE_CALL, &error);
       if (req < 0)
         {
           fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25352

Purpose
아래 두 가지 문제로 인해 CTP(sql_by_cci)가 실패하여 수정하였습니다.
1) 누락된 세미콜론(;) 추가
2) 상수 sql에 대해 값을 수정할 수 없으므로 새로운 상수 sql2를 추가

Implementation
N/A

Remarks
N/A