### PR TITLE
[CBRD-25610] null value was removed on cci

### DIFF
--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1645,9 +1645,9 @@ get_server_output (FILE * fp, char conn)
   if (req < 0)
     {
       /* if phase-0 */
-      static const char *sql2 = "CALL GET_LINE (?, ?)";
+      sql = "CALL GET_LINE (?, ?)";
 
-      req = cci_prepare (conn, sql2, CCI_PREPARE_CALL, &error);
+      req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
       if (req < 0)
         {
           fprintf (stdout, "Get Server-Output Error:%d\n", error.err_code);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25610

Purpose

CTP(sql_by_cci) 결과가 잘못 나오는 문제가 발생하여 이를 수정했습니다.

PR(#682) 에서 상수 sql의 값을 변경할 수 없다고 생각하여 새로운 상수 sql2를 추가했으나, cci에서 PLCSQL을 수행하는 중 기존 null 값이 제거되는 문제가 발생했습니다. 

따라서, 새로운 상수 sql2를 제거하고 기존 sql로 되돌렸습니다.

Implementation

N/A

Remarks

N/A