### PR TITLE
bugfix: a string to print to the second argument of fprintf()

### DIFF
--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -2057,7 +2057,7 @@ execute (FILE * fp, char conn, const SqlStateStruce *pSqlState)
 _END:
   if (server_output_buffer)
     {
-      fprintf (fp, server_output_buffer);
+      fprintf (fp, "%s", server_output_buffer);
     }
   if (req > 0)
     cci_close_req_handle (req);
@@ -2240,7 +2240,7 @@ executebind (FILE * fp, char conn, char *param, const SqlStateStruce *pSqlState)
 _END:
   if (server_output_buffer)
     {
-      fprintf (fp, server_output_buffer);
+      fprintf (fp, "%s", server_output_buffer);
     }
   if (req > 0)
     cci_close_req_handle (req);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25626

출력하고자 하는 문자열을 fprintf() 함수의 두 번째 인자로 주면 
그 문자열 안에 우연히 %t, %s, %d, 등이 있을 때 이들이 있는 그대로 출력되지 않는 문제가 있습니다. 
이를 수정했습니다. 