### PR TITLE
[CUBRIDQA-1240] Added the showTrace option to SystemModel in CTP to refrain from converting numeric values to '?' for trace statistics when set to true

### DIFF
--- a/CTP/sql/configuration/System.xml
+++ b/CTP/sql/configuration/System.xml
@@ -2,5 +2,6 @@
 <useMonitor>false</useMonitor>
 <jdbcPath>/data/home/bu1/CUBRID/jdbc/cubrid_jdbc.jar</jdbcPath>
 <queryPlan>false</queryPlan>
+<showTrace>false</showTrace>
 <errorMessage>false</errorMessage>
 </system>

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/SystemModel.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/SystemModel.java
@@ -45,6 +45,8 @@ public class SystemModel {
 
     private boolean queryPlan;
 
+    private boolean showTrace;
+
     private boolean cpResultToRemoteHost;
 
     private boolean errorMessage;
@@ -117,6 +119,14 @@ public class SystemModel {
 
     public void setQueryPlan(boolean queryPlan) {
         this.queryPlan = queryPlan;
+    }
+
+    public boolean isShowTrace() {
+        return showTrace;
+    }
+
+    public void setShowTrace(boolean showTrace) {
+        this.showTrace = showTrace;
     }
 
     public String getRemoteHost() {

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -900,11 +900,18 @@ public class ConsoleDAO extends Executor {
             } catch (Exception e) {
             }
         }
-
+        SystemModel systemModel =
+                (SystemModel)
+                        XstreamHelper.fromXml(
+                                EnvGetter.getenv("CTP_HOME")
+                                        + File.separator
+                                        + "sql/configuration/System.xml");
         String script = sql.getScript().trim().toUpperCase();
         if (script.startsWith("SHOW TRACE")) {
             String res = ret.toString();
-            res = res.replaceAll("[0-9]+", "?");
+            if (!systemModel.isShowTrace()) {
+                res = res.replaceAll("[0-9]+", "?");
+            }
             sql.setResult(sql.getResult() + res + System.getProperty("line.separator"));
         } else {
             sql.setResult(sql.getResult() + ret.toString() + System.getProperty("line.separator"));


### PR DESCRIPTION
Refer to: http://jira.cubrid.org/browse/CUBRIDQA-1240

_SHOW TRACE;_ 를 CTP에서 사용했을때 출력되는 trace statistics에 관하여 showTrace 옵션을 도입할 것을 제안합니다. 본 옵션은 사용자가 트레이스 통계에서 숫자 값을 유지하거나 '?'로 변환할 수 있는 설정을 제공합니다. 

해당 옵션은 다음과 같이 동작합니다:

 In [CTP/sql/configuration/System.xml](https://github.com/CUBRID/cubrid-testtools/blob/develop/CTP/sql/configuration/System.xml),
- **showTrace = false (기본값)**

  `<showTrace>false</showTrace>`
  
  false(기본값)로 설정된 경우, 기존 동작과 동일하게 SHOW TRACE 출력의 숫자 값이 자동으로 '?'로 변환됩니다.


- **showTrace = true**

  `<showTrace>true</showTrace>`
  
  true로 설정된 경우, SHOW TRACE 출력에 변환되지 않은 기존의 숫자 값이 표시됩니다.

### Notes

- CTP/sql/configuration/System.xml 파일에 showTrace 옵션이 추가되면 regression의 장비들은 매번 CTP/common/script/upgrade.sh 파일을 실행하기에 System.xml 파일도 CTP 엔진과 함께 업데이트 됩니다. 이러한 이유로 System.xml과 CTP 엔진이랑 버전이 맞지 않는 경우는 드물며, 이 feature를 로컬 장비에서 사용하시려면 본 PR이 머지가 된 이후에 upgrade.sh 파일을 실행하시고 System.xml을 수정하시길 바랍니다.
- JDBC only (cci 미지원)

