### PR TITLE
[CUBRIDQA-1241] get server output after all the execution results are read

### DIFF
--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1937,6 +1937,7 @@ execute (FILE * fp, char conn, const SqlStateStruce *pSqlState)
   bool hasqueryplan = pSqlState->hasqp;
   bool onlyjoingraph = pSqlState->onlyjg;
   bool hasfullplan = pSqlState->hasfullp;
+  bool executed = false;
 
   fprintf (fp, "===================================================\n");
 
@@ -1959,10 +1960,7 @@ execute (FILE * fp, char conn, const SqlStateStruce *pSqlState)
     }
 
   res = cci_execute (req, CCI_EXEC_QUERY_ALL, 0, &error);
-  if (is_server_message_on)
-    {
-      server_output_buffer = get_server_output (fp, conn);
-    }
+  executed = true;
   if (res < 0)
     {
       fprintf (stdout, "Error:%d\n", error.err_code);
@@ -2055,9 +2053,13 @@ execute (FILE * fp, char conn, const SqlStateStruce *pSqlState)
     }
 
 _END:
-  if (server_output_buffer)
+  if (executed && is_server_message_on)
     {
-      fprintf (fp, "%s", server_output_buffer);
+      server_output_buffer = get_server_output (fp, conn);
+      if (server_output_buffer)
+        {
+          fprintf (fp, "%s", server_output_buffer);
+        }
     }
   if (req > 0)
     cci_close_req_handle (req);
@@ -2085,6 +2087,8 @@ executebind (FILE * fp, char conn, char *param, const SqlStateStruce *pSqlState)
   bool onlyjoingraph = pSqlState->onlyjg;
   bool hasfullplan = pSqlState->hasfullp;
   bool iscall = pSqlState->iscallwithoutvalue;
+  bool executed = false;
+
   fprintf (fp, "===================================================\n");
 
   if (iscall)
@@ -2133,10 +2137,7 @@ executebind (FILE * fp, char conn, char *param, const SqlStateStruce *pSqlState)
     }
 
   res = cci_execute (req, CCI_EXEC_QUERY_ALL, 0, &error);
-  if (is_server_message_on)
-    {
-      server_output_buffer = get_server_output (fp, conn);
-    }
+  executed = true;
   if (res < 0)
     {
       fprintf (stdout, "Error:%d\n", error.err_code);
@@ -2238,9 +2239,13 @@ executebind (FILE * fp, char conn, char *param, const SqlStateStruce *pSqlState)
     }
 
 _END:
-  if (server_output_buffer)
+  if (executed && is_server_message_on)
     {
-      fprintf (fp, "%s", server_output_buffer);
+      server_output_buffer = get_server_output (fp, conn);
+      if (server_output_buffer)
+        {
+          fprintf (fp, "%s", server_output_buffer);
+        }
     }
   if (req > 0)
     cci_close_req_handle (req);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1241
http://jira.cubrid.org/browse/CBRD-25636

CUBRIDQA-1241 이슈와 이것의 동일문제라고 생각되는 CBRD-25636 이슈를 해결하기 위한 CTP 모듈 수정입니다. 
EVALUATE 문을 cci_execute()로 실행 직후에 get_server_output()을 호출하여 call 문을 수행하는 것이 
실행 결과를 읽어 들일 때 영향을 미치는 것으로 보여 
(--+ server-message on 이 없으면 결과 출력이 잘 됩니다.)
get_server_output() 문을 cci_execute()의 결과를 읽고 출력한 이후에 호출하도록 옮겼습니다. 

왜 하필 EVALUATE 만 문제가 되었을까는 의문입니다. CCI interface 의 이슈인 듯 합니다. 

다음 TC의 SQL_BY_CCI 테스트 실패를 해결하는 수정입니다. 
cubrid-testcases/sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/14_evaluate_wrong.sql