### PR TITLE
[CUBRIDQA-1242] Add sort option on compare_result_between_files method

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -335,7 +335,7 @@ function diff_ignore_lineno
 
 # After comparing two files, This function write the result int result files.
 # Usage:
-#        compare_result_between_files file1 file2 [error]
+#        compare_result_between_files file1 file2 [error|sort]
 
 function compare_result_between_files
 {

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -374,14 +374,30 @@ function compare_result_between_files
   dos2unix $right
 
   echo "start to compare files: diff $left $right"  
-  if [ "$3" = "error" ]
+  if [ "$3" = "error" ] && [ "$4" = "sort" ] || [ "$3" = "sort" ] && [ "$4" = "error" ]
+  then
+        sorted_left="${left}_sorted"
+        sorted_right="${right}_sorted"
+        sort $left > $sorted_left
+        sort $right > $sorted_right
+
+        if diff_ignore_lineno $sorted_left $sorted_right -b
+        then
+                write_nok
+                echo "diff $sorted_left $sorted_right failed" >> $result_file
+                diff_ignore_lineno $sorted_left $sorted_right -y |tee -a $result_file
+        else
+                write_ok
+        fi
+
+        rm -f $sorted_left $sorted_right
+  elif [ "$3" = "error" ]
   then
         if diff_ignore_lineno $left $right -b
         then
                 write_nok
                 echo "diff $left $right failed" >> $result_file
-                #diff $left $right -y >> $result_file
-		diff_ignore_lineno $left $right -y |tee -a $result_file
+                diff_ignore_lineno $left $right -y |tee -a $result_file
         else
                 write_ok
         fi
@@ -410,8 +426,7 @@ function compare_result_between_files
         else
                 write_nok
                 echo "diff $left $right failed" >> $result_file
-                #diff $left $right -y >> $result_file
-		diff_ignore_lineno $left $right -y |tee -a $result_file
+                diff_ignore_lineno $left $right -y |tee -a $result_file
         fi
         let "answer_no = answer_no + 1"
   fi

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -386,6 +386,23 @@ function compare_result_between_files
                 write_ok
         fi
         let "answer_no = answer_no + 1"
+  elif [ "$3" = "sort" ]
+  then
+        sorted_left="${left}_sorted"
+        sorted_right="${right}_sorted"
+        sort $left > $sorted_left
+        sort $right > $sorted_right
+
+        if diff_ignore_lineno $sorted_left $sorted_right -b
+        then
+                write_ok
+        else
+                write_nok
+                echo "diff $sorted_left $sorted_right failed" >> $result_file
+                diff_ignore_lineno $sorted_left $sorted_right -y |tee -a $result_file
+        fi
+
+        rm -f $sorted_left $sorted_right
   else
         if diff_ignore_lineno $left $right -b
         then


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1242

Usage:
compare_result_between_files  file1 file2 [error | sort]

sort 옵션 사용시, 
file1 과 file2 의 내용을 linux sort 를 통하여 정렬후 비교.
내용의 순서와 관계없이 검증해야되는 케이스에서는 옵션사용 필요.