### PR TITLE
[CUBRIDQA-1244] ha_repl 시스템 뷰 조회 시 특정 컬럼을 제외

### DIFF
--- a/CTP/ha_repl/lib/common.inc
+++ b/CTP/ha_repl/lib/common.inc
@@ -3,7 +3,7 @@ check_server_status=cmd:cubrid server status;cubrid_rel | awk '{print $4}'
 HC_CHECK_FOR_CMD_EACH_STATEMENT_0=cmd: sleep 3
 
 HC_CHECK_FOR_EACH_STATEMENT_1=select 'db_stored_procedure_args' TABLE_NAME, db_stored_procedure_args.* from db_stored_procedure_args order by 1,2,3,4,5,6,7;
-HC_CHECK_FOR_EACH_STATEMENT_2=select 'db_stored_procedure' TABLE_NAME, db_stored_procedure.* from db_stored_procedure order by 1,2,3,4,5,6,7,8,9;
+HC_CHECK_FOR_EACH_STATEMENT_2=select 'db_stored_procedure' TABLE_NAME, sp_name, pkg_name, sp_type, return_type, arg_count, lang, authid, owner, code, comment from db_stored_procedure order by 1,2,3,4,5,6,7,8,9;
 HC_CHECK_FOR_EACH_STATEMENT_3=select 'db_partition' TABLE_NAME, db_partition.* from db_partition order by 1,2,3,4,5,6,7,8;
 HC_CHECK_FOR_EACH_STATEMENT_4=select 'db_trig' TABLE_NAME, db_trig.* from db_trig order by 1,2,3,4,5,6,7,8;
 HC_CHECK_FOR_EACH_STATEMENT_5=select 'db_index_key' TABLE_NAME, db_index_key.* from db_index_key order by 1,2,3,4,5,6,7,8;


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CUBRIDQA-1244


하드 코딩되어있는 common.inc 를 통해 system table 결과를 master, slave에 출력 후 diff 하는 과정이 있습니다.
common.inc의 db_stored_procedure table sql문을 수정합니다.

`public Test(Context context, String envId) throws Exception {
		this.context = context;
		this.hostManager = new InstanceManager(context, envId);

		this.mlog = new Log(CommonUtils.concatFile(context.getCurrentLogDir(), "test_" + envId + ".log"), false, context.isContinueMode());
		this.finishedLog = new Log(CommonUtils.concatFile(context.getCurrentLogDir(), "dispatch_tc_FIN_" + envId + ".txt"), false, context.isContinueMode());
		this.commonReader = new CommonReader(CommonUtils.concatFile(com.navercorp.cubridqa.common.Constants.ENV_CTP_HOME + "/ha_repl/lib", "common.inc"));
	}
`