### PR TITLE
[CBRD-25356] Revised clean.sh to change att_name to attr_name

### DIFF
--- a/CTP/isolation/ctltool/clean.sh
+++ b/CTP/isolation/ctltool/clean.sh
@@ -35,14 +35,14 @@ function clean_cubrid
   cubrid tranlist $dbname|grep $HOSTNAME|awk '{print $4}'|xargs -i kill -9 {} >/dev/null 2>&1
   if [ `csql -u dba $dbname -c "show create table db_trigger"|grep -c "unique_name"` -eq 1 ];then
     sql_trigger="select unique_name from db_trigger;"
-    sql_serial="select unique_name from db_serial where att_name is null;"
+    sql_serial="select unique_name from db_serial where attr_name is null;"
     sql_function="SELECT owner||'.'||sp_name FROM db_stored_procedure where sp_type='FUNCTION' and sp_name !='sleep' and sp_name !='sleep1' and sp_name !='sleep2'"
     sql_procedure="SELECT owner||'.'||sp_name FROM db_stored_procedure where sp_type='PROCEDURE';"
     sql_vclass="select owner_name||'.'||class_name from db_class where is_system_class='NO' and class_type='VCLASS';"
     sql_class="select owner_name||'.'||class_name from db_class where is_system_class='NO' and class_type='CLASS';"
   else
     sql_trigger="select name from db_trigger;"
-    sql_serial="select name from db_serial where att_name is null;"
+    sql_serial="select name from db_serial where attr_name is null;"
     sql_function="SELECT sp_name FROM db_stored_procedure where sp_type='FUNCTION' and sp_name !='sleep' and sp_name !='sleep1' and sp_name !='sleep2'"
     sql_procedure="SELECT sp_name FROM db_stored_procedure where sp_type='PROCEDURE';"
     sql_vclass="select class_name from db_class where is_system_class='NO' and class_type='VCLASS';"


### PR DESCRIPTION
isolation test에서 TC pass/fail 결과 자체에는 문제 없지만 TC수행 시 아래와 같이 에러가 발생하므로 CTP를 수정합니다.
```
+ pkill -u isolation -9 sleep
+ sh /home/isolation/CTP/isolation/ctltool/clean.sh qacsql ctldb

In line 1, column 41,

ERROR: before '  is null;'
Attribute "att_name" was not found.

+ grep 'flag: OK' .test.log
flag: OK
```

http://jira.cubrid.org/browse/CBRD-25356