### PR TITLE
[CUBRIDQA-1098] Removed a warning in case of not supporting javasp

### DIFF
--- a/CTP/sql/bin/run.sh
+++ b/CTP/sql/bin/run.sh
@@ -179,7 +179,7 @@ function do_init()
     fi
     
     cci_urlproperty=`ini -s sql ${config_file_main} cci_urlproperty`
-    support_javasp=`cubrid | grep -w javasp | awk '{if($1=="javasp") {print "yes"}}'`
+    support_javasp=`echo $(cubrid | grep -w javasp) | awk '{if($1=="javasp") {print "yes"} else {print "no"}}'`
     
     cd $curDir
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1098

11.4 에서 javasp 가 삭제관련  스크립트 warning 메시지 제거