### PR TITLE
[CUBRIDQA-1247] Fix output message when 'write_nok file' in init.sh

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -603,6 +603,7 @@ function write_nok
         let "case_no = case_no + 1"
   elif [ -f "$1" ]; 
   then
+	echo "----------------- $case_no : NOK"
 	echo "$case_name-$case_no : NOK"  >> ${cur_path}/$result_file
 	cat $1 >> ${cur_path}/$result_file
 	let "case_no = case_no + 1"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1247

as-is
\+ write_nok exp_test.log
\+ '[' -z exp_test.log ']'
\+ '[' -f exp_test.log ']'
\+ echo 'cbrd_25833-3 : NOK'
\+ cat exp_test.log

to-be
\+ write_nok exp_test.log
\+ '[' -z exp_test.log ']'
\+ '[' -f exp_test.log ']'
\+ echo '----------------- 3 : NOK'
----------------- 3 : NOK
\+ echo 'cbrd_25833-3 : NOK'
\+ cat exp_test.log
