### PR TITLE
[CUBRIDQA-1249] Removed unnecessary code on DeployOneNode.java

### DIFF
--- a/CTP/shell/src/com/navercorp/cubridqa/shell/deploy/DeployOneNode.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/deploy/DeployOneNode.java
@@ -115,13 +115,6 @@ public class DeployOneNode {
 			scripts.addCommand("chmod -R u+x CUBRID");
 		}
 
-		String buildId = context.getTestBuild();
-		String[] arr = buildId.split("\\.");
-		if (Integer.parseInt(arr[0]) >= 10) {
-			scripts.addCommand("echo inquire_on_exit=3 >> $CUBRID/conf/cubrid.conf");
-		}
-		scripts.addCommand("echo error_log_size=800000000 >> $CUBRID/conf/cubrid.conf");
-
 		String result;
 		try {
 			result = ssh.execute(scripts);
@@ -154,13 +147,6 @@ public class DeployOneNode {
 			scripts.addCommand(CommonUtils.getExportsOfMEKYParams());
 			scripts.addCommand("run_cubrid_install " + role + " " + buildUrl + " " + context.getProperty(ConfigParameterConstants.CUBRID_ADDITIONAL_DOWNLOAD_URL, "").trim() + " 2>&1");
 		}
-
-		String buildId = context.getTestBuild();
-		String[] arr = buildId.split("\\.");
-		if (Integer.parseInt(arr[0]) >= 10) {
-			scripts.addCommand("echo inquire_on_exit=3 >> $CUBRID/conf/cubrid.conf");
-		}
-		scripts.addCommand("echo error_log_size=800000000 >> $CUBRID/conf/cubrid.conf");
 
 		String result;
 		try {


### PR DESCRIPTION
Refer to http://jira.cubrid.org//browse/CUBRIDQA-1249

ctp.sh로 Linux shell test 수행시 cubrid.conf를 변경하는 code가 있어, 이를 제거합니다.
제거된 코드는 shell_ctrl의 CTP/conf/shell_template.conf에 재지정하여, 테스트가 기존과 동일하게 수행될 수 있도록 변경했습니다.
(관련 tc의 답지 수정은 이 수정 사항을 반영한 후, test 결과에 따라 재검토할 예정입니다)


+ 추가 확인 및 공유사항
DeployOneNode.java의 updateCUBRIDConfigurations()에서도 cubrid.conf, cubrid_broker.conf, cubrid_ha.conf를 변경하는 것 code가 있는 것으로 확인 됐습니다.
현재로서는 이들 config가 test case에 어떤 영향을 주는지는 확인되지 않았습니다.
이번 수정 때 이들 code도 제거할 것인지 검토하면 좋을 것 같습니다.