### PR TITLE
[CUBRIDQA-1254] changed cci DBMS-output implementation to heap‑allocate the buffer

### DIFF
--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1933,12 +1933,6 @@ get_server_output (FILE * fp, char conn)
                     fprintf (stdout, "Get Server-Output Error: snprintf failed\n");
                     goto _END;
                   }
-                if ((size_t)written >= buf_size - (p - buff))
-                  {
-                    fprintf (stdout, "Warning: Buffer truncated while writing server output.\n");
-                    p += buf_size - (p - buff) - 1;
-                    break;
-                  }
                 p += written;
               }
 	    }

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -46,6 +46,7 @@
 #undef _GNU_SOURCE
 
 #define DBMS_OUTPUT_BUFFER_SIZE (50000)
+#define MAX_DBMS_OUTPUT_BUFFER_SIZE (1024 * 1024)  /* 1MB */
 #define MAXLINELENGH 1024*1024*5
 #define MAX_SQL_NUM 100*256
 #define MAX_SQL_LEN 1024*200
@@ -1801,11 +1802,23 @@ get_server_output (FILE * fp, char conn)
 {
   int req = 0, res = 0;
   T_CCI_ERROR error;
-  static const char *sql = "call DBMS_OUTPUT.get_line(?, ?)";
-  static char buff[DBMS_OUTPUT_BUFFER_SIZE];
-  char *ret = NULL, *p, *str;
+  const char *sql = "call DBMS_OUTPUT.get_line(?, ?)";
+  char *buff = NULL, *p, *str;
+  size_t buf_size = DBMS_OUTPUT_BUFFER_SIZE;
   int status, ind;
   
+  /* allocate initial buffer */
+  buff = malloc (buf_size);
+  if (buff == NULL)
+    {
+      fprintf (stdout, "Get Server-Output Error: malloc failed\n");
+      fprintf (fp, "Get Server-Output Error: malloc failed\n");
+      goto _END;
+    }
+  buff[0] = '\n';
+  buff[1] = '\0';
+  p = buff + 1;
+
   /* if phase-1 */
   req = cci_prepare (conn, sql, CCI_PREPARE_CALL, &error);
   if (req < 0)
@@ -1838,9 +1851,6 @@ get_server_output (FILE * fp, char conn)
       goto _END;
     }
 
-  buff[0] = '\n';
-  buff[1] = '\0';
-  p = buff + 1;
   while (1)
     {
       res = cci_execute (req, 0, 0, &error);
@@ -1889,8 +1899,42 @@ get_server_output (FILE * fp, char conn)
 	  assert (ind >= 0);
 	  if (ind > 0)
 	    {
-	      sprintf (p, "%s\n", str);
-	      p += (ind + 1);
+              size_t need = (p - buff) + ind + 2;
+              if (need > buf_size)
+                {
+                  size_t new_size = buf_size;
+                  while (new_size < need && new_size < MAX_DBMS_OUTPUT_BUFFER_SIZE)
+                    new_size *= 2;
+                  if (new_size < need)
+                    {
+                      fprintf (stdout, "Warning: buffer max size reached\n");
+                      break;
+                    }
+                  size_t offset = p - buff;
+                  buff = realloc (buff, new_size);
+                  if (buff == NULL)
+                    {
+                      fprintf (stdout, "Get Server-Output Error: realloc failed\n");
+                      goto _END;
+                    }
+                  buf_size = new_size;
+                  p = buff + offset;
+                }
+              {
+                int written = snprintf (p, buf_size - (p - buff), "%s\n", str);
+                if (written < 0)
+                  {
+                    fprintf (stdout, "Get Server-Output Error: snprintf failed\n");
+                    goto _END;
+                  }
+                if ((size_t)written >= buf_size - (p - buff))
+                  {
+                    fprintf (stdout, "Warning: Buffer truncated while writing server output.\n");
+                    p += buf_size - (p - buff) - 1;
+                    break;
+                  }
+                p += written;
+              }
 	    }
 	  else
 	    {
@@ -1916,10 +1960,13 @@ get_server_output (FILE * fp, char conn)
   ret = buff;
 
 _END:
+  if (ret == NULL && buff != NULL)
+    free (buff);
   if (req > 0)
     cci_close_req_handle (req);
   return ret;
 }
+
 
 int
 execute (FILE * fp, char conn, const SqlStateStruce *pSqlState)

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1815,6 +1815,7 @@ get_server_output (FILE * fp, char conn)
       fprintf (fp, "Get Server-Output Error: malloc failed\n");
       goto _END;
     }
+  memset (buff, 0, buf_size);
   buff[0] = '\n';
   buff[1] = '\0';
   p = buff + 1;
@@ -1910,15 +1911,20 @@ get_server_output (FILE * fp, char conn)
                       fprintf (stdout, "Warning: buffer max size reached\n");
                       break;
                     }
-                  size_t offset = p - buff;
-                  buff = realloc (buff, new_size);
-                  if (buff == NULL)
+                    size_t offset = p - buff;
+                    char *tmp = realloc (buff, new_size);
+                    if (tmp == NULL)
                     {
-                      fprintf (stdout, "Get Server-Output Error: realloc failed\n");
+                      fprintf(stdout, "Get Server-Output Error: realloc failed\n");
                       goto _END;
                     }
-                  buf_size = new_size;
-                  p = buff + offset;
+                    buff = tmp;
+                    if (new_size > offset)
+                    {
+                      memset (buff + offset, 0, new_size - offset);
+                    }
+                    buf_size = new_size;
+                    p = buff + offset;
                 }
               {
                 int written = snprintf (p, buf_size - (p - buff), "%s\n", str);

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1911,20 +1911,20 @@ get_server_output (FILE * fp, char conn)
                       fprintf (stdout, "Warning: buffer max size reached\n");
                       break;
                     }
-                    size_t offset = p - buff;
-                    char *tmp = realloc (buff, new_size);
-                    if (tmp == NULL)
+                  size_t offset = p - buff;
+                  char *tmp = realloc (buff, new_size);
+                  if (tmp == NULL)
                     {
                       fprintf(stdout, "Get Server-Output Error: realloc failed\n");
                       goto _END;
                     }
-                    buff = tmp;
-                    if (new_size > offset)
+                  buff = tmp;
+                  if (new_size > offset)
                     {
                       memset (buff + offset, 0, new_size - offset);
                     }
-                    buf_size = new_size;
-                    p = buff + offset;
+                  buf_size = new_size;
+                  p = buff + offset;
                 }
               {
                 int written = snprintf (p, buf_size - (p - buff), "%s\n", str);

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1905,7 +1905,7 @@ get_server_output (FILE * fp, char conn)
                   size_t new_size = buf_size;
                   while (new_size < need && new_size < MAX_DBMS_OUTPUT_BUFFER_SIZE)
                     new_size *= 2;
-                  if (new_size < need)
+                  if (new_size >= MAX_DBMS_OUTPUT_BUFFER_SIZE)
                     {
                       fprintf (stdout, "Warning: buffer max size reached\n");
                       break;

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -1803,7 +1803,7 @@ get_server_output (FILE * fp, char conn)
   int req = 0, res = 0;
   T_CCI_ERROR error;
   const char *sql = "call DBMS_OUTPUT.get_line(?, ?)";
-  char *buff = NULL, *p, *str;
+  char *ret = NULL, *buff = NULL, *p, *str;
   size_t buf_size = DBMS_OUTPUT_BUFFER_SIZE;
   int status, ind;
   


### PR DESCRIPTION
Refer to: http://jira.cubrid.org/browse/CUBRIDQA-1254

### 변경 사항

**1. 버퍼 힙 할당으로 전환**

Before:
```
static char buff[DBMS_OUTPUT_BUFFER_SIZE];
```
After:
```
+ char *buff = malloc(buf_size);
  size_t buf_size = DBMS_OUTPUT_BUFFER_SIZE;
```
- 정적 배열 대신 malloc으로 초기 버퍼 확보

**2. on‑demand realloc 적용**

```
size_t need = (p - buff) + ind + 2;  // 추가할 문자열 + '\n' + '\0'
if (need > buf_size) {
  size_t new_size = buf_size;
  while (new_size < need && new_size < MAX_DBMS_OUTPUT_BUFFER_SIZE)
    new_size *= 2;
  buff = realloc(buff, new_size);
  buf_size = new_size;
  p = buff + offset;
}
```
- 필요할 때만 버퍼 크기를 두 배로 늘려 오버플로우 방지
- MAX_DBMS_OUTPUT_BUFFER_SIZE로 상한 설정

**3. snprintf로 안전한 쓰기 보장**
`int written = snprintf(p, buf_size - (p - buff), "%s\n", str);`
 - 남은 공간만큼만 기록하여 경계 밖 덮어쓰기 방지
-  잘림 시 written >= remaining 조건으로 경고 출력

**4. 오류 경로에서 메모리 해제**

- malloc/realloc 후 에러 발생 시 free(buff) 호출
- 성공 시 호출자에서 free() 책임으로 메모리 누수 방지

**5. 새 상수 추가**
`#define MAX_DBMS_OUTPUT_BUFFER_SIZE  (1024 * 1024)  // 1 MB 상한`
