### PR TITLE
[CUBRIDQA-1276] Add a value for the QA Scenario field

### DIFF
--- a/CTP/common/tpl/issue_create.tpl
+++ b/CTP/common/tpl/issue_create.tpl
@@ -10,6 +10,7 @@
 	   "summary": "[Regression] #JSON_TPL_ISSUE_SUMMARY_INFO#",
 	   "components":[{"name":"CUBRID"}],
 	   "versions": [{"name":"#JSON_TPL_AFFECT_VERSION#"}],
+           "customfield_210565": {"value":"Not Required"},
 	   "description": "#JSON_TPL_CALL_STACK_INFO#"
 	}
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1276

현상 : core report 화면에서 jira 이슈 생성시 에러 
원인 : jira 에 추가되었던 "QA Scenario" 필수 커스텀 필드에 대한 정보 누락 
수정 : 해당 필드와 값에 대한 정보를 추가 

* 자세한 내용은 이슈 참고