### PR TITLE
[APIS-1028] The JDBC function 'getObject' doesn't support oracle_compat_number_be…

### DIFF
--- a/CTP/sql/configuration/test_config/test_default.xml
+++ b/CTP/sql/configuration/test_config/test_default.xml
@@ -15,6 +15,7 @@
     <add_debug_hint>false</add_debug_hint>
     <need_xml_summary>true</need_xml_summary>
     <!--<url_properties>useSSL=true</url_properties> -->
+    <!--<oracle_compat_number>off</oracle_compat_number> -->
    <reset>
        <!-- <item>SET NAMES utf8</item>-->
        <item>SET SYSTEM PARAMETERS 'add_column_update_hard_default=default'</item>

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Test.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Test.java
@@ -51,6 +51,8 @@ public class Test {
 
     public static String urlProperties = "";
 
+    public static String oracleCompatNumber = "";
+
     private String testId;
 
     private String caseFilter;
@@ -139,6 +141,14 @@ public class Test {
 
     public void setUrlProperties(String urlProperties) {
         this.urlProperties = urlProperties;
+    }
+
+    public String getOracleCompatNumber() {
+        return oracleCompatNumber;
+    }
+
+    public void setOracleCompatNumber(String oracleCompatNumber) {
+        this.oracleCompatNumber = oracleCompatNumber;
     }
 
     public boolean isNeedDebugHint() {

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -515,9 +515,15 @@ public class ConsoleDAO extends Executor {
                     if (paramType == null) {
                         continue;
                     }
+
                     if (paramType.indexOf("OUT") != -1) {
                         Object o = ps.getObject(index);
-                        sb.append(o + System.getProperty("line.separator"));
+                        if ( isNumeric(o != null ? o.toString() : "")) {
+                            String s = ps.getString(index);
+                            sb.append(s + System.getProperty("line.separator"));
+                        } else {
+                            sb.append(o + System.getProperty("line.separator"));
+                        }
                         param.setValue(o);
                     }
                 }
@@ -567,7 +573,7 @@ public class ConsoleDAO extends Executor {
                                 case Types.CHAR:
                                     ps.setString(index, (String) value);
                                     break;
-                                case Types.VARCHAR:
+                                case Types.VARCHAR: 
                                     ps.setString(index, (String) value);
                                     break;
                                     // case Types.NCHAR:
@@ -878,11 +884,19 @@ public class ConsoleDAO extends Executor {
 
             while (rs.next()) {
                 for (int i = 0; i < columnCount; i++) {
+                    String value;
+                    Object data; 
                     int index = i + 1;
                     String columnTypeName = meta.getColumnTypeName(index);
                     int columnType = meta.getColumnType(index);
-                    Object data = rs.getObject(index);
-                    String value = getColumnValue(columnType, columnTypeName, data, rs, index);
+                    data = rs.getObject(index);
+                    if ( columnType == Types.DOUBLE || 
+                         columnType == Types.REAL || 
+                         (columnType == Types.OTHER && isNumeric(data != null ? data.toString() : ""))) {
+                        value = rs.getString(index);
+                    } else {
+                        value = getColumnValue(columnType, columnTypeName, data, rs, index);
+                    }
                     ret.append(value + "     ");
                 }
                 ret.append(System.getProperty("line.separator"));
@@ -917,6 +931,15 @@ public class ConsoleDAO extends Executor {
             sql.setResult(sql.getResult() + ret.toString() + System.getProperty("line.separator"));
         }
     }
+
+     private Boolean isNumeric(String str) {
+            try {
+                Double.parseDouble(str);
+                return true;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+     }
 
     /**
      * @Title: getColumnValue @Description:Get every column's result.

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -518,7 +518,7 @@ public class ConsoleDAO extends Executor {
 
                     if (paramType.indexOf("OUT") != -1) {
                         Object o = ps.getObject(index);
-                        if ( isNumeric(o != null ? o.toString() : "")) {
+                        if ( Test.oracleCompatNumber.equals("on") && isNumeric(o != null ? o.toString() : "")) {
                             String s = ps.getString(index);
                             sb.append(s + System.getProperty("line.separator"));
                         } else {
@@ -890,9 +890,10 @@ public class ConsoleDAO extends Executor {
                     String columnTypeName = meta.getColumnTypeName(index);
                     int columnType = meta.getColumnType(index);
                     data = rs.getObject(index);
-                    if ( columnType == Types.DOUBLE || 
+                    if ( Test.oracleCompatNumber.equals("on") && 
+                         (columnType == Types.DOUBLE || 
                          columnType == Types.REAL || 
-                         (columnType == Types.OTHER && isNumeric(data != null ? data.toString() : ""))) {
+                         (columnType == Types.OTHER && isNumeric(data != null ? data.toString() : "")))) {
                         value = rs.getString(index);
                     } else {
                         value = getColumnValue(columnType, columnTypeName, data, rs, index);

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/PropertiesUtil.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/PropertiesUtil.java
@@ -130,6 +130,12 @@ public class PropertiesUtil {
             val = urlProp.getText();
             test.setUrlProperties(val);
         }
+       List oracle_number = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.ORACLE_COMPAT_NUMBER);
+        if (!oracle_number.isEmpty()) {
+            Element oranum = (Element) oracle_number.get(0);
+            val = oranum.getText();
+            test.setOracleCompatNumber(val);
+        }
 
         List needXmlSummary = root.selectNodes(TestUtil.ROOT_NODE + TestUtil.NEED_XML_SUMMARY);
         if (!needXmlSummary.isEmpty()) {

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/TestUtil.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/util/TestUtil.java
@@ -83,6 +83,8 @@ public class TestUtil {
 
     public static final String URL_PROPERTIES = "url_properties";
 
+    public static final String ORACLE_COMPAT_NUMBER = "oracle_compat_number";
+
     public static final String ADD_DEBUG_HINT = "add_debug_hint";
 
     public static final String NEED_XML_SUMMARY = "need_xml_summary";


### PR DESCRIPTION
…havior setting.
http://jira.cubrid.org/browse/APIS-1028

getObject 가 double, float 에 대해 oracle_compat_number_behavior 설정을 지원하지 않아 
최대한 가능한 조건에서 getString 함수를 사용하도록 수정합니다. 
oracle_compat_number_behavior 과 관련한 조건 처리를 추가하지 않았기 때문에 
미설정상태에서도 위 조건에 따른 getString 으로 동작합니다.  