### PR TITLE
[CUBRIDQA-1281] Add to get_cubrid_port_id function for shell test

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -80,7 +80,7 @@ function get_cubrid_port_id(){
     if [ "${port_id}" = "" ]
     then
         echo "1523"
-	else
+    else
         echo "${port_id}"
     fi
 }

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -77,12 +77,12 @@ function get_broker_port_from_shell_config
 
 function get_cubrid_port_id(){
     local port_id=`grep -i "cubrid_port_id" $CUBRID/conf/cubrid.conf | awk -F '=' '{print $2}'`
-	if [ "${port_id}" = "" ]
-	then
-	    echo "1523"
+    if [ "${port_id}" = "" ]
+    then
+        echo "1523"
 	else
-		echo "${port_id}"
-	fi
+        echo "${port_id}"
+    fi
 }
 
 # This function is not recommended.

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -76,7 +76,7 @@ function get_broker_port_from_shell_config
 }
 
 function get_cubrid_port_id(){
-    local port_id=`grep -i "cubrid_port_id" $CUBRID/conf/cubrid.conf | awk -F '=' '{print $2}'`
+    local port_id=`ini.sh -s "common" $CUBRID/conf/cubrid.conf cubrid_port_id`
     if [ "${port_id}" = "" ]
     then
         echo "1523"

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -75,6 +75,11 @@ function get_broker_port_from_shell_config
   echo $port
 }
 
+function get_cubrid_port_id(){
+    local port_id=`grep "cubrid_port_id" $CUBRID/conf/cubrid.conf | awk -F '=' '{print $2}'`
+    echo "${port_id}"
+}
+
 # This function is not recommended.
 # It is used to get another available port. 
 function generate_port {

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -77,7 +77,12 @@ function get_broker_port_from_shell_config
 
 function get_cubrid_port_id(){
     local port_id=`grep "cubrid_port_id" $CUBRID/conf/cubrid.conf | awk -F '=' '{print $2}'`
-    echo "${port_id}"
+	if [ "${port_id}" = "" ]
+	then
+	    echo "1523"
+	else
+		echo "${port_id}"
+	fi
 }
 
 # This function is not recommended.

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -76,7 +76,7 @@ function get_broker_port_from_shell_config
 }
 
 function get_cubrid_port_id(){
-    local port_id=`grep "cubrid_port_id" $CUBRID/conf/cubrid.conf | awk -F '=' '{print $2}'`
+    local port_id=`grep -i "cubrid_port_id" $CUBRID/conf/cubrid.conf | awk -F '=' '{print $2}'`
 	if [ "${port_id}" = "" ]
 	then
 	    echo "1523"


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CUBRIDQA-1281, https://github.com/CUBRID/cubrid-testcases-private-ex/pull/2747#issuecomment-3026592641

cubrid.conf에서 cubrid_port_id를 가져올 수 있는 function을 추가합니다.