### PR TITLE
[CUBRIDQA-1243]decrease retry num for stabilize circleci print timeout

### DIFF
--- a/CTP/conf/shell_ci.conf
+++ b/CTP/conf/shell_ci.conf
@@ -77,7 +77,7 @@ testcase_exclude_from_file=${HOME}/cubrid-testcases-private-ex/shell/config/dail
 
 # Define the max retry count for the failed case, when the case testing is failed, CTP will repeat to execute the failed case, 
 # and once it's PASS during retry process, CTP will stop retry and start to execute the next case. 
-testcase_retry_num=3
+testcase_retry_num=2
 
 # Define the max timeout time (unit: second) for each case
 testcase_timeout_in_secs=720


### PR DESCRIPTION
재수행 횟수를 3-> 2로 조정.
실패시 총 3번 수행 (1회 +2 회) 
최악의 케이스: timeout 으로 인한 실패 (720sec + 100sec) * 3회 = 45분가량 소요