### PR TITLE
[CUBRIDQA-1279] add circleci pod index on test result log.

### DIFF
--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
@@ -39,7 +39,12 @@ public class ShellHelper {
 	public final static String getTestNodeTitle(Context context, String envId, String host) {
 		String title;
 		if (context.isExecuteAtLocal()) {
-			title = "local";
+			String circleNodeIndex = System.getenv("CIRCLE_NODE_INDEX");
+			if (circleNodeIndex != null && !circleNodeIndex.trim().isEmpty()) {
+				title = circleNodeIndex;
+			} else {
+				title = "local";
+			}
 		} else {
 			String port = context.getInstanceProperty(envId, ConfigParameterConstants.TEST_INSTANCE_PORT_SUFFIX);
 			String user = context.getInstanceProperty(envId, ConfigParameterConstants.TEST_INSTANCE_USER_SUFFIX);

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
@@ -41,7 +41,7 @@ public class ShellHelper {
 		if (context.isExecuteAtLocal()) {
 			String circleNodeIndex = System.getenv("CIRCLE_NODE_INDEX");
 			if (circleNodeIndex != null && !circleNodeIndex.trim().isEmpty()) {
-				title = circleNodeIndex;
+				title = "parallel-"+circleNodeIndex;
 			} else {
 				title = "local";
 			}

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
@@ -41,7 +41,7 @@ public class ShellHelper {
 		if (context.isExecuteAtLocal()) {
 			String circleNodeIndex = System.getenv("CIRCLE_NODE_INDEX");
 			if (circleNodeIndex != null && !circleNodeIndex.trim().isEmpty()) {
-				title = "parallel-"+circleNodeIndex;
+				title = "parallel-" + circleNodeIndex;
 			} else {
 				title = "local";
 			}


### PR DESCRIPTION
circleci Tests 탭의 fail 된 케이스가 나오지만 로그와 매칭시키기 어려움.
이를 해소하기 위해 인덱스를 의미하는 CIRCLE_NODE_INDEX 환경변수값이 있으면 해당값을 출력하도록 수정.

regression 에 경우 [user@ip:port] 와 같이 수행된 환경정보가 출력됨.
local 수행인 경우 [local] 로 값을 지정하도록 되어있음.

기존 : [NOK]:  cubrid-testcases-private-ex/shell/_04_misc/_04_index/itrack_10001/cases/itrack_10001.sh 738472 EnvId=local[local]

변경후 : [NOK]:  cubrid-testcases-private-ex/shell/_04_misc/_04_index/itrack_10001/cases/itrack_10001.sh 738472 EnvId=local[paralle-1]

이는 로컬수행 (circleci 는 로컬수행으로동작)시에만 영향을 미치므로 regression 에는 영향 없음.