### PR TITLE
Revert "Revert "[CUBRIDQA-1287] Set basicdb Charset to UTF-8 for CUBRID 11.5 and Above in do_configure""

### DIFF
--- a/CTP/sql/bin/run.sh
+++ b/CTP/sql/bin/run.sh
@@ -667,15 +667,20 @@ function do_configure()
      curDir=`pwd`
      #get charset config
      db_charset=`ini -s sql ${config_file_main} db_charset`
-     if [ -z "$db_charset" ];then
-     	if [ $cubrid_ver_p1 -ge 10 ] && [ "$scenario_category" == "site" ]
-     	then
-  		db_charset="ko_KR.euckr"
-     	else
-  		db_charset="en_US.iso88591"
+     if [ -z "$db_charset" ] || [ "$db_charset" = "en_US" ];then
+          if [ $cubrid_ver_p1 -ge 10 ] && [ "$scenario_category" == "site" ]
+          then
+               db_charset="ko_KR.euckr"
+          else
+               if [ $cubrid_ver_p1 -ge 11 ] && [ $cubrid_ver_p2 -ge 5 ] && [ "$scenario_category" = "sql" -o "$scenario_category" = "sql_by_cci" ]
+               then
+                    db_charset="en_US.utf8"
+               else
+                    db_charset="en_US.iso88591"
+               fi
           fi
-     fi 
-     
+     fi
+
      LD_LIBRARY_PATH=$LD_LIBRARY_PATH
   
      java_version=`file $JAVA_HOME/bin/java|grep 64-bit|wc -l`


### PR DESCRIPTION
매뉴얼 테스트를 위해 charset변경 부분을 다시 적용합니다. 