### PR TITLE
[CUBRIDQA-1287] Set basicdb Charset to UTF-8 for CUBRID 11.5 and Above in do_configure

### DIFF
--- a/CTP/sql/bin/run.sh
+++ b/CTP/sql/bin/run.sh
@@ -679,7 +679,7 @@ function do_configure()
      # [CUBRIDQA-1287] Change the charset of the 'basic' database used in SQL tests
      # from iso88591 to utf8 starting from version 11.5+
      if [ "${scenario_category}" = "sql" ] || [ "${scenario_category}" = "sql_by_cci" ]; then
-        if [ $cubrid_ver_p1 -gt 11 ] || { [ $cubrid_ver_p1 -eq 11 ] && [ $cubrid_ver_p2 -ge 5 ]; }; then
+        if [ "${cubrid_ver_p1}" -gt 11 ] || { [ "${cubrid_ver_p1}" -eq 11 ] && [ "${cubrid_ver_p2}" -ge 5 ]; }; then
            db_charset="en_US.utf8"
         fi
      fi

--- a/CTP/sql/bin/run.sh
+++ b/CTP/sql/bin/run.sh
@@ -673,9 +673,17 @@ function do_configure()
   		db_charset="ko_KR.euckr"
      	else
   		db_charset="en_US.iso88591"
-          fi
+        fi
      fi 
-     
+
+     # [CUBRIDQA-1287] Change the charset of the 'basic' database used in SQL tests
+     # from iso88591 to utf8 starting from version 11.5+
+     if [ "${scenario_category}" = "sql" ] || [ "${scenario_category}" = "sql_by_cci" ]; then
+        if [ $cubrid_ver_p1 -gt 11 ] || { [ $cubrid_ver_p1 -eq 11 ] && [ $cubrid_ver_p2 -ge 5 ]; }; then
+           db_charset="en_US.utf8"
+        fi
+     fi
+
      LD_LIBRARY_PATH=$LD_LIBRARY_PATH
   
      java_version=`file $JAVA_HOME/bin/java|grep 64-bit|wc -l`


### PR DESCRIPTION
sql test시 큐브리드 버전이 11.5+ 일 때, 데이터베이스 'basic' 의 charset이 utf8로 생성되도록 수정합니다.