### PR TITLE
[CBRD-26220] Filter Deprecated java_stored_procedure Parameter for 11.5 and Above

### DIFF
--- a/CTP/sql/bin/run.sh
+++ b/CTP/sql/bin/run.sh
@@ -302,6 +302,15 @@ function config_cubrid_without_ha()
 {
      build_ver_type=""
      cubrid_conf_para=`ini -s "sql/cubrid.conf" --separator="||" ${config_file_main}`
+
+     # [CBRD-26220] In CUBRID 11.5+, the java_stored_procedure parameters are identical to PL,
+     # no longer documented, and marked as DEPRECATED. 
+     # Therefore, they are filtered out in CTP for 11.5+.
+     if [ "${cubrid_ver_p1}" -gt 11 ] || { [ "${cubrid_ver_p1}" -eq 11 ] && [ "${cubrid_ver_p2}" -ge 5 ]; }; then
+        echo "Filtering out deprecated parameters for CUBRID 11.5+"
+        cubrid_conf_para=`echo "$cubrid_conf_para" | sed 's/java_stored_procedure=[^|]*||*//g' | sed 's/||*$//'`
+     fi
+
      if [ "$cubrid_conf_para" ];then
      	ini -s common -u "${cubrid_conf_para}" $CUBRID/conf/cubrid.conf
      fi


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-26220

java_stored_procedure 관련 파라미터들은 pl과 동작이 동일하고, 더 이상 매뉴얼에서도 언급하지 않으므로 DEPRECATED 속성이 부여되었습니다.
여전히 CTP에서는 java_stored_procedure 를 사용한 conf 파일들이 존재하기 때문에 
`The 'java_stored_procedure' parameter at line 55 in file '/home/CUBRID/conf/cubrid.conf' : Deprecated parameter`
에러가 발생합니다.

11.5 이후 엔진에서는 conf 파일에 ` java_stored_procedure = yes `가 포함되지 않도록 CTP를 수정합니다.
 
