### PR TITLE
[CUBRIDQA-1303] Now $CUBRID/log is emptied when executing each test case

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -724,7 +724,7 @@ function init
   fi
   export CUBRID_BITS
   
-  rm $CUBRID/log/* > /dev/null 2>&1
+  rm -rf $CUBRID/log/* > /dev/null 2>&1
 
   if [ $OS = "AIX" ];then
   	cp $init_path/commonforjdbc_aix.jar $init_path/commonforjdbc.jar


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CUBRIDQA-1303

init.sh의 init()에 관련 코드가 있으나, 제대로 동작하지 않았던 것 같습니다.
이에 -rf 옵션을 추가합니다.