### PR TITLE
[CUBRIDQA-1306] Setting environment variables to build cubrid 10.1 in rocky 8

### DIFF
--- a/CTP/common/script/run_cubrid_install
+++ b/CTP/common/script/run_cubrid_install
@@ -522,6 +522,10 @@ function BuildAndInstallForUnitTest()
           sh build.sh ${configure_options}
         )
     else
+        #http://jira.cubrid.org/browse/CUBRIDQA-1306
+        export CC=$HOME/gcc-4.8.5/bin/gcc
+        export CXX=$HOME/gcc-4.8.5/bin/g++
+
         sh build.sh ${configure_options}
     fi
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1306

rocky 8 의 기본 gcc 버전 8 은 unittest 에서 cubrid 10.1 버전 빌드시 실패하는 문제를 수정합니다. 

해당 경우 gcc 4.8.5 버전으로 빌드되도록 환경 변수를 추가합니다. 
설치 파일 gcc 4.8.5 는 https://github.com/CUBRID/cubrid-testtools-internal/pull/494 에서 추가합니다. 