### PR TITLE
[CUBRIDQA-1308] Added an option to exclude child process logging.

### DIFF
--- a/CTP/sql/memory/cub_server.c
+++ b/CTP/sql/memory/cub_server.c
@@ -75,6 +75,7 @@ main (int argc, char *argv[])
   //const char *option4 = "--expensive-definedness-checks=yes";
   const char *option5 = "--track-origins=yes";
   const char *option6 = "--num-callers=30"; 
+  const char *option7 = "--child-silent-after-fork=yes";
   char *option4 = NULL;
   option4 = getenv ("TIME_OPTION");
   if (option4 == NULL)
@@ -100,7 +101,7 @@ main (int argc, char *argv[])
     return -1;
 
   sprintf (server_exe_path, "%s/bin/server.exe", p);
-  execl (valgrind_path, valgrind_path, log_file, default_sup, option2, option3, option4, option5, option6, server_exe_path, argv[1], NULL);
+  execl (valgrind_path, valgrind_path, log_file, default_sup, option2, option3, option4, option5, option6, option7, server_exe_path, argv[1], NULL);
 
   if (valgrind_out_dir != NULL)
     free (valgrind_out_dir);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1308

cub_pl 등 자식 프로세스가 valgrind 로깅이 되는 경우가 간헐적 발생하여 
이를 차단하는 추가 옵션을 적용합니다. 