### PR TITLE
[CUBRIDQA-1314] add ENV_ keyword on manualtest job sender module.

### DIFF
--- a/CTP/common/sched/src/com/navercorp/cubridqa/scheduler/producer/ManualSender.java
+++ b/CTP/common/sched/src/com/navercorp/cubridqa/scheduler/producer/ManualSender.java
@@ -325,7 +325,7 @@ public class ManualSender {
 
 	private static void showHelp() {
 		System.out
-				.println("Usage: java com.navercorp.cubridqa.scheduler.producer.ManualSender <queue> <url1,url2,...> <scenario> <priority> [compat_file|-i18nAll|-dbimgAll|-compatAll] [PROPS:MKEY_TEST1=v1;MKEY_TEST2=v2]");
+				.println("Usage: java com.navercorp.cubridqa.scheduler.producer.ManualSender <queue> <url1,url2,...> <scenario> <priority> [compat_file|-i18nAll|-dbimgAll|-compatAll] [PROPS:MKEY_TEST1=v1;MKEY_TEST2=v2|ENV_TEST1=v1;ENV_TEST2=v2]");
 		System.out.println();
 	}
 

--- a/CTP/common/sched/src/com/navercorp/cubridqa/scheduler/producer/crontab/CUBJob.java
+++ b/CTP/common/sched/src/com/navercorp/cubridqa/scheduler/producer/crontab/CUBJob.java
@@ -193,7 +193,7 @@ public class CUBJob implements Job {
 		while (it.hasNext()) {
 			key = it.next().trim();
 			value = testProps.getProperty(key);
-			if (key.startsWith("MKEY_")) {
+			if (key.startsWith("MKEY_") || key.startsWith("ENV_")) {
 				msgProps.put(key, value);
 			}
 		}


### PR DESCRIPTION
큐를 전송하는 방식에는 세가지가 있다. 

구분 | MKEY_ 지원 | ENV_ 지원 | 용도 | 비고
-- | -- | -- | -- | --
ManualSender | ✅ | ✅ | regression 재수행 (sender.sh) |이미 모든 속성 처리 가능
일반 Producer (FileProcess) | ✅ | ✅ | regression 수행 (job.conf) | additionalProps로 전달 가능 (별도 용도)
BuildMain/CUBJob | ✅ | ❌→✅ | manual test 수행 (manual_job.conf) | 수정하여 지원가능

manualt test 수행을 지원하기 위한 java 코드 수정.