### PR TITLE
[CUBRIDQA-1314] support grepo update logic and isoltion test worker node CTP update.

### DIFF
--- a/CTP/common/script/start_consumer.sh
+++ b/CTP/common/script/start_consumer.sh
@@ -139,6 +139,18 @@ function updateCodes()
 { 
     curDir=`pwd`
     branchName=$1
+    
+    # Check branch change and remove cache if needed
+    branchMarkerFile="${CTP_HOME}/.dailyqa/.current_branch"
+    if [ -f "$branchMarkerFile" ]; then
+        currentBranch=`cat $branchMarkerFile`
+        if [ "$currentBranch" != "$branchName" ]; then
+            localBranchName=`echo $branchName|sed 's#/#_#g'`
+            cacheFile="${CTP_HOME}/.dailyqa/cubrid-testtools_${localBranchName}_CTP.zip"
+            [ -f "$cacheFile" ] && rm -f "$cacheFile" && echo "Branch changed: $currentBranch -> $branchName (cache removed)"
+        fi
+    fi
+    
     changedCount=`cd ${CTP_HOME}; run_grepo_fetch -r cubrid-testtools -b "$branchName" -p "CTP" -e "conf" --check-only . | grep "fetch" | grep CHANGED | wc -l`
         
     if [ "$changedCount" -gt "0" ]
@@ -369,6 +381,7 @@ do
 		then
 			echo "Action: $x, ${q_exec[$count]}.sh, CONTINUE"
 			# Update CTP if ENV_CTP_BRANCH_NAME is set in continue mode
+			tempBranchContinue=""
 			if [ $withoutSync -ne 1 ]
 			then
 				source ${CTP_HOME}/common/sched/init.sh $ser_site
@@ -376,6 +389,7 @@ do
 				then
 					echo "ENV_CTP_BRANCH_NAME detected: $CTP_BRANCH_NAME (updating from $branchName)"
 					updateCodes $CTP_BRANCH_NAME
+					tempBranchContinue="$branchName"
 				fi
 			fi
 			(cd ${CTP_HOME}; export BUILD_IS_FROM_GIT=$isFromGit ;source ${CTP_HOME}/common/sched/init.sh $ser_site;sh common/ext/${q_exec[$count]}.sh YES)
@@ -383,6 +397,10 @@ do
 			echo
             echo "End continue mode test!"
 			consumerTimer ${existsMsgId} "stop"
+			
+			# Restore original branch if temp branch was used
+			[ -n "$tempBranchContinue" ] && updateCodes $tempBranchContinue
+			
 			contimeENDTIME=`getTimeStamp`
 			echo "END_CONTINUE_TIME:${contimeENDTIME}"
 			echo '' > ${CTP_HOME}/common/sched/status/${x}
@@ -393,6 +411,7 @@ do
 		hasTestBuild
 		
 		#update client again if ENV_CTP_BRANCH_NAME is set in message
+		tempBranch=""
 		if [ "$hasBuild" == "true" ] && [ $withoutSync -ne 1 ]
 		then
 			source ${CTP_HOME}/common/sched/init.sh $ser_site
@@ -400,6 +419,7 @@ do
 			then
 				echo "ENV_CTP_BRANCH_NAME detected: $CTP_BRANCH_NAME (updating from $branchName)"
 				updateCodes $CTP_BRANCH_NAME
+				tempBranch="$branchName"
 			fi
 		fi
 		
@@ -439,6 +459,9 @@ do
 				(cd ${CTP_HOME}; source ${CTP_HOME}/common/sched/init.sh $ser_site; sh common/ext/${q_exec[$count]}.sh)
 			
 				consumerTimer $msgId "stop"
+
+				# Restore original branch if temp branch was used
+				[ -n "$tempBranch" ] && updateCodes $tempBranch
 
 				ENDTIME=`getTimeStamp`
 				echo 

--- a/CTP/common/script/upgrade.sh
+++ b/CTP/common/script/upgrade.sh
@@ -47,4 +47,4 @@ mkdir -p ../.ctp
 cp -rf common/lib/* ../.ctp/
 
 export `grep -E "^grepo_service_url" conf/common.conf | tr -d '\r'`
-"$JAVA_HOME/bin/java" -cp ../.ctp/cubridqa-common.jar com.navercorp.cubridqa.common.grepo.UpgradeMain -r cubrid-testtools -b "$branchName" -p "CTP" -e "conf" .; (chmod u+x ./bin/*; chmod u+x ./common/script/*; chmod u+x ./common/ext/*; chmod u+x sql/bin/*; rm -rf ../.ctp >/dev/null 3>&1); echo DONE; cd "${current_user_dir}"; exit
+"$JAVA_HOME/bin/java" -cp ../.ctp/cubridqa-common.jar com.navercorp.cubridqa.common.grepo.UpgradeMain -r cubrid-testtools -b "$branchName" -p "CTP" -e "conf" .; (chmod u+x ./bin/*; chmod u+x ./common/script/*; chmod u+x ./common/ext/*; chmod u+x sql/bin/*; mkdir -p ${dest_tool_dir}/.dailyqa; echo "$branchName" > ${dest_tool_dir}/.dailyqa/.current_branch; rm -rf ../.ctp >/dev/null 3>&1); echo DONE; cd "${current_user_dir}"; exit

--- a/CTP/isolation/src/com/navercorp/cubridqa/isolation/deploy/DeployOneNode.java
+++ b/CTP/isolation/src/com/navercorp/cubridqa/isolation/deploy/DeployOneNode.java
@@ -96,6 +96,8 @@ public class DeployOneNode {
 	}
 
 	public void deploy() {
+		updateCTP();
+		
 		while (true) {
 			if (installCUBRID()) {
 				break;
@@ -106,6 +108,33 @@ public class DeployOneNode {
 		}
 
 		updateCUBRIDConfigurations();
+	}
+	
+	private void updateCTP() {
+		ShellScriptInput scripts = new ShellScriptInput();
+		scripts.addCommand("cd ${CTP_HOME}/common/script");
+		
+		String ctpBranchName = System.getenv(ConfigParameterConstants.CTP_BRANCH_NAME);
+		if (!CommonUtils.isEmpty(ctpBranchName)) {
+			scripts.addCommand("export CTP_BRANCH_NAME=" + ctpBranchName);
+		}
+		
+		String skipUpgrade = System.getenv(ConfigParameterConstants.CTP_SKIP_UPDATE);
+		if (!CommonUtils.isEmpty(skipUpgrade)) {
+			scripts.addCommand("export CTP_SKIP_UPDATE=" + skipUpgrade);
+		}
+		scripts.addCommand("chmod u+x upgrade.sh");
+		scripts.addCommand("./upgrade.sh");
+		
+		String result;
+		try {
+			log.print("==> Begin to update CTP:");
+			result = ssh.execute(scripts);
+			log.println(result);
+			log.print("DONE.");
+		} catch (Exception e) {
+			log.print("[ERROR] Fail to update CTP: " + e.getMessage());
+		}
 	}
 
 	private void updateCUBRIDConfigurations() {


### PR DESCRIPTION
## 📋 적용 내용 - 간략 요약

### 🎯 목적
임시 브랜치로 테스트 후 자동 원복

### 🔧 핵심 메커니즘

**추적 파일**: `$HOME/CTP/.dailyqa/.current_branch` - 현재 브랜치 저장
**캐시 파일**: `$HOME/CTP/.dailyqa/cubrid-testtools_[branch]_CTP.zip` - 브랜치별 캐시

### 📊 동작 흐름

#### 평상시 (develop)
```
.current_branch: "develop"
요청: "develop" 
→ 브랜치 같음 → 캐시 유지 → SHA1 비교만 수행
```

#### 임시 브랜치 테스트
```
[전환]
.current_branch: "develop"
메시지: ENV_CTP_BRANCH_NAME=feature/xxx
→ 브랜치 다름 → feature 캐시 삭제 → 서버에서 다운로드 → 배포
→ .current_branch: "feature/xxx" 기록
→ tempBranch="develop" 저장

[테스트 실행]
feature/xxx 코드로 테스트

[자동 원복]
테스트 종료 → updateCodes("develop") 호출
→ develop 캐시 삭제 → 다운로드 → 배포
→ .current_branch: "develop" 기록
```

### 🔑 핵심 로직

**브랜치 변경 시**: 캐시 삭제 → grepo가 강제 다운로드
**테스트 후**: 원래 브랜치로 자동 복귀
