### PR TITLE
[CBRD-26096] Update ha_repl to support REPLICATION ON/OFF settings

### DIFF
--- a/CTP/ha_repl/lib/common.inc
+++ b/CTP/ha_repl/lib/common.inc
@@ -15,7 +15,7 @@ HC_CHECK_FOR_EACH_STATEMENT_10=select 'db_attr_setdomain_elm' TABLE_NAME, db_att
 HC_CHECK_FOR_EACH_STATEMENT_11=select 'db_attribute' TABLE_NAME, db_attribute.* from db_attribute order by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
 HC_CHECK_FOR_EACH_STATEMENT_12=select 'db_vclass' TABLE_NAME, db_vclass.* from db_vclass order by 1,2,3,4;
 HC_CHECK_FOR_EACH_STATEMENT_13=select 'db_direct_super_class' TABLE_NAME, db_direct_super_class.* from db_direct_super_class order by 1,2;
-HC_CHECK_FOR_EACH_STATEMENT_14=select 'db_class' TABLE_NAME, class_name, owner_name, class_type, is_system_class, tde_algorithm, statistics_strategy, partitioned, is_reuse_oid_class, collation, comment from db_class order by 1,2,3,4,5,6,7,8,9,10;
+HC_CHECK_FOR_EACH_STATEMENT_14=select 'db_class' TABLE_NAME, class_name, owner_name, class_type, is_system_class, is_replication_class, tde_algorithm, statistics_strategy, partitioned, is_reuse_oid_class, collation, comment from db_class order by 1,2,3,4,5,6,7,8,9,10,11,12;
 HC_CHECK_FOR_EACH_STATEMENT_15=select '_db_serial' TABLE_NAME, if(owner is null, USER, (select name from db_user where db_user=owner)) owner, _db_serial.name, _db_serial.current_val, _db_serial.increment_val, _db_serial.max_val, _db_serial.min_val, _db_serial.start_val, _db_serial.cyclic, _db_serial.started, _db_serial.class_name, _db_serial.attr_name, _db_serial.cached_num, _db_serial.comment from _db_serial;
 HC_CHECK_FOR_EACH_STATEMENT_16=select '_db_collation' TABLE_NAME, _db_collation.* from _db_collation order by 1,2,3,4,5,6,7,8,9;
 HC_CHECK_FOR_EACH_STATEMENT_17=select '_db_data_type' TABLE_NAME, _db_data_type.* from _db_data_type order by 1,2,3;

--- a/CTP/ha_repl/src/com/navercorp/cubridqa/ha_repl/Test.java
+++ b/CTP/ha_repl/src/com/navercorp/cubridqa/ha_repl/Test.java
@@ -79,7 +79,7 @@ public class Test {
                 // Select common.inc by version:
                 // <= 11.3 -> common.inc.legacy
                 // == 11.4 -> common.inc.114 (CUBRIDQA-1244)
-                // >= 11.5 -> common.inc (CBRD-25862)
+                // >= 11.5 -> common.inc (CBRD-25862, CBRD-26096)
                 String commonIncFile;
                 int major = Integer.parseInt(versionParts[0]);
                 int minor = Integer.parseInt(versionParts[1]);

--- a/CTP/ha_repl/src/com/navercorp/cubridqa/ha_repl/Test.java
+++ b/CTP/ha_repl/src/com/navercorp/cubridqa/ha_repl/Test.java
@@ -25,6 +25,9 @@
 package com.navercorp.cubridqa.ha_repl;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -62,6 +65,7 @@ public class Test {
 	boolean testCompleted;
 	String currentTestFile;
 	Context context;
+	ArrayList<String> replicationTablesForCurrentTest = new ArrayList<String>();
 
 	public Test(Context context, String envId) throws Exception {
 		this.context = context;
@@ -147,6 +151,7 @@ public class Test {
 
 	private void executeTest(File f) {
 		this.currentTestFile = f.getAbsolutePath();
+		this.replicationTablesForCurrentTest = loadReplicationTableList();
 		
 		//do clean
 		ArrayList<SSHConnect> allNodeList = hostManager.getAllNodeList();
@@ -595,6 +600,87 @@ public class Test {
 			this.fail100List.add(info);
 	}
 
+	private ArrayList<String> loadReplicationTableList() {
+		ArrayList<String> tables = new ArrayList<String>();
+		File tableFile = new File(this.currentTestFile + ".repl_table");
+		if (!tableFile.exists()) {
+			return tables;
+		}
+
+		FileInputStream fis = null;
+		InputStreamReader reader = null;
+		LineNumberReader lineReader = null;
+		try {
+			fis = new FileInputStream(tableFile);
+			reader = new InputStreamReader(fis, "UTF-8");
+			lineReader = new LineNumberReader(reader);
+			String line = null;
+			while ((line = lineReader.readLine()) != null) {
+				line = line.trim();
+				if (line.length() == 0) {
+					continue;
+				}
+				boolean duplicated = false;
+				for (String tableName : tables) {
+					if (tableName.equalsIgnoreCase(line)) {
+						duplicated = true;
+						break;
+					}
+				}
+				if (!duplicated) {
+					tables.add(line);
+				}
+			}
+		} catch (Exception e) {
+			mlog.println("fail to read replication table list: " + e.getMessage());
+		} finally {
+			try {
+				if (lineReader != null) {
+					lineReader.close();
+				}
+			} catch (Exception e) {
+			}
+			try {
+				if (reader != null) {
+					reader.close();
+				}
+			} catch (Exception e) {
+			}
+			try {
+				if (fis != null) {
+					fis.close();
+				}
+			} catch (Exception e) {
+			}
+		}
+		if (tableFile.exists()) {
+			tableFile.delete();
+		}
+		return tables;
+	}
+
+	private String escapeSqlLiteral(String input) {
+		if (input == null) {
+			return "";
+		}
+		return CommonUtils.replace(input, "'", "''");
+	}
+
+	private void mergeTableInfo(ArrayList<String[]> target, ArrayList<String[]> source) {
+		for (String[] candidate : source) {
+			boolean exists = false;
+			for (String[] current : target) {
+				if (current[0].equalsIgnoreCase(candidate[0])) {
+					exists = true;
+					break;
+				}
+			}
+			if (!exists) {
+				target.add(candidate);
+			}
+		}
+	}
+
 	private ArrayList<String> getCheckSQLForDML() throws Exception {
 		SSHConnect ssh = hostManager.getHost("master");
 		String script = "cd $CUBRID;";
@@ -604,6 +690,28 @@ public class Test {
 		GeneralScriptInput csql = new GeneralScriptInput(script);
 		String tablesResult = ssh.execute(csql);
 		ArrayList<String[]> tablesToBeVerified = HaReplUtils.extractTableToBeVerified(tablesResult, "FIND_PK_CLASS");
+		ArrayList<String> replicationTables = this.replicationTablesForCurrentTest;
+		if (replicationTables.size() > 0) {
+			StringBuffer inClause = new StringBuffer();
+			for (int i = 0; i < replicationTables.size(); i++) {
+				if (i > 0) {
+					inClause.append(",");
+				}
+				inClause.append("'").append(escapeSqlLiteral(replicationTables.get(i).toLowerCase())).append("'");
+			}
+
+			String replScript = "cd $CUBRID;";
+			replScript += "csql -u dba "
+					+ hostManager.getTestDb()
+					+ " -c \"select 'FIND'||'_'||'REPL_CLASS', class_name, count(*) from db_attribute where lower(class_name) in ("
+					+ inClause.toString()
+					+ ") group by class_name;\" | grep 'FIND_REPL_CLASS' ";
+			GeneralScriptInput replCsql = new GeneralScriptInput(replScript);
+			String replTablesResult = ssh.execute(replCsql);
+			ArrayList<String[]> replTablesToBeVerified = HaReplUtils.extractTableToBeVerified(replTablesResult, "FIND_REPL_CLASS");
+			mergeTableInfo(tablesToBeVerified, replTablesToBeVerified);
+		}
+
 		ArrayList<String> result = new ArrayList<String>();
 		if (tablesToBeVerified.size() == 0) {
 			return result;
@@ -1035,3 +1143,4 @@ public class Test {
 		}
 	}
 }
+

--- a/CTP/ha_repl/src/com/navercorp/cubridqa/ha_repl/migrate/SQLFileReader.java
+++ b/CTP/ha_repl/src/com/navercorp/cubridqa/ha_repl/migrate/SQLFileReader.java
@@ -93,9 +93,12 @@ public class SQLFileReader {
 		int countLeftBracket = CountString(startEnumSubString, "(");
 		int countRightBracket = CountString(startEnumSubString, ")");
 		if (countLeftBracket <= countRightBracket && countRightBracket > 0) {
-			String startSubString = line.substring(0, line.toUpperCase().lastIndexOf("'"));
-			String endSubString = line.toUpperCase().substring(line.toUpperCase().lastIndexOf("'")).replaceFirst("\\)", ")  PRIMARY KEY");
-			line = startSubString + endSubString;
+			// Do not add PRIMARY KEY if REPLICATION option exists
+			if (!editLine.hasReplication()) {
+				String startSubString = line.substring(0, line.toUpperCase().lastIndexOf("'"));
+				String endSubString = line.toUpperCase().substring(line.toUpperCase().lastIndexOf("'")).replaceFirst("\\)", ")  PRIMARY KEY");
+				line = startSubString + endSubString;
+			}
 			editLine.setLine(line);
 			editLine.setEnumType(false);
 			editLine.setCreateTableOrClass(false);
@@ -111,11 +114,26 @@ public class SQLFileReader {
 
 	// Edited by cn15209 20120627
 	// add primary key
-	private EditLine editLineForCreateTableOrClass(String line, boolean isCreateTableOrClass, boolean isEnumType) {
+	private EditLine editLineForCreateTableOrClass(String line, boolean isCreateTableOrClass, boolean isEnumType, boolean hasReplication) {
 		EditLine editLine = new EditLine();
 		editLine.setLine(line);
 		editLine.setCreateTableOrClass(isCreateTableOrClass);
 		editLine.setEnumType(isEnumType);
+		editLine.setHasReplication(hasReplication);
+
+		// Check for REPLICATION ON/OFF option
+		String upperLine = line.toUpperCase();
+		if (upperLine.indexOf("REPLICATION ON") >= 0 || upperLine.indexOf("REPLICATION OFF") >= 0) {
+			editLine.setHasReplication(true);
+			editLine.setCreateTableOrClass(false);
+			return editLine;
+		}
+
+		// If REPLICATION option exists, do not add PRIMARY KEY
+		if (hasReplication) {
+			editLine.setCreateTableOrClass(false);
+			return editLine;
+		}
 
 		if (line.toUpperCase().indexOf("PRIMARY KEY") >= 0) {
 			editLine.setCreateTableOrClass(false);
@@ -283,11 +301,13 @@ public class SQLFileReader {
 		private String line = "";
 		private boolean isCreateTableOrClass = false;
 		private boolean isEnumType = false;
+		private boolean hasReplication = false;
 
 		public EditLine() {
 			setLine("");
 			setCreateTableOrClass(false);
 			setEnumType(false);
+			setHasReplication(false);
 		}
 
 		public void setLine(String line) {
@@ -314,6 +334,14 @@ public class SQLFileReader {
 			return isEnumType;
 		}
 
+		public void setHasReplication(boolean hasReplication) {
+			this.hasReplication = hasReplication;
+		}
+
+		public boolean hasReplication() {
+			return hasReplication;
+		}
+
 	}
 
 	public void convert() throws IOException {
@@ -324,6 +352,7 @@ public class SQLFileReader {
 		out.write("--test:" + Constants.LINE_SEPARATOR);
 		boolean isCreateTableOrClass = false;
 		boolean isEnumType = false;
+		boolean hasReplication = false;
 		EditLine editLine = null;
 		HoldCasCheck holdCasCheck;
 		while ((line = lineReader.readLine()) != null) {
@@ -347,10 +376,11 @@ public class SQLFileReader {
 			}
 
 			// edited by cn15209 20120627
-			editLine = editLineForCreateTableOrClass(line, isCreateTableOrClass, isEnumType);
+			editLine = editLineForCreateTableOrClass(line, isCreateTableOrClass, isEnumType, hasReplication);
 			line = editLine.getLine();
 			isCreateTableOrClass = editLine.isCreateTableOrClass();
 			isEnumType = editLine.isEnumType();
+			hasReplication = editLine.hasReplication();
 			lineScanner.scan(line);
 			if (line.endsWith(";")) {
 				if (lineScanner.isInPlcsqlText()) {
@@ -371,9 +401,10 @@ public class SQLFileReader {
 							addCheckPoint();
 						}
 					}
-					isMultipleLine = false;
-					shouldBeDeleted = false;
-					isDML = false;
+				isMultipleLine = false;
+				shouldBeDeleted = false;
+				isDML = false;
+				hasReplication = false;
 				}
 			} else {
 				if (isMultipleLine) {
@@ -500,3 +531,4 @@ public class SQLFileReader {
 
 	}
 }
+

--- a/CTP/ha_repl/src/com/navercorp/cubridqa/ha_repl/migrate/SQLFileReader.java
+++ b/CTP/ha_repl/src/com/navercorp/cubridqa/ha_repl/migrate/SQLFileReader.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.OutputStreamWriter;
+import java.util.ArrayList;
 
 import com.navercorp.cubridqa.common.CommonUtils;
 import com.navercorp.cubridqa.ha_repl.HoldCasCheck;
@@ -45,6 +46,8 @@ public class SQLFileReader {
 
 	OutputStreamWriter out = null;
 	boolean isDML = false;
+	private File replicationTableFile = null;
+	private ArrayList<String> replicationTableList = new ArrayList<String>();
 
 	public SQLFileReader(File file) throws Exception {
 		this.fis = new FileInputStream(file);
@@ -54,6 +57,7 @@ public class SQLFileReader {
 		String outFilename = file.getAbsolutePath();
 		outFilename = outFilename.substring(0, outFilename.lastIndexOf(".")) + ".test";
 		File outFile = new File(outFilename);
+		this.replicationTableFile = new File(outFilename + ".repl_table");
 		if (!outFile.exists()) {
 			try {
 				outFile.createNewFile();
@@ -66,6 +70,79 @@ public class SQLFileReader {
 			out = new OutputStreamWriter(new FileOutputStream(outFile), "UTF-8");
 		} catch (IOException e) {
 			throw new RuntimeException(e);
+		}
+	}
+
+	private String extractCreateTableName(String line) {
+		if (line == null) {
+			return "";
+		}
+		String upperLine = line.toUpperCase();
+		int posCreateTable = upperLine.indexOf("CREATE TABLE");
+		int posCreateClass = upperLine.indexOf("CREATE CLASS");
+		if (posCreateTable < 0 && posCreateClass < 0) {
+			return "";
+		}
+
+		String namePart = line;
+		if (posCreateTable >= 0) {
+			namePart = line.substring(posCreateTable).replaceFirst("(?i)CREATE\\s+TABLE\\s+", "");
+		} else if (posCreateClass >= 0) {
+			namePart = line.substring(posCreateClass).replaceFirst("(?i)CREATE\\s+CLASS\\s+", "");
+		}
+		namePart = namePart.trim();
+		if (namePart.length() == 0) {
+			return "";
+		}
+
+		int end = namePart.length();
+		for (int i = 0; i < namePart.length(); i++) {
+			char c = namePart.charAt(i);
+			if (Character.isWhitespace(c) || c == '(') {
+				end = i;
+				break;
+			}
+		}
+		return namePart.substring(0, end).trim();
+	}
+
+	private void addReplicationTableName(String tableName) {
+		if (tableName == null || tableName.trim().length() == 0) {
+			return;
+		}
+		for (String item : replicationTableList) {
+			if (item.equalsIgnoreCase(tableName.trim())) {
+				return;
+			}
+		}
+		replicationTableList.add(tableName.trim());
+	}
+
+	private void writeReplicationTableList() {
+		if (replicationTableList.size() == 0) {
+			if (replicationTableFile != null && replicationTableFile.exists()) {
+				replicationTableFile.delete();
+			}
+			return;
+		}
+
+		OutputStreamWriter tableWriter = null;
+		try {
+			tableWriter = new OutputStreamWriter(new FileOutputStream(replicationTableFile), "UTF-8");
+			for (String tableName : replicationTableList) {
+				tableWriter.write(tableName);
+				tableWriter.write(Constants.LINE_SEPARATOR);
+			}
+			tableWriter.flush();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		} finally {
+			try {
+				if (tableWriter != null) {
+					tableWriter.close();
+				}
+			} catch (Exception e) {
+			}
 		}
 	}
 
@@ -114,17 +191,25 @@ public class SQLFileReader {
 
 	// Edited by cn15209 20120627
 	// add primary key
-	private EditLine editLineForCreateTableOrClass(String line, boolean isCreateTableOrClass, boolean isEnumType, boolean hasReplication) {
+	private EditLine editLineForCreateTableOrClass(String line, boolean isCreateTableOrClass, boolean isEnumType, boolean hasReplication, String createTableName) {
 		EditLine editLine = new EditLine();
 		editLine.setLine(line);
 		editLine.setCreateTableOrClass(isCreateTableOrClass);
 		editLine.setEnumType(isEnumType);
 		editLine.setHasReplication(hasReplication);
+		editLine.setCreateTableName(createTableName);
 
 		// Check for REPLICATION ON/OFF option
 		String upperLine = line.toUpperCase();
+		if (upperLine.indexOf("CREATE TABLE") >= 0 || upperLine.indexOf("CREATE CLASS") >= 0) {
+			String foundTableName = extractCreateTableName(line);
+			if (foundTableName.length() > 0) {
+				editLine.setCreateTableName(foundTableName);
+			}
+		}
 		if (upperLine.indexOf("REPLICATION ON") >= 0 || upperLine.indexOf("REPLICATION OFF") >= 0) {
 			editLine.setHasReplication(true);
+			addReplicationTableName(editLine.getCreateTableName());
 			editLine.setCreateTableOrClass(false);
 			return editLine;
 		}
@@ -211,9 +296,11 @@ public class SQLFileReader {
 			if (line.toUpperCase().indexOf("ENUM") >= 0 && line.toUpperCase().indexOf("'") >= 0) {
 				return checkEnum(line, editLine);
 			} else if (true == isEnumType && line.contains(")")) {
-				String startSubString = line.substring(0, line.toUpperCase().lastIndexOf("'"));
-				String endSubString = line.toUpperCase().substring(line.toUpperCase().lastIndexOf("'")).replaceFirst("\\)", ")  PRIMARY KEY");
-				line = startSubString + endSubString;
+				if (!hasReplication) {
+					String startSubString = line.substring(0, line.toUpperCase().lastIndexOf("'"));
+					String endSubString = line.toUpperCase().substring(line.toUpperCase().lastIndexOf("'")).replaceFirst("\\)", ")  PRIMARY KEY");
+					line = startSubString + endSubString;
+				}
 				editLine.setLine(line);
 				editLine.setEnumType(false);
 				editLine.setCreateTableOrClass(false);
@@ -302,12 +389,14 @@ public class SQLFileReader {
 		private boolean isCreateTableOrClass = false;
 		private boolean isEnumType = false;
 		private boolean hasReplication = false;
+		private String createTableName = "";
 
 		public EditLine() {
 			setLine("");
 			setCreateTableOrClass(false);
 			setEnumType(false);
 			setHasReplication(false);
+			setCreateTableName("");
 		}
 
 		public void setLine(String line) {
@@ -342,6 +431,14 @@ public class SQLFileReader {
 			return hasReplication;
 		}
 
+		public void setCreateTableName(String createTableName) {
+			this.createTableName = createTableName;
+		}
+
+		public String getCreateTableName() {
+			return createTableName;
+		}
+
 	}
 
 	public void convert() throws IOException {
@@ -353,6 +450,7 @@ public class SQLFileReader {
 		boolean isCreateTableOrClass = false;
 		boolean isEnumType = false;
 		boolean hasReplication = false;
+		String createTableName = "";
 		EditLine editLine = null;
 		HoldCasCheck holdCasCheck;
 		while ((line = lineReader.readLine()) != null) {
@@ -376,11 +474,12 @@ public class SQLFileReader {
 			}
 
 			// edited by cn15209 20120627
-			editLine = editLineForCreateTableOrClass(line, isCreateTableOrClass, isEnumType, hasReplication);
+			editLine = editLineForCreateTableOrClass(line, isCreateTableOrClass, isEnumType, hasReplication, createTableName);
 			line = editLine.getLine();
 			isCreateTableOrClass = editLine.isCreateTableOrClass();
 			isEnumType = editLine.isEnumType();
 			hasReplication = editLine.hasReplication();
+			createTableName = editLine.getCreateTableName();
 			lineScanner.scan(line);
 			if (line.endsWith(";")) {
 				if (lineScanner.isInPlcsqlText()) {
@@ -405,6 +504,7 @@ public class SQLFileReader {
 				shouldBeDeleted = false;
 				isDML = false;
 				hasReplication = false;
+				createTableName = "";
 				}
 			} else {
 				if (isMultipleLine) {
@@ -428,6 +528,7 @@ public class SQLFileReader {
 		}
 		out.flush();
 		out.close();
+		writeReplicationTableList();
 	}
 
 	private void addCheckPoint() throws IOException {


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-26096

CBRD-26096 (Replication 옵션 추가) 대응의 일환으로, ha_repl 테스트 도구(CTP)에서 복제 설정 여부에 따라 테스트 케이스 동작을 제어하도록 수정하였습니다.

주요 수정 사항

1. 시스템 컬럼 참조 추가: common.inc 내 db_class 조회 쿼리에 is_replication_class 컬럼을 추가하여 테이블의 복제 설정 상태 또한 검증할 수 있도록 합니다.
2. PK 자동 생성 로직 수정:
- 기존: ha_repl 테스트 시 모든 테이블에 기본적으로 PK를 자동 추가함.
- 수정: 테이블에 REPLICATION ON 또는 REPLICATION OFF 설정이 명시적으로 되어 있는 경우, PK를 자동으로 추가하지 않도록 예외 처리를 적용했습니다.
3. 데이터 정합성 체크(Diff) 대상 확장:
기존에는 PK가 있는 테이블만 Master/Slave 정합성 체크를 수행했으나, 복제 옵션이 명시된 테이블들은 별도 관리하여 정합성 체크 단계에 강제로 포함되도록 수정하였습니다.

이를 통해 사용자가 의도적으로 설정한 복제 환경에서도 데이터 일치 여부를 정확히 검증할 수 있습니다.
수정 사유
복제 제한 사항(Restriction) 관련 테스트 시, 사용자가 의도적으로 설정한 복제 옵션이 테스트 도구의 자동 PK 생성 로직과 충돌하지 않도록 하기 위함입니다.
