### PR TITLE
[CUBRIDQA-1368] record log lines around 'FATAL ERROR' in the result file of Shell Tests

### DIFF
--- a/CTP/shell/init_path/shell_utils.sh
+++ b/CTP/shell/init_path/shell_utils.sh
@@ -51,7 +51,7 @@ function get_core_analyzer_file {
     local core=$1
     local core_stack_fn=${CUBRID}/`basename $core | sed 's/core/briefstack/g'`
     if [ ! -f ${core_stack_fn} ]; then
-       analyzer.sh $core > ${core_stack_fn}
+        analyzer.sh $core > ${core_stack_fn}
     fi
     echo ${core_stack_fn}
 }
@@ -68,42 +68,42 @@ function do_check_more_errors {
 
     local core_brief_stack_fn=""
     clear_core_analyzer_files
-    
+
     if [  -f "$CTP_CORE_EXCLUDE_FILE" ]; then
-      find $init_path $CUBRID $test_case_dir -name "core*" -type f > temp_assert_log
-      local hit_all_cnt=0
-      local hit_server_cnt=0
-      local all_core_cnt=0
-      local all_server_core_cnt=0
+        find $init_path $CUBRID $test_case_dir -name "core*" -type f > temp_assert_log
+        local hit_all_cnt=0
+        local hit_server_cnt=0
+        local all_core_cnt=0
+        local all_server_core_cnt=0
 
-      local curr_is_server=0
-      local curr_hit=0
-      while read core
-      do
-         all_core_cnt=`expr $all_core_cnt + 1`
-
-         core_brief_stack_fn=`get_core_analyzer_file $core`
-
-         curr_hit=`cat ${core_brief_stack_fn} | grep -aE -f "$CTP_CORE_EXCLUDE_FILE" |wc -l`
-         if [ $curr_hit -gt 0 ]; then
-           hit_all_cnt=`expr $hit_all_cnt + 1`
-         fi
-
-         curr_is_server=`cat ${core_brief_stack_fn} | grep "PROCESS NAME" | grep "cub_server" |wc -l`
-         if [ $curr_is_server -gt 0 ]; then            
-            all_server_core_cnt=`expr $all_server_core_cnt + 1`
-            if [ $curr_hit -gt 0 ]; then
-               hit_server_cnt=`expr $hit_server_cnt + 1`
-            fi
-         fi
-      done < temp_assert_log
-
-      if [ $hit_all_cnt -eq $all_core_cnt ] || [ $all_server_core_cnt -gt 0 -a $all_server_core_cnt -eq $hit_server_cnt ]; then
+        local curr_is_server=0
+        local curr_hit=0
         while read core
         do
-          rm -rf $core
+            all_core_cnt=`expr $all_core_cnt + 1`
+
+            core_brief_stack_fn=`get_core_analyzer_file $core`
+
+            curr_hit=`cat ${core_brief_stack_fn} | grep -aE -f "$CTP_CORE_EXCLUDE_FILE" |wc -l`
+            if [ $curr_hit -gt 0 ]; then
+                hit_all_cnt=`expr $hit_all_cnt + 1`
+            fi
+
+            curr_is_server=`cat ${core_brief_stack_fn} | grep "PROCESS NAME" | grep "cub_server" |wc -l`
+            if [ $curr_is_server -gt 0 ]; then
+               all_server_core_cnt=`expr $all_server_core_cnt + 1`
+               if [ $curr_hit -gt 0 ]; then
+                  hit_server_cnt=`expr $hit_server_cnt + 1`
+               fi
+            fi
         done < temp_assert_log
-      fi
+
+        if [ $hit_all_cnt -eq $all_core_cnt ] || [ $all_server_core_cnt -gt 0 -a $all_server_core_cnt -eq $hit_server_cnt ]; then
+            while read core
+            do
+                rm -rf $core
+            done < temp_assert_log
+        fi
     fi
 
 
@@ -113,19 +113,19 @@ function do_check_more_errors {
     old_fatal_err_cnt=0
     if [ -f $CUBRID/log/qa_fatal_error_count.log ]
     then
-	old_fatal_err_cnt=`cat $CUBRID/log/qa_fatal_error_count.log`
+        old_fatal_err_cnt=`cat $CUBRID/log/qa_fatal_error_count.log`
     fi
 
     cub_build_id=`cubrid_rel | grep CUBRID | awk -F ')' '{print $1}' | awk -F '(' '{print $NF}'`
     current_datetime=`date "+%Y%m%d_%H%M%S"`
     backup_name=AUTO_${cub_build_id}_${current_datetime}
     backup_dir=~/ERROR_BACKUP/${backup_name}
-	host_ip="${TEST_SSH_HOST}"
-	if [ "${host_ip}" = "" ]; then
-	    host_ip=`hostname -i`
-	fi
-	export TEST_INFO_ENV="ssh -p ${TEST_SSH_PORT} ${USER}@${host_ip}"
-	export TEST_INFO_BUILD_ID=${cub_build_id}
+    host_ip="${TEST_SSH_HOST}"
+    if [ "${host_ip}" = "" ]; then
+        host_ip=`hostname -i`
+    fi
+    export TEST_INFO_ENV="ssh -p ${TEST_SSH_PORT} ${USER}@${host_ip}"
+    export TEST_INFO_BUILD_ID=${cub_build_id}
 
     if [ $core_dump_cnt -gt 0 ] || [ $fatal_err_cnt -gt $old_fatal_err_cnt -a "$SKIP_CHECK_FATAL_ERROR" != "TRUE" ]; then
         mkdir -p $backup_dir
@@ -134,7 +134,7 @@ function do_check_more_errors {
 
         host_ip=`hostname -i`
         if [ $core_dump_cnt -gt 0 ]; then
- 	    out=" : NOK found core file on host "$host_ip"("$backup_dir")"
+            out=" : NOK found core file on host "$host_ip"("$backup_dir")"
             echo $out >> $result_file_full_name
             echo $out
 
@@ -150,21 +150,21 @@ function do_check_more_errors {
                  fi
             done < temp_log
 
-	    while read core
-	    do
+            while read core
+            do
                 core_brief_stack_fn=`get_core_analyzer_file $core`
-		is_cub_cas=`cat ${core_brief_stack_fn} | grep "PROCESS NAME:"|grep "cub_cas"|wc -l`
-		if [ ${has_cub_server_crash} -eq 0 -o $is_cub_cas -eq 0 ];then
-			  issue_title=`grep SUMMARY ${core_brief_stack_fn} | head -n 1`
-		    echo \<!--HTMLESCAPESTART--\>\<a class=SHELLCORE href=\"javascript:reportShellCoreIssue\(\'${core}\', \'${backup_name}\', \'${host_ip}\', \'${TEST_SSH_PORT}\', \'${USER}\', \'${cub_build_id}\', \'${issue_title}\' \) \"\>\<i\>\<font color=red\>REPORT ISSUE FOR BELOW CRASH\</font\>\</i\>\</a\>\<!--HTMLESCAPEEND--\> >> $result_file_full_name
-			  cat ${core_brief_stack_fn} >> $result_file_full_name
-			  core_full_stack_fn=${CUBRID}/`basename $core | sed 's/core/fullstack/g'`
-			  analyzer.sh -f $core > ${core_full_stack_fn}
-		else
-			  echo "CRASH FROM CUB_CAS:${core}(skip to print call stacks)" >> $result_file_full_name
-		fi
-	    done < temp_log
-            
+                is_cub_cas=`cat ${core_brief_stack_fn} | grep "PROCESS NAME:"|grep "cub_cas"|wc -l`
+                if [ ${has_cub_server_crash} -eq 0 -o $is_cub_cas -eq 0 ];then
+                    issue_title=`grep SUMMARY ${core_brief_stack_fn} | head -n 1`
+                    echo \<!--HTMLESCAPESTART--\>\<a class=SHELLCORE href=\"javascript:reportShellCoreIssue\(\'${core}\', \'${backup_name}\', \'${host_ip}\', \'${TEST_SSH_PORT}\', \'${USER}\', \'${cub_build_id}\', \'${issue_title}\' \) \"\>\<i\>\<font color=red\>REPORT ISSUE FOR BELOW CRASH\</font\>\</i\>\</a\>\<!--HTMLESCAPEEND--\> >> $result_file_full_name
+                    cat ${core_brief_stack_fn} >> $result_file_full_name
+                    core_full_stack_fn=${CUBRID}/`basename $core | sed 's/core/fullstack/g'`
+                    analyzer.sh -f $core > ${core_full_stack_fn}
+                else
+                    echo "CRASH FROM CUB_CAS:${core}(skip to print call stacks)" >> $result_file_full_name
+                fi
+            done < temp_log
+
             clear_core_analyzer_files
         fi
         if [ $fatal_err_cnt -gt 0 ]; then
@@ -175,12 +175,12 @@ function do_check_more_errors {
         cp -rfp $CUBRID $backup_dir/CUBRID
         cp -rfp $test_case_dir $backup_dir
         cp -rfp $init_path $backup_dir/init_path
-	cd ~/ERROR_BACKUP
-	tar zcvf AUTO_${cub_build_id}_${current_datetime}.tar.gz AUTO_${cub_build_id}_${current_datetime}
-	rm -rf AUTO_${cub_build_id}_${current_datetime}
+        cd ~/ERROR_BACKUP
+        tar zcvf AUTO_${cub_build_id}_${current_datetime}.tar.gz AUTO_${cub_build_id}_${current_datetime}
+        rm -rf AUTO_${cub_build_id}_${current_datetime}
         cd -
 
-	cat temp_log | xargs -i rm -rf {}
+        cat temp_log | xargs -i rm -rf {}
         echo $fatal_err_cnt>$CUBRID/log/qa_fatal_error_count.log
     fi
     rm temp_log -f >/dev/null 2>&1
@@ -207,7 +207,7 @@ function do_save_snapshot_by_type {
     result_file_full_name=${test_case_dir}/cases/${case_name}.result
     cub_build_id=`cubrid_rel | grep CUBRID | awk -F ')' '{print $1}' | awk -F '(' '{print $NF}'`
     current_datetime=`date "+%Y%m%d_%H%M%S"`
-    
+
     backup_fname=AUTO_${kind}_${cub_build_id}_${current_datetime}
     backup_dir=~/ERROR_BACKUP/${backup_fname}
 

--- a/CTP/shell/init_path/shell_utils.sh
+++ b/CTP/shell/init_path/shell_utils.sh
@@ -134,9 +134,7 @@ function do_check_more_errors {
 
         host_ip=`hostname -i`
         if [ $core_dump_cnt -gt 0 ]; then
-            out=" : NOK found core file on host "$host_ip"("$backup_dir")"
-            echo $out >> $result_file_full_name
-            echo $out
+            echo " : NOK found core file on host "$host_ip"("$backup_dir")" | tee -a $result_file_full_name
 
             local has_cub_server_crash=0
             local is_cub_server=0
@@ -168,9 +166,14 @@ function do_check_more_errors {
             clear_core_analyzer_files
         fi
         if [ $fatal_err_cnt -gt 0 ]; then
-            out=" : NOK found fatal error on host "$host_ip"("$backup_dir")"
-            echo $out >> $result_file_full_name
-            echo $out
+            echo " : NOK found fatal error on host "$host_ip"("$backup_dir")" | tee -a $result_file_full_name
+            for f in $(grep -RIl 'FATAL ERROR' $CUBRID/log/); do
+                echo "== $f ==" | tee -a $result_file_full_name
+                # print the 'FATAL ERROR' line and 10 lines before and 10 lines after it
+                grep -B 10 -A 10 'FATAL ERROR' $f |& tee -a $result_file_full_name
+                echo "== end ==" | tee -a $result_file_full_name
+            done
+
         fi
         cp -rfp $CUBRID $backup_dir/CUBRID
         cp -rfp $test_case_dir $backup_dir

--- a/CTP/shell/init_path/shell_utils.sh
+++ b/CTP/shell/init_path/shell_utils.sh
@@ -168,10 +168,13 @@ function do_check_more_errors {
         if [ $fatal_err_cnt -gt 0 ]; then
             echo " : NOK found fatal error on host "$host_ip"("$backup_dir")" | tee -a $result_file_full_name
             for f in $(grep -RIl 'FATAL ERROR' $CUBRID/log/); do
-                echo "== $f ==" | tee -a $result_file_full_name
-                # print the 'FATAL ERROR' line and 20 lines before and 20 lines after it
-                grep -B 20 -A 20 'FATAL ERROR' $f |& tee -a $result_file_full_name
-                echo "== end ==" | tee -a $result_file_full_name
+                # only for regular files which are not symbolic links
+                if [ -f "$f" ] && [ ! -L "$f" ]; then
+                    echo "== $f ==" | tee -a $result_file_full_name
+                    # print the 'FATAL ERROR' line and 20 lines before and 20 lines after it
+                    grep -B 20 -A 20 'FATAL ERROR' $f |& tee -a $result_file_full_name
+                    echo "== end ==" | tee -a $result_file_full_name
+                fi
             done
 
         fi

--- a/CTP/shell/init_path/shell_utils.sh
+++ b/CTP/shell/init_path/shell_utils.sh
@@ -169,8 +169,8 @@ function do_check_more_errors {
             echo " : NOK found fatal error on host "$host_ip"("$backup_dir")" | tee -a $result_file_full_name
             for f in $(grep -RIl 'FATAL ERROR' $CUBRID/log/); do
                 echo "== $f ==" | tee -a $result_file_full_name
-                # print the 'FATAL ERROR' line and 10 lines before and 10 lines after it
-                grep -B 10 -A 10 'FATAL ERROR' $f |& tee -a $result_file_full_name
+                # print the 'FATAL ERROR' line and 20 lines before and 20 lines after it
+                grep -B 20 -A 20 'FATAL ERROR' $f |& tee -a $result_file_full_name
                 echo "== end ==" | tee -a $result_file_full_name
             done
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1368

Shell Test 후 FATAL ERROR 로그 주변 40줄 정도를 result 파일에 남도록 수정했습니다. 
검토 부탁드립니다. 

참고로, 이 버전의 CTP 로 두 건의 flaky 실패건의 원인을 볼 수 있었습니다. 
두 건 모두 '용량이 부족해서 format 할 수 없다' 는 취지의 로그가 남아 있었습니다. 

(https://app.circleci.com/pipelines/github/CUBRID/cubrid/27150/workflows/587f1012-7fef-4932-9f9b-c51db0583cef/jobs/119413/tests)
```
Time: 03/20/26 15:09:09.325 - ERROR *** file /home/src/storage/file_io.c, line 2367 ERROR CODE = -9, Tran = 0, CLIENT = :(0), EID = 899
Unable to format disk volume "/home/cubrid-testcases-private-ex/shell/_35_cherry/issue_22015_QEWC/trigger_2/cases/db22015/db22015_lgar013" with 32767 pages (524256 Kbytes) due to insufficient space. Current space available is 26816 pages (429056 Kbytes).
Time: 03/20/26 15:09:09.325 - FATAL ERROR *** file /home/src/transaction/log_page_buffer.c, line 5749 ERROR CODE = -98, Tran = 0, CLIENT = :(0), EID = 900
Unable to create archive log "/home/cubrid-testcases-private-ex/shell/_35_cherry/issue_22015_QEWC/trigger_2/cases/db22015/db22015_lgar013" to archive pages from 425958 to 458723.
[13] 0x0000000000389e8b: er_dump_call_stack_internal(print_output&) at /home/src/base/stack_dump.c:390
[12] 0x000000000038a752: er_dump_call_stack(_IO_FILE*) at /home/src/base/printer.hpp:43
[11] 0x000000000034549c: er_notify_event_on_error at /home/src/base/error_manager.c:1306
[10] 0x0000000000345c55: er_set at /home/src/base/error_manager.c:1237
[09] 0x000000000079cb7a: logpb_archive_active_log(cubthread::entry*) at /home/src/transaction/log_page_buffer.c:5964
[08] 0x000000000079d5c8: logpb_next_append_page(cubthread::entry*, log_setdirty) at /home/src/transaction/log_page_buffer.c:2667
[07] 0x000000000079de95: logpb_end_append at /home/src/transaction/log_page_buffer.c:4456
[06] 0x00000000007a0901: logpb_flush_pages_direct(cubthread::entry*) at /home/src/transaction/log_page_buffer.c:3957
[05] 0x0000000000780b40: log_flush_execute at /home/src/transaction/log_manager.c:10386
[04] 0x0000000000739a0d: void cubthread::daemon::loop_with_context<cubthread::entry>(cubthread::daemon*, cubthread::context_manager<cubthread::entry>*, cubthread::task<cubthread::entry>*, char const*) at /home/src/thread/thread_daemon.hpp:178
[03] 0x0000000000b8a1ef: execute_native_thread_routine at thread.o:?
[02] 0x00000000000081ca: start_thread at ??:?
[01] 0x0000000000039953: __GI___clone at :?
```

## Remark
- diff 내용이 많아 보이지만, 첫 번 째 commit 은 indentation과 trailing space 삭제라 관련이 없고
두 번째 commit [3b49592] 이 주요 내용입니다. 여기부터 보시면 좋을 것 같습니다. 
- FATAL ERROR 로그 라인 주변의 40 라인을 출력한다는 것은 일단 임의로 그렇게 한 것이고 논의하여 정해야 합니다. 