### PR TITLE
[CUBRIDQA-1337] fix bug for retry.

### DIFF
--- a/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
@@ -61,6 +61,31 @@ public class Dispatch {
 	
 	// Retry management
 	private HashMap<String, Integer> retryCountMap;
+	private HashSet<String> inProgressRetrySet;
+
+	public static class DispatchItem {
+		private final String testCase;
+		private final int retryCount;
+		private final boolean retryDispatch;
+
+		public DispatchItem(String testCase, int retryCount, boolean retryDispatch) {
+			this.testCase = testCase;
+			this.retryCount = retryCount;
+			this.retryDispatch = retryDispatch;
+		}
+
+		public String getTestCase() {
+			return testCase;
+		}
+
+		public int getRetryCount() {
+			return retryCount;
+		}
+
+		public boolean isRetryDispatch() {
+			return retryDispatch;
+		}
+	}
 
 	private Dispatch(Context context) throws Exception {
 		this.context = context;
@@ -69,6 +94,7 @@ public class Dispatch {
 		this.isFinished = false;
 		this.nextTestFileIndex = -1;
 		this.retryCountMap = new HashMap<String, Integer>();
+		this.inProgressRetrySet = new HashSet<String>();
 		load();
 	}
 
@@ -80,10 +106,7 @@ public class Dispatch {
 		return instance;
 	}
 
-	public synchronized String nextTestFile() {
-		if (isFinished)
-			return null;
-
+	public synchronized DispatchItem nextTestItem() {
 		// First, process all normal test cases
 		if (this.nextTestFileIndex < totalTbdSize) {
 			if (this.nextTestFileIndex < 0) {
@@ -91,30 +114,34 @@ public class Dispatch {
 			}
 			String nextTestFile = tbdList.get(this.nextTestFileIndex);
 			this.nextTestFileIndex++;
-			return nextTestFile;
+			return new DispatchItem(nextTestFile, 0, false);
 		}
 
 		// After all normal cases are done, process retry cases
 		if (!retryCountMap.isEmpty()) {
-			// Get first retry case
 			String retryTestFile = retryCountMap.keySet().iterator().next();
-			return retryTestFile;
+			int retryCount = retryCountMap.remove(retryTestFile);
+			inProgressRetrySet.add(retryTestFile);
+			return new DispatchItem(retryTestFile, retryCount, true);
 		}
 
 		// All done
-		isFinished = true;
 		return null;
 	}
+
+	public synchronized String nextTestFile() {
+		DispatchItem dispatchItem = nextTestItem();
+		return dispatchItem == null ? null : dispatchItem.getTestCase();
+	}
 	
-	public synchronized void addFailedTestCaseForRetry(String testCase) {
-		Integer currentRetryCount = retryCountMap.get(testCase);
-		if (currentRetryCount == null) {
-			currentRetryCount = 0;
-		}
-		
+	public synchronized void addFailedTestCaseForRetry(String testCase, int currentRetryCount) {
 		if (currentRetryCount < context.getMaxRetryCount()) {
 			retryCountMap.put(testCase, currentRetryCount + 1);
 		}
+	}
+
+	public synchronized void addFailedTestCaseForRetry(String testCase) {
+		addFailedTestCaseForRetry(testCase, 0);
 	}
 	
 	public synchronized Integer getRetryCount(String testCase) {
@@ -124,6 +151,10 @@ public class Dispatch {
 	
 	public synchronized void removeFromRetryQueue(String testCase) {
 		retryCountMap.remove(testCase);
+	}
+
+	public synchronized void completeRetryDispatch(String testCase) {
+		inProgressRetrySet.remove(testCase);
 	}
 	
 
@@ -371,8 +402,10 @@ public class Dispatch {
 		return totalTbdSize;
 	}
 
-	public boolean isFinished() {
-		return this.isFinished;
+	public synchronized boolean isFinished() {
+		boolean normalDone = this.totalTbdSize == 0 || this.nextTestFileIndex >= this.totalTbdSize;
+		boolean retryDone = this.retryCountMap.isEmpty() && this.inProgressRetrySet.isEmpty();
+		return normalDone && retryDone;
 	}
 
 	public int getMacroSkippedSize() {

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
@@ -31,6 +31,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 
 import com.navercorp.cubridqa.shell.common.CommonUtils;
 import com.navercorp.cubridqa.shell.common.Log;
@@ -153,7 +154,11 @@ public class Dispatch {
 		retryCountMap.remove(testCase);
 	}
 
-	public synchronized void completeRetryDispatch(String testCase) {
+	public synchronized void completeRetryDispatchAndRequeueIfNeeded(String testCase, boolean needRetry, int currentRetryCount) {
+		if (needRetry && currentRetryCount < context.getMaxRetryCount()) {
+			retryCountMap.put(testCase, currentRetryCount + 1);
+		}
+
 		inProgressRetrySet.remove(testCase);
 	}
 	

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
@@ -107,10 +107,16 @@ public class Test {
 				}
 			}
 
-			testCase = Dispatch.getInstance().nextTestFile();
-			if (testCase == null) {
-				break;
+			Dispatch.DispatchItem dispatchItem = Dispatch.getInstance().nextTestItem();
+			if (dispatchItem == null) {
+				if (Dispatch.getInstance().isFinished()) {
+					break;
+				}
+
+				CommonUtils.sleep(1);
+				continue;
 			}
+			testCase = dispatchItem.getTestCase();
 
 			consoleOutput = "";
 			this.testCaseFullName = testCase;
@@ -123,8 +129,8 @@ public class Test {
 
 			workerLog.println("[TESTCASE] " + this.testCaseFullName);
 			
-			// Get current retry count for this test case
-			int currentRetryCount = Dispatch.getInstance().getRetryCount(this.testCaseFullName);
+			int currentRetryCount = dispatchItem.getRetryCount();
+			boolean isRetryDispatch = dispatchItem.isRetryDispatch();
 
 			/*
 			 * Reset test environment Kill CUBRID process, clear SSH and
@@ -208,12 +214,14 @@ public class Test {
 				}
 				
 				// Handle retry queue management
-				if (needRetry && this.maxRetryCount > 0) {
-					// Add failed test case to retry queue
-					Dispatch.getInstance().addFailedTestCaseForRetry(this.testCaseFullName);
-				} else if (currentRetryCount > 0) {
-					// Remove completed retry case from queue
-					Dispatch.getInstance().removeFromRetryQueue(this.testCaseFullName);
+				try {
+					if (needRetry && this.maxRetryCount > 0) {
+						Dispatch.getInstance().addFailedTestCaseForRetry(this.testCaseFullName, currentRetryCount);
+					}
+				} finally {
+					if (isRetryDispatch) {
+						Dispatch.getInstance().completeRetryDispatch(this.testCaseFullName);
+					}
 				}
 
 				workerLog.println("");

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
@@ -131,6 +131,8 @@ public class Test {
 			
 			int currentRetryCount = dispatchItem.getRetryCount();
 			boolean isRetryDispatch = dispatchItem.isRetryDispatch();
+			boolean retryLifecycleHandled = false;
+			try {
 
 			/*
 			 * Reset test environment Kill CUBRID process, clear SSH and
@@ -214,23 +216,32 @@ public class Test {
 				}
 				
 				// Handle retry queue management
-				try {
-					if (needRetry && this.maxRetryCount > 0) {
-						Dispatch.getInstance().addFailedTestCaseForRetry(this.testCaseFullName, currentRetryCount);
-					}
-				} finally {
-					if (isRetryDispatch) {
-						Dispatch.getInstance().completeRetryDispatch(this.testCaseFullName);
-					}
+				if (isRetryDispatch) {
+					Dispatch.getInstance().completeRetryDispatchAndRequeueIfNeeded(this.testCaseFullName,
+							needRetry && this.maxRetryCount > 0, currentRetryCount);
+					retryLifecycleHandled = true;
+				} else if (needRetry && this.maxRetryCount > 0) {
+					Dispatch.getInstance().addFailedTestCaseForRetry(this.testCaseFullName, currentRetryCount);
 				}
 
 				workerLog.println("");
 			}
 
-			if (needDropTestCase) {
-				dropTestCaseAfterTest();
+				if (needDropTestCase) {
+					dropTestCaseAfterTest();
+				}
+				dispatchLog.println(this.testCaseFullName);
+			} finally {
+				if (isRetryDispatch && !retryLifecycleHandled) {
+					try {
+						Dispatch.getInstance().completeRetryDispatchAndRequeueIfNeeded(this.testCaseFullName,
+								true, currentRetryCount);
+					} catch (Exception e) {
+						workerLog.println("ERROR: fallback retry lifecycle handling failed: "
+								+ e.getMessage());
+					}
+				}
 			}
-			dispatchLog.println(this.testCaseFullName);
 		}
 
 		close();

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
@@ -200,7 +200,7 @@ public class FeedbackDB implements Feedback {
 
 		executed_num = fail_num + succ_num;
 
-		float execute_rate = tbdNum <= 0 ? 0 : (float) executed_num / (float) tbdNum * 100;
+		float execute_rate = calculateExecuteRate(succ_num, fail_num, tbdNum);
 
 		try {
 			float success_rate = tbdNum <= 0 ? 0 : (float) succ_num / (float) executed_num * 100;
@@ -222,6 +222,15 @@ public class FeedbackDB implements Feedback {
 			close(stmt);
 			close(conn);
 		}
+	}
+
+	static float calculateExecuteRate(int succNum, int failNum, int totalTbdNum) {
+		if (totalTbdNum <= 0) {
+			return 0;
+		}
+
+		float executeRate = (float) (succNum + failNum) / (float) totalTbdNum * 100;
+		return executeRate > 100 ? 100 : executeRate;
 	}
 
 	public void showTestResult() {


### PR DESCRIPTION
## Purpose
- Shell test database feedback 모드에서 retry 사용 시 `execute_rate`가 100%를 초과하는 문제 수정
- retry 케이스의 중복 할당 및 dropped retry 문제 해결

## Implementation
### 1. Retry Dispatch 로직 (Dispatch.java)
- `DispatchItem`에 `retryDispatch` 플래그 추가
- `inProgressRetrySet`으로 실행 중인 retry 추적
- `isFinished()`를 동적 계산으로 변경:
  - normal 완료 && retry 대기 없음 && 실행 중 없음
- `completeRetryDispatchAndRequeueIfNeeded()` 추가:
  - 재큐잉 필요 시 retry 카운트 증가 후 `retryCountMap`에 추가
  - `inProgressRetrySet`에서 제거

### 2. Test 실행부 (Test.java)
- `nextTestItem()` 사용, 반환 값이 null일 때:
  - `isFinished()==true`면 종료
  - 아니면 sleep 후 continue
- retry dispatch 완료 시 `completeRetryDispatchAndRequeueIfNeeded()` 호출

### 3. execute_rate 계산 (FeedbackDB.java)
- `calculateExecuteRate()`에 100% 상한 보정 추가

## Verification

- `ant clean dist` → BUILD SUCCESSFUL
- `DispatchRetryEdgeCaseUnitTest` → PASSED

## Remark

- DB 스키마 변경 없음
- E2E 테스트는 unit test로 대체
