### PR TITLE
[CUBRIDQA-1369] run_sql.sh - a new shell for running a single testcase with CTP

### DIFF
--- a/CTP/README.md
+++ b/CTP/README.md
@@ -105,8 +105,27 @@ The section guides users to quickly start SQL test with CTP, for the more catego
 	    ```
 	    - `sql_file`: path to the `.sql` test case file
 	    - `db_name`: database name to use (default: `basic`). The suffix `_qa` is appended automatically.
-	    - Requires `JAVA_HOME` and `CUBRID` environment variables
+	    - Requires `JAVA_HOME`, `CUBRID`, and `CTP_HOME` environment variables
 	    - This is useful for quick single-case validation and AI-driven automated bug detection, providing a middle ground between `ctp.sh sql -c conf` (full batch run) and `ctp.sh sql --interactive` (manual interactive mode)
+	    - **Custom database**: To use a database other than `basic`, you must create a corresponding XML config file at `$CTP_HOME/sql/configuration/Function_Db/<db_name>_qa.xml`. For example, to use `testdb`:
+	      ```xml
+	      <!-- $CTP_HOME/sql/configuration/Function_Db/testdb_qa.xml -->
+	      <DefaultTestDB>
+	        <id>testdb_for_Linux</id>
+	        <name>testdb</name>
+	        <dbaPwd></dbaPwd>
+	        <pubPwd></pubPwd>
+	        <dburl>jdbc:cubrid:localhost:33000:testdb:::</dburl>
+	        <dbuser>dba</dbuser>
+	        <dbpassword></dbpassword>
+	        <connectionType>DriverManager</connectionType>
+	        <charSet>UTF-8</charSet>
+	        <version>Main</version>
+	        <script>
+	      </script>
+	      </DefaultTestDB>
+	      ```
+	      Pre-configured databases: `basic` (default), `kcc`, `mdb`, `neis05`, `neis08`, `shell`
 
 
   - Examine the results

--- a/CTP/README.md
+++ b/CTP/README.md
@@ -94,12 +94,21 @@ The section guides users to quickly start SQL test with CTP, for the more catego
 	    $ bin/ctp.sh sql_by_cci -c ./conf/sql.conf
 	    ``` 
 
-	* Use interactive mode to debug your **SQL/MEDIUM** case (this feature does not support SQL_BY_CCI)          
+	* Use interactive mode to debug your **SQL/MEDIUM** case (this feature does not support SQL_BY_CCI)
 	    ```
 	    $ bin/ctp.sh sql --interactive
 	    ```
 
-    
+	* Use `run_sql.sh` to run a **single SQL test file** without a conf file or interactive mode:
+	    ```
+	    $ bin/run_sql.sh <sql_file> [db_name]
+	    ```
+	    - `sql_file`: path to the `.sql` test case file
+	    - `db_name`: database name to use (default: `basic`). The suffix `_qa` is appended automatically.
+	    - Requires `JAVA_HOME` and `CUBRID` environment variables
+	    - This is useful for quick single-case validation and AI-driven automated bug detection, providing a middle ground between `ctp.sh sql -c conf` (full batch run) and `ctp.sh sql --interactive` (manual interactive mode)
+
+
   - Examine the results
 
 	* When the test is completed, CTP will print the summary result message, please see the example of SQL result for reference

--- a/CTP/bin/run_sql.sh
+++ b/CTP/bin/run_sql.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Run a single SQL file using CTP's ConsoleAgent (same output format as ctp.sh sql)
+# Usage: run_sql.sh <sql_file> [db_name]
+
+SQL_FILE=$(readlink -f "$1")
+DB_NAME="${2:-basic}"
+
+[ -z "$1" ] && echo "Usage: $0 <sql_file> [db_name]" && exit 1
+[ ! -f "$SQL_FILE" ] && echo "Error: SQL file not found: $1" && exit 1
+[ -z "$JAVA_HOME" ] && echo "Error: JAVA_HOME is not set" && exit 1
+[ -z "$CUBRID" ] && echo "Error: CUBRID is not set" && exit 1
+
+CTP_HOME=$(cd $(dirname $(readlink -f $0))/..; pwd)
+
+CPCLASSES=""
+for jar in "$CTP_HOME/sql/lib/"*.jar; do
+    CPCLASSES="$CPCLASSES:$jar"
+done
+
+"$JAVA_HOME/bin/java" \
+    -classpath "$CPCLASSES" \
+    com.navercorp.cubridqa.cqt.console.ConsoleAgent \
+    runCQT sql sql 64 test_default.xml \
+    "${SQL_FILE}?db=${DB_NAME}_qa"

--- a/CTP/bin/run_sql.sh
+++ b/CTP/bin/run_sql.sh
@@ -1,24 +1,35 @@
 #!/bin/bash
 # Run a single SQL file using CTP's ConsoleAgent (same output format as ctp.sh sql)
 # Usage: run_sql.sh <sql_file> [db_name]
-
-SQL_FILE=$(readlink -f "$1")
-DB_NAME="${2:-basic}"
+# Note: A matching <db_name>_qa.xml must exist in $CTP_HOME/sql/configuration/Function_Db/
+#       Pre-configured: basic (default), testdb, kcc, mdb, neis05, neis08, shell
+#       See CTP/README.md for how to create a custom db config.
 
 [ -z "$1" ] && echo "Usage: $0 <sql_file> [db_name]" && exit 1
+
+SQL_FILE="$(readlink -f "$1")"
+DB_NAME="${2:-basic}"
+
 [ ! -f "$SQL_FILE" ] && echo "Error: SQL file not found: $1" && exit 1
 [ -z "$JAVA_HOME" ] && echo "Error: JAVA_HOME is not set" && exit 1
 [ -z "$CUBRID" ] && echo "Error: CUBRID is not set" && exit 1
 
-CTP_HOME=$(cd $(dirname $(readlink -f $0))/..; pwd)
+[ -z "$CTP_HOME" ] && echo "Error: CTP_HOME is not set" && exit 1
+export CTP_HOME
+[ ! -d "$CTP_HOME/sql/lib" ] && echo "Error: CTP_HOME is invalid: $CTP_HOME" && exit 1
 
+shopt -s nullglob
 CPCLASSES=""
 for jar in "$CTP_HOME/sql/lib/"*.jar; do
-    CPCLASSES="$CPCLASSES:$jar"
+    CPCLASSES="${CPCLASSES:+$CPCLASSES:}$jar"
 done
+shopt -u nullglob
+
+[ -z "$CPCLASSES" ] && echo "Error: No jar files found in $CTP_HOME/sql/lib/" && exit 1
 
 "$JAVA_HOME/bin/java" \
     -classpath "$CPCLASSES" \
     com.navercorp.cubridqa.cqt.console.ConsoleAgent \
     runCQT sql sql 64 test_default.xml \
     "${SQL_FILE}?db=${DB_NAME}_qa"
+exit $?

--- a/CTP/sql/configuration/Function_Db/testdb_qa.xml
+++ b/CTP/sql/configuration/Function_Db/testdb_qa.xml
@@ -1,0 +1,14 @@
+<DefaultTestDB>
+  <id>testdb_for_Linux</id>
+  <name>testdb</name>
+  <dbaPwd></dbaPwd>
+  <pubPwd></pubPwd>
+  <dburl>jdbc:cubrid:localhost:33000:testdb:::</dburl>
+  <dbuser>dba</dbuser>
+  <dbpassword></dbpassword>
+  <connectionType>DriverManager</connectionType>
+  <charSet>UTF-8</charSet>
+  <version>Main</version>
+  <script>
+</script>
+</DefaultTestDB>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1369

## 요약

`ctp.sh sql -c conf`(전체 배치 실행)과 `ctp.sh sql --interactive`(수동 대화형 모드) 사이의 간편한 실행 방식을 제공합니다.

- `CTP/bin/run_sql.sh` 추가: `ConsoleAgent`를 직접 호출하여 **단일 SQL 테스트 파일**을 실행하는 경량 래퍼 스크립트
- 사용법: `run_sql.sh <sql_file> [db_name]` (db_name 기본값: `basic`)
- conf 파일 설정이나 interactive 모드 진입 없이 단일 테스트 케이스를 바로 실행 가능
- AI를 활용한 자동 버그 탐지 워크플로우에서 개별 SQL 테스트를 간편하게 실행하기 위해 개발

<img width="1682" height="265" alt="image" src="https://github.com/user-attachments/assets/862c622b-1d15-46c0-b888-de0b03ca0f75" />


## 변경 사항

- `CTP/bin/run_sql.sh`: 단일 SQL 파일 실행 스크립트 신규 추가
- `CTP/sql/configuration/Function_Db/testdb_qa.xml`: 커스텀 데이터베이스 설정 예제 추가
- `CTP/README.md`: `run_sql.sh` 사용법 및 커스텀 DB 설정 방법 문서 추가

## 주의사항: 데이터베이스 설정 파일 필요

`run_sql.sh`는 내부적으로 `ConsoleAgent`가 `$CTP_HOME/sql/configuration/Function_Db/<db_name>_qa.xml` 파일을 참조합니다. **사용하려는 데이터베이스에 해당하는 `_qa.xml` 파일이 반드시 존재해야 합니다.**

기본 제공 데이터베이스: `basic` (기본값), `testdb`, `kcc`, `mdb`, `neis05`, `neis08`, `shell`

커스텀 데이터베이스를 사용하려면 아래와 같이 XML 파일을 생성하세요:

```xml
<!-- $CTP_HOME/sql/configuration/Function_Db/mydb_qa.xml -->
<DefaultTestDB>
  <id>mydb_for_Linux</id>
  <name>mydb</name>
  <dbaPwd></dbaPwd>
  <pubPwd></pubPwd>
  <dburl>jdbc:cubrid:localhost:33000:mydb:::</dburl>
  <dbuser>dba</dbuser>
  <dbpassword></dbpassword>
  <connectionType>DriverManager</connectionType>
  <charSet>UTF-8</charSet>
  <version>Main</version>
  <script>
</script>
</DefaultTestDB>
```

## 사용 예시

```bash
# 기본 데이터베이스(basic_qa)로 단일 테스트 실행
bin/run_sql.sh /path/to/testcase.sql

# 특정 데이터베이스 지정 (testdb_qa.xml이 존재해야 함)
bin/run_sql.sh /path/to/testcase.sql testdb
```

## 필요 환경변수

- `JAVA_HOME`: Java 설치 경로
- `CUBRID`: CUBRID 설치 경로
- `CTP_HOME`: CTP 루트 디렉토리 경로

## 테스트 계획
- [x] `run_sql.sh test.sql` 실행 시 정상적으로 테스트 수행 및 결과 출력 확인
- [x] `run_sql.sh test.sql testdb` 실행 시 지정된 데이터베이스 사용 확인
- [x] 인자 누락 또는 환경변수 미설정 시 적절한 에러 메시지 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)