### PR TITLE
[CUBRIDQA-1370] Added CTP writer-side support for shell last-pass logs

### DIFF
--- a/CTP/isolation/src/com/navercorp/cubridqa/isolation/impl/FeedbackDB.java
+++ b/CTP/isolation/src/com/navercorp/cubridqa/isolation/impl/FeedbackDB.java
@@ -30,6 +30,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.sql.Types;
 
 import javax.sql.DataSource;
 
@@ -56,6 +57,9 @@ public class FeedbackDB implements Feedback {
 	int tbdNum = 0;
 	int macroSkippedNum = 0;
 	int tempSkippedNum = 0;
+	boolean lastPassEligible = false;
+	String lastPassVersionId = null;
+	String lastPassBuildWid = null;
 
 	public FeedbackDB(Context context) {
 		this.context = context;
@@ -111,6 +115,7 @@ public class FeedbackDB implements Feedback {
 		Log log = new Log(CommonUtils.concatFile(context.getCurrentLogDir(), "current_task_id"), false, false);
 		log.println(String.valueOf(task_id));
 		log.close();
+		resolveLastPassBuildContext(context.getBuildId());
 	}
 
 	@Override
@@ -120,8 +125,10 @@ public class FeedbackDB implements Feedback {
 		try {
 			cont = CommonUtils.getFileContent(CommonUtils.concatFile(context.getCurrentLogDir(), "current_task_id"));
 			this.task_id = Integer.parseInt(cont.trim());
+			resolveLastPassBuildContext(context.getBuildId());
 		} catch (Exception e) {
 			this.task_id = -1;
+			clearLastPassBuildContext();
 			e.printStackTrace();
 		}
 	}
@@ -299,25 +306,47 @@ public class FeedbackDB implements Feedback {
 
 	@Override
 	public void onTestCaseStopEvent(String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedType) {
+		String category = context.getTestCategory();
+		Timestamp d = new Timestamp(System.currentTimeMillis());
+		boolean isExecutedCase = isExecutedCase(skippedType);
 		Connection conn = null;
-
-		PreparedStatement stmt = null;
-		String sql;
-
-		long caseStopTime = System.currentTimeMillis();
-		Timestamp d = new Timestamp(caseStopTime);
-
-		sql = "insert into shell_items(main_id, case_file, env_node, elapse_time, test_result, is_timeout, has_core, result_cont, end_time, is_skipped) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 		try {
 			conn = ds.getConnection();
+			int itemId = insertShellItem(conn, testCase, flag, elapseTime, resultCont, envIdentify, isTimeOut, hasCore, skippedType, d);
+			if (isExecutedCase && flag == false && itemId > 0) {
+				insertLastPassSnapshot(conn, itemId, category, testCase);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		} finally {
+			close(conn);
+		}
 
+		if (isExecutedCase && flag) {
+			refreshLastPass(category, testCase, resultCont, d);
+		}
+
+		if (isExecutedCase) {
+			refreshShellMain(false);
+			if (hasCore) {
+				notifyUpdateMain();
+			}
+		}
+	}
+
+	private int insertShellItem(Connection conn, String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedType,
+			Timestamp endTime) throws Exception {
+		PreparedStatement stmt = null;
+		String sql = "insert into shell_items(main_id, case_file, env_node, elapse_time, test_result, is_timeout, has_core, result_cont, end_time, is_skipped) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+		try {
 			stmt = conn.prepareStatement(sql);
 			stmt.setInt(1, task_id);
 			stmt.setString(2, testCase);
 			stmt.setString(3, envIdentify);
 			stmt.setDouble(4, elapseTime);
-			if (skippedType.equals(Constants.SKIP_TYPE_NO)) {
+			if (isExecutedCase(skippedType)) {
 				stmt.setString(5, (flag ? "OK" : "NOK"));
 			} else {
 				stmt.setString(5, "");
@@ -325,23 +354,210 @@ public class FeedbackDB implements Feedback {
 			stmt.setString(6, (isTimeOut ? "Y" : "N"));
 			stmt.setString(7, (hasCore ? "Y" : "N"));
 			stmt.setString(8, resultCont);
-			stmt.setTimestamp(9, d);
+			stmt.setTimestamp(9, endTime);
 			stmt.setString(10, skippedType);
 			stmt.executeUpdate();
-
-		} catch (Exception e) {
-			e.printStackTrace();
 		} finally {
+			close(stmt);
+		}
+
+		if (isExecutedCase(skippedType) && flag == false) {
+			return selectLastInsertId(conn);
+		}
+
+		return 0;
+	}
+
+	private void refreshLastPass(String category, String testCase, String resultCont, Timestamp endTime) {
+		if (isLastPassEligible() == false) {
+			return;
+		}
+
+		Connection conn = null;
+		try {
+			conn = ds.getConnection();
+			upsertLastPass(conn, category, testCase, resultCont, endTime, context.getBuildId());
+		} catch (Exception e) {
+			warnLastPass("shell_last_pass refresh", category, testCase, e);
+		} finally {
+			close(conn);
+		}
+	}
+
+	private void insertLastPassSnapshot(Connection conn, int itemId, String category, String testCase) {
+		if (isLastPassEligible() == false) {
+			return;
+		}
+
+		PreparedStatement selectStmt = null;
+		PreparedStatement insertStmt = null;
+		ResultSet rs = null;
+
+		try {
+			selectStmt = conn.prepareStatement(
+					"select main_id, build_id, result_cont, end_time from shell_last_pass where category=? and version_id=? and case_file=? and build_wid<=? limit 1");
+			selectStmt.setString(1, category);
+			selectStmt.setString(2, lastPassVersionId);
+			selectStmt.setString(3, testCase);
+			selectStmt.setString(4, lastPassBuildWid);
+			rs = selectStmt.executeQuery();
+
+			if (rs.next()) {
+				int lastPassMainId = rs.getInt("main_id");
+				boolean isMainIdNull = rs.wasNull();
+				insertStmt = conn.prepareStatement(
+						"insert into shell_last_pass_snapshot(item_id, last_pass_main_id, last_pass_build_id, last_pass_result_cont, last_pass_end_time) values(?, ?, ?, ?, ?)");
+				insertStmt.setInt(1, itemId);
+				if (isMainIdNull) {
+					insertStmt.setNull(2, Types.INTEGER);
+				} else {
+					insertStmt.setInt(2, lastPassMainId);
+				}
+				insertStmt.setString(3, rs.getString("build_id"));
+				insertStmt.setString(4, rs.getString("result_cont"));
+				insertStmt.setTimestamp(5, rs.getTimestamp("end_time"));
+				insertStmt.executeUpdate();
+			}
+		} catch (Exception e) {
+			warnLastPass("shell_last_pass_snapshot insert", category, testCase, e);
+		} finally {
+			close(rs);
+			close(selectStmt);
+			close(insertStmt);
+		}
+	}
+
+	private void upsertLastPass(Connection conn, String category, String testCase, String resultCont, Timestamp endTime, String buildId) throws Exception {
+		PreparedStatement selectStmt = null;
+		PreparedStatement updateStmt = null;
+		PreparedStatement insertStmt = null;
+		ResultSet rs = null;
+
+		try {
+			selectStmt = conn.prepareStatement("select build_id, build_wid from shell_last_pass where category=? and version_id=? and case_file=?");
+			selectStmt.setString(1, category);
+			selectStmt.setString(2, lastPassVersionId);
+			selectStmt.setString(3, testCase);
+			rs = selectStmt.executeQuery();
+
+			if (rs.next()) {
+				String storedBuildId = rs.getString("build_id");
+				String storedBuildWid = rs.getString("build_wid");
+				if (shouldReplaceLastPass(storedBuildId, storedBuildWid, buildId)) {
+					updateStmt = conn.prepareStatement(
+							"update shell_last_pass set build_id=?, build_wid=?, main_id=?, result_cont=?, end_time=? where category=? and version_id=? and case_file=?");
+					updateStmt.setString(1, buildId);
+					updateStmt.setString(2, lastPassBuildWid);
+					updateStmt.setInt(3, task_id);
+					updateStmt.setString(4, resultCont);
+					updateStmt.setTimestamp(5, endTime);
+					updateStmt.setString(6, category);
+					updateStmt.setString(7, lastPassVersionId);
+					updateStmt.setString(8, testCase);
+					updateStmt.executeUpdate();
+				}
+			} else {
+				insertStmt = conn.prepareStatement(
+						"insert into shell_last_pass(category, version_id, case_file, build_id, build_wid, main_id, result_cont, end_time) values(?, ?, ?, ?, ?, ?, ?, ?)");
+				insertStmt.setString(1, category);
+				insertStmt.setString(2, lastPassVersionId);
+				insertStmt.setString(3, testCase);
+				insertStmt.setString(4, buildId);
+				insertStmt.setString(5, lastPassBuildWid);
+				insertStmt.setInt(6, task_id);
+				insertStmt.setString(7, resultCont);
+				insertStmt.setTimestamp(8, endTime);
+				insertStmt.executeUpdate();
+			}
+		} finally {
+			close(rs);
+			close(selectStmt);
+			close(updateStmt);
+			close(insertStmt);
+		}
+	}
+
+	private boolean shouldReplaceLastPass(String storedBuildId, String storedBuildWid, String buildId) {
+		if (storedBuildWid == null || storedBuildWid.trim().length() == 0) {
+			return true;
+		}
+
+		int compareResult = storedBuildWid.compareTo(lastPassBuildWid);
+		if (compareResult < 0) {
+			return true;
+		}
+
+		return compareResult == 0 && buildId != null && buildId.equals(storedBuildId);
+	}
+
+	private int selectLastInsertId(Connection conn) throws Exception {
+		PreparedStatement stmt = null;
+		ResultSet rs = null;
+
+		try {
+			stmt = conn.prepareStatement("select last_insert_id()");
+			rs = stmt.executeQuery();
+			if (rs.next()) {
+				return rs.getInt(1);
+			}
+		} finally {
+			close(rs);
+			close(stmt);
+		}
+
+		return 0;
+	}
+
+	private boolean isExecutedCase(String skippedType) {
+		return Constants.SKIP_TYPE_NO.equals(skippedType);
+	}
+
+	private void resolveLastPassBuildContext(String buildId) {
+		Connection conn = null;
+		PreparedStatement stmt = null;
+		ResultSet rs = null;
+
+		clearLastPassBuildContext();
+		if (buildId == null || buildId.trim().length() == 0) {
+			return;
+		}
+
+		try {
+			conn = ds.getConnection();
+			stmt = conn.prepareStatement("select version_id, cversion(build_id) as build_wid from cubrid_build where build_id=? and build_type='general' limit 1");
+			stmt.setString(1, buildId);
+			rs = stmt.executeQuery();
+			if (rs.next()) {
+				lastPassVersionId = rs.getString("version_id");
+				lastPassBuildWid = rs.getString("build_wid");
+				lastPassEligible = lastPassVersionId != null && lastPassVersionId.trim().length() > 0 && lastPassBuildWid != null && lastPassBuildWid.trim().length() > 0;
+			}
+		} catch (Exception e) {
+			clearLastPassBuildContext();
+			warnLastPassBuild("cubrid_build resolve", buildId, e);
+		} finally {
+			close(rs);
 			close(stmt);
 			close(conn);
 		}
+	}
 
-		if (skippedType.equals(Constants.SKIP_TYPE_NO)) {
-			refreshShellMain(false);
-			if (hasCore) {
-				notifyUpdateMain();
-			}
-		}
+	private void clearLastPassBuildContext() {
+		lastPassEligible = false;
+		lastPassVersionId = null;
+		lastPassBuildWid = null;
+	}
+
+	private boolean isLastPassEligible() {
+		return lastPassEligible && lastPassVersionId != null && lastPassBuildWid != null;
+	}
+
+	private void warnLastPass(String action, String category, String testCase, Exception e) {
+		System.err.println("[WARN] " + action + " failed for " + category + ":" + testCase + " - " + e.getMessage());
+	}
+
+	private void warnLastPassBuild(String action, String buildId, Exception e) {
+		System.err.println("[WARN] " + action + " failed for build_id=" + buildId + " - " + e.getMessage());
 	}
 
 	/**

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
@@ -31,6 +31,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.sql.Types;
 
 import javax.sql.DataSource;
 
@@ -54,6 +55,9 @@ public class FeedbackDB implements Feedback {
 	int tbdNum = 0;
 	int macroSkippedNum = 0;
 	int tempSkippedNum = 0;
+	boolean lastPassEligible = false;
+	String lastPassVersionId = null;
+	String lastPassBuildWid = null;
 
 	public FeedbackDB(Context context) {
 		this.context = context;
@@ -116,6 +120,7 @@ public class FeedbackDB implements Feedback {
 		log.println(String.valueOf(task_id));
 		context.setTaskId(task_id);
 		log.close();
+		resolveLastPassBuildContext(build);
 	}
 
 	@Override
@@ -126,8 +131,10 @@ public class FeedbackDB implements Feedback {
 			cont = CommonUtils.getFileContent(CommonUtils.concatFile(context.getCurrentLogDir(), "current_task_id"));
 			this.task_id = Integer.parseInt(cont.trim());
 			context.setTaskId(task_id);
+			resolveLastPassBuildContext(context.getTestBuild());
 		} catch (Exception e) {
 			this.task_id = -1;
+			clearLastPassBuildContext();
 			e.printStackTrace();
 		}
 	}
@@ -316,58 +323,32 @@ public class FeedbackDB implements Feedback {
 
 	@Override
 	public void onTestCaseStopEvent(String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedType, int retryCount) {
+		String category = context.getTestCategory();
+		Timestamp d = new Timestamp(System.currentTimeMillis());
+		resultCont = trimResultContent(resultCont);
+		boolean isExecutedCase = isExecutedCase(skippedType);
 
 		if (context.isSkipToSaveSuccCase() == false || flag == false) {
 			Connection conn = null;
-			int resultContSize = 0;
-
-			PreparedStatement stmt = null;
-			String sql;
-
-			long caseStopTime = System.currentTimeMillis();
-			Timestamp d = new Timestamp(caseStopTime);
-			if (resultCont != null) {
-				resultContSize = resultCont.length();
-				if (resultContSize > MAX_CONTENT_SIZE) {
-					String resultContPrefix = resultCont.substring(0, MAX_CONTENT_SIZE / 2);
-					String resultContSuffer = resultCont.substring(resultContSize - MAX_CONTENT_SIZE / 2, resultContSize);
-					resultCont = resultContPrefix + System.getProperty("line.separator") + "********** THE CONTENT LENGTH IS" + resultContSize + "(TRIMMED) **********"
-							+ System.getProperty("line.separator") + resultContSuffer;
-				}
-			}
-
-			sql = "insert into shell_items(main_id, case_file, env_node, elapse_time, test_result, is_timeout, has_core, result_cont, end_time, is_skipped, retry_count) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 			try {
 				conn = ds.getConnection();
-
-				stmt = conn.prepareStatement(sql);
-				stmt.setInt(1, task_id);
-				stmt.setString(2, testCase);
-				stmt.setString(3, envIdentify);
-				stmt.setDouble(4, elapseTime);
-				if (skippedType.equals(Constants.SKIP_TYPE_NO)) {
-					stmt.setString(5, (flag ? "OK" : "NOK"));
-				} else {
-					stmt.setString(5, "");
+				int itemId = insertShellItem(conn, testCase, flag, elapseTime, resultCont, envIdentify, isTimeOut, hasCore, skippedType, retryCount, d);
+				if (isExecutedCase && flag == false && itemId > 0) {
+					insertLastPassSnapshot(conn, itemId, category, testCase);
 				}
-				stmt.setString(6, (isTimeOut ? "Y" : "N"));
-				stmt.setString(7, (hasCore ? "Y" : "N"));
-				stmt.setString(8, resultCont);
-				stmt.setTimestamp(9, d);
-				stmt.setString(10, skippedType);
-				stmt.setInt(11, retryCount);
-				stmt.executeUpdate();
-
 			} catch (Exception e) {
 				e.printStackTrace();
 			} finally {
-				close(stmt);
 				close(conn);
 			}
 		}
 
-		if (skippedType.equals(Constants.SKIP_TYPE_NO)) {
+		if (isExecutedCase && flag) {
+			refreshLastPass(category, testCase, resultCont, d);
+		}
+
+		if (isExecutedCase) {
 			updateShellMain(flag, hasCore);
 		}
 	}
@@ -376,22 +357,12 @@ public class FeedbackDB implements Feedback {
 	public void onTestCaseStopEventForRetry(String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedType,
 			int retryCount) {
 		Connection conn = null;
-		int resultContSize = 0;
 
 		PreparedStatement stmt = null;
 		String sql;
 
-		long caseStopTime = System.currentTimeMillis();
-		Timestamp d = new Timestamp(caseStopTime);
-		if (resultCont != null) {
-			resultContSize = resultCont.length();
-			if (resultContSize > MAX_CONTENT_SIZE) {
-				String resultContPrefix = resultCont.substring(0, MAX_CONTENT_SIZE / 2);
-				String resultContSuffer = resultCont.substring(resultContSize - MAX_CONTENT_SIZE / 2, resultContSize);
-				resultCont = resultContPrefix + System.getProperty("line.separator") + "********** THE CONTENT LENGTH IS" + resultContSize + "(TRIMMED) **********"
-						+ System.getProperty("line.separator") + resultContSuffer;
-			}
-		}
+		Timestamp d = new Timestamp(System.currentTimeMillis());
+		resultCont = trimResultContent(resultCont);
 
 		sql = "insert into shell_retry_log(main_id, case_file, env_node, elapse_time, test_result, is_timeout, has_core, result_cont, end_time, is_skipped, retry_count) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
@@ -422,6 +393,248 @@ public class FeedbackDB implements Feedback {
 			close(stmt);
 			close(conn);
 		}
+	}
+
+	private int insertShellItem(Connection conn, String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedType,
+			int retryCount, Timestamp endTime) throws Exception {
+		PreparedStatement stmt = null;
+		String sql = "insert into shell_items(main_id, case_file, env_node, elapse_time, test_result, is_timeout, has_core, result_cont, end_time, is_skipped, retry_count) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+		try {
+			stmt = conn.prepareStatement(sql);
+			stmt.setInt(1, task_id);
+			stmt.setString(2, testCase);
+			stmt.setString(3, envIdentify);
+			stmt.setDouble(4, elapseTime);
+			if (isExecutedCase(skippedType)) {
+				stmt.setString(5, (flag ? "OK" : "NOK"));
+			} else {
+				stmt.setString(5, "");
+			}
+			stmt.setString(6, (isTimeOut ? "Y" : "N"));
+			stmt.setString(7, (hasCore ? "Y" : "N"));
+			stmt.setString(8, resultCont);
+			stmt.setTimestamp(9, endTime);
+			stmt.setString(10, skippedType);
+			stmt.setInt(11, retryCount);
+			stmt.executeUpdate();
+		} finally {
+			close(stmt);
+		}
+
+		if (isExecutedCase(skippedType) && flag == false) {
+			return selectLastInsertId(conn);
+		}
+
+		return 0;
+	}
+
+	private void refreshLastPass(String category, String testCase, String resultCont, Timestamp endTime) {
+		if (isLastPassEligible() == false) {
+			return;
+		}
+
+		Connection conn = null;
+		try {
+			conn = ds.getConnection();
+			upsertLastPass(conn, category, testCase, resultCont, endTime, context.getTestBuild());
+		} catch (Exception e) {
+			warnLastPass("shell_last_pass refresh", category, testCase, e);
+		} finally {
+			close(conn);
+		}
+	}
+
+	private void insertLastPassSnapshot(Connection conn, int itemId, String category, String testCase) {
+		if (isLastPassEligible() == false) {
+			return;
+		}
+
+		PreparedStatement selectStmt = null;
+		PreparedStatement insertStmt = null;
+		ResultSet rs = null;
+
+		try {
+			selectStmt = conn.prepareStatement(
+					"select main_id, build_id, result_cont, end_time from shell_last_pass where category=? and version_id=? and case_file=? and build_wid<=? limit 1");
+			selectStmt.setString(1, category);
+			selectStmt.setString(2, lastPassVersionId);
+			selectStmt.setString(3, testCase);
+			selectStmt.setString(4, lastPassBuildWid);
+			rs = selectStmt.executeQuery();
+
+			if (rs.next()) {
+				int lastPassMainId = rs.getInt("main_id");
+				boolean isMainIdNull = rs.wasNull();
+				insertStmt = conn.prepareStatement(
+						"insert into shell_last_pass_snapshot(item_id, last_pass_main_id, last_pass_build_id, last_pass_result_cont, last_pass_end_time) values(?, ?, ?, ?, ?)");
+				insertStmt.setInt(1, itemId);
+				if (isMainIdNull) {
+					insertStmt.setNull(2, Types.INTEGER);
+				} else {
+					insertStmt.setInt(2, lastPassMainId);
+				}
+				insertStmt.setString(3, rs.getString("build_id"));
+				insertStmt.setString(4, rs.getString("result_cont"));
+				insertStmt.setTimestamp(5, rs.getTimestamp("end_time"));
+				insertStmt.executeUpdate();
+			}
+		} catch (Exception e) {
+			warnLastPass("shell_last_pass_snapshot insert", category, testCase, e);
+		} finally {
+			close(rs);
+			close(selectStmt);
+			close(insertStmt);
+		}
+	}
+
+	private void upsertLastPass(Connection conn, String category, String testCase, String resultCont, Timestamp endTime, String buildId) throws Exception {
+		PreparedStatement selectStmt = null;
+		PreparedStatement updateStmt = null;
+		PreparedStatement insertStmt = null;
+		ResultSet rs = null;
+
+		try {
+			selectStmt = conn.prepareStatement("select build_id, build_wid from shell_last_pass where category=? and version_id=? and case_file=?");
+			selectStmt.setString(1, category);
+			selectStmt.setString(2, lastPassVersionId);
+			selectStmt.setString(3, testCase);
+			rs = selectStmt.executeQuery();
+
+			if (rs.next()) {
+				String storedBuildId = rs.getString("build_id");
+				String storedBuildWid = rs.getString("build_wid");
+				if (shouldReplaceLastPass(storedBuildId, storedBuildWid, buildId)) {
+					updateStmt = conn.prepareStatement(
+							"update shell_last_pass set build_id=?, build_wid=?, main_id=?, result_cont=?, end_time=? where category=? and version_id=? and case_file=?");
+					updateStmt.setString(1, buildId);
+					updateStmt.setString(2, lastPassBuildWid);
+					updateStmt.setInt(3, task_id);
+					updateStmt.setString(4, resultCont);
+					updateStmt.setTimestamp(5, endTime);
+					updateStmt.setString(6, category);
+					updateStmt.setString(7, lastPassVersionId);
+					updateStmt.setString(8, testCase);
+					updateStmt.executeUpdate();
+				}
+			} else {
+				insertStmt = conn.prepareStatement(
+						"insert into shell_last_pass(category, version_id, case_file, build_id, build_wid, main_id, result_cont, end_time) values(?, ?, ?, ?, ?, ?, ?, ?)");
+				insertStmt.setString(1, category);
+				insertStmt.setString(2, lastPassVersionId);
+				insertStmt.setString(3, testCase);
+				insertStmt.setString(4, buildId);
+				insertStmt.setString(5, lastPassBuildWid);
+				insertStmt.setInt(6, task_id);
+				insertStmt.setString(7, resultCont);
+				insertStmt.setTimestamp(8, endTime);
+				insertStmt.executeUpdate();
+			}
+		} finally {
+			close(rs);
+			close(selectStmt);
+			close(updateStmt);
+			close(insertStmt);
+		}
+	}
+
+	private boolean shouldReplaceLastPass(String storedBuildId, String storedBuildWid, String buildId) {
+		if (storedBuildWid == null || storedBuildWid.trim().length() == 0) {
+			return true;
+		}
+
+		int compareResult = storedBuildWid.compareTo(lastPassBuildWid);
+		if (compareResult < 0) {
+			return true;
+		}
+
+		return compareResult == 0 && buildId != null && buildId.equals(storedBuildId);
+	}
+
+	private int selectLastInsertId(Connection conn) throws Exception {
+		PreparedStatement stmt = null;
+		ResultSet rs = null;
+
+		try {
+			stmt = conn.prepareStatement("select last_insert_id()");
+			rs = stmt.executeQuery();
+			if (rs.next()) {
+				return rs.getInt(1);
+			}
+		} finally {
+			close(rs);
+			close(stmt);
+		}
+
+		return 0;
+	}
+
+	private String trimResultContent(String resultCont) {
+		if (resultCont == null) {
+			return null;
+		}
+
+		int resultContSize = resultCont.length();
+		if (resultContSize <= MAX_CONTENT_SIZE) {
+			return resultCont;
+		}
+
+		String resultContPrefix = resultCont.substring(0, MAX_CONTENT_SIZE / 2);
+		String resultContSuffix = resultCont.substring(resultContSize - MAX_CONTENT_SIZE / 2, resultContSize);
+		return resultContPrefix + System.getProperty("line.separator") + "********** THE CONTENT LENGTH IS" + resultContSize + "(TRIMMED) **********" + System.getProperty("line.separator")
+				+ resultContSuffix;
+	}
+
+	private boolean isExecutedCase(String skippedType) {
+		return Constants.SKIP_TYPE_NO.equals(skippedType);
+	}
+
+	private void resolveLastPassBuildContext(String buildId) {
+		Connection conn = null;
+		PreparedStatement stmt = null;
+		ResultSet rs = null;
+
+		clearLastPassBuildContext();
+		if (buildId == null || buildId.trim().length() == 0) {
+			return;
+		}
+
+		try {
+			conn = ds.getConnection();
+			stmt = conn.prepareStatement("select version_id, cversion(build_id) as build_wid from cubrid_build where build_id=? and build_type='general' limit 1");
+			stmt.setString(1, buildId);
+			rs = stmt.executeQuery();
+			if (rs.next()) {
+				lastPassVersionId = rs.getString("version_id");
+				lastPassBuildWid = rs.getString("build_wid");
+				lastPassEligible = lastPassVersionId != null && lastPassVersionId.trim().length() > 0 && lastPassBuildWid != null && lastPassBuildWid.trim().length() > 0;
+			}
+		} catch (Exception e) {
+			clearLastPassBuildContext();
+			warnLastPassBuild("cubrid_build resolve", buildId, e);
+		} finally {
+			close(rs);
+			close(stmt);
+			close(conn);
+		}
+	}
+
+	private void clearLastPassBuildContext() {
+		lastPassEligible = false;
+		lastPassVersionId = null;
+		lastPassBuildWid = null;
+	}
+
+	private boolean isLastPassEligible() {
+		return lastPassEligible && lastPassVersionId != null && lastPassBuildWid != null;
+	}
+
+	private void warnLastPass(String action, String category, String testCase, Exception e) {
+		System.err.println("[WARN] " + action + " failed for " + category + ":" + testCase + " - " + e.getMessage());
+	}
+
+	private void warnLastPassBuild(String action, String buildId, Exception e) {
+		System.err.println("[WARN] " + action + " failed for build_id=" + buildId + " - " + e.getMessage());
 	}
 
 	/**

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
@@ -325,7 +325,8 @@ public class FeedbackDB implements Feedback {
 	public void onTestCaseStopEvent(String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedType, int retryCount) {
 		String category = context.getTestCategory();
 		Timestamp d = new Timestamp(System.currentTimeMillis());
-		resultCont = trimResultContent(resultCont);
+		String lastPassResultCont = resultCont;
+		String shellItemResultCont = trimResultContent(resultCont);
 		boolean isExecutedCase = isExecutedCase(skippedType);
 
 		if (context.isSkipToSaveSuccCase() == false || flag == false) {
@@ -333,7 +334,7 @@ public class FeedbackDB implements Feedback {
 
 			try {
 				conn = ds.getConnection();
-				int itemId = insertShellItem(conn, testCase, flag, elapseTime, resultCont, envIdentify, isTimeOut, hasCore, skippedType, retryCount, d);
+				int itemId = insertShellItem(conn, testCase, flag, elapseTime, shellItemResultCont, envIdentify, isTimeOut, hasCore, skippedType, retryCount, d);
 				if (isExecutedCase && flag == false && itemId > 0) {
 					insertLastPassSnapshot(conn, itemId, category, testCase);
 				}
@@ -345,7 +346,7 @@ public class FeedbackDB implements Feedback {
 		}
 
 		if (isExecutedCase && flag) {
-			refreshLastPass(category, testCase, resultCont, d);
+			refreshLastPass(category, testCase, lastPassResultCont, d);
 		}
 
 		if (isExecutedCase) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1370

Added writer-side support for shell last-pass logs in CTP.

This introduces lineage-gated storage for the previous successful full log, plus frozen snapshots for failing rows, without changing normal `shell_items` pass retention behavior.

Note: 기존 `shell_items`관련 로직은 변경되지 않습니다. 최신으로 성공한 full 로그를 트래킹 및 스냅샷을 기록하는 기능을 추가하였으며, 이는 실패하거나 잘못되어도 기존 CTP shell 수행 프로세스는 영향을 받지 않습니다.

## Changes

- Added build eligibility resolution from `cubrid_build`
- Added `shell_last_pass` refresh on eligible executed `OK`
- Added `shell_last_pass_snapshot` freeze on eligible executed `NOK`
- Kept `shell_items` behavior the same as before for normal pass rows
- Kept full successful logs only in `shell_last_pass`
- Kept `shell_retry_log` separate from last-pass logic


# Write Path Logic

### Success path

Executed successful cases:

- keep existing `shell_items` behavior
- if eligible, refresh `shell_last_pass`
- overwrite only when:
  - no row exists yet
  - incoming `build_wid` is newer than the stored row
  - incoming `build_wid` is the same and it is a rerun of the same `build_id`
- do not overwrite with an older build

If `skipToSaveSuccCase=true`:

- OK `shell_items` rows may still be skipped
- `shell_last_pass` is still refreshed for eligible successful cases

```mermaid
sequenceDiagram
    participant W as Writer FeedbackDB
    participant CB as cubrid_build
    participant SI as shell_items
    participant SLP as shell_last_pass

    W->>CB: resolve(build_id)
    CB-->>W: version_id, build_wid, eligible=true
    W->>SI: insert OK shell_items row if normal path allows
    alt eligible executed OK
        W->>SLP: select existing row by category/version/case
        alt no row
            W->>SLP: insert latest successful log
        else stored row is older or same exact build
            W->>SLP: update latest successful log
        else stored row is newer
            W-->>W: keep existing row
        end
    end
```

### Failure path

Executed failing cases:

- insert the normal `shell_items` row first
- get the new `item_id`
- if the task is eligible, read `shell_last_pass` using:
  - same `category`
  - same `version_id`
  - same `case_file`
  - `stored build_wid <= current build_wid`
- if a row is found, freeze it into `shell_last_pass_snapshot`
- if no row is found, write no snapshot

```mermaid
sequenceDiagram
    participant W as Writer FeedbackDB
    participant SI as shell_items
    participant SLP as shell_last_pass
    participant SNAP as shell_last_pass_snapshot

    W->>SI: insert NOK shell_items row
    SI-->>W: new item_id
    alt eligible executed NOK
        W->>SLP: select same lineage where stored build_wid <= current build_wid
        alt match found
            SLP-->>W: build_id, main_id, result_cont, end_time
            W->>SNAP: insert frozen snapshot by item_id
        else no valid prior success
            W-->>W: no snapshot written
        end
    else ineligible task
        W-->>W: no snapshot lookup
    end
```
