### PR TITLE
[CUBRIDQA-1337] fix retry logic bug.

### DIFF
--- a/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
@@ -117,7 +117,12 @@ public class Dispatch {
 			}
 
 			if (normalCompletedCount < totalTbdSize) {
-				try { wait(1000); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); }
+				try {
+					wait(1000);
+				} catch (InterruptedException ie) {
+					Thread.currentThread().interrupt();
+					return null;
+				}
 				continue;
 			}
 
@@ -128,7 +133,12 @@ public class Dispatch {
 			}
 
 			if (!activeRetrySet.isEmpty()) {
-				try { wait(1000); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); }
+				try {
+					wait(1000);
+				} catch (InterruptedException ie) {
+					Thread.currentThread().interrupt();
+					return null;
+				}
 				continue;
 			}
 

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
@@ -59,8 +59,12 @@ public class Dispatch {
 
 	private boolean isFinished;
 	
-	// Retry management
+	// Retry management - minimal gate design
 	private HashMap<String, Integer> retryCountMap;
+	private java.util.ArrayDeque<String> retryQueue;
+	private java.util.HashSet<String> activeRetrySet;
+	private int maxRetryCount;
+	private int normalCompletedCount;
 
 	private Dispatch(Context context) throws Exception {
 		this.context = context;
@@ -69,7 +73,24 @@ public class Dispatch {
 		this.isFinished = false;
 		this.nextTestFileIndex = -1;
 		this.retryCountMap = new HashMap<String, Integer>();
+		this.maxRetryCount = context.getMaxRetryCount();
+		this.retryQueue = new java.util.ArrayDeque<String>();
+		this.activeRetrySet = new java.util.HashSet<String>();
+		this.normalCompletedCount = 0;
 		load();
+	}
+
+	Dispatch(java.util.ArrayList<String> tbdList, int maxRetryCount) {
+		this.context = null;
+		this.tbdList = tbdList;
+		this.totalTbdSize = tbdList == null ? 0 : tbdList.size();
+		this.nextTestFileIndex = 0;
+		this.isFinished = false;
+		this.retryCountMap = new java.util.HashMap<String, Integer>();
+		this.retryQueue = new java.util.ArrayDeque<String>();
+		this.activeRetrySet = new java.util.HashSet<String>();
+		this.maxRetryCount = maxRetryCount;
+		this.normalCompletedCount = 0;
 	}
 
 	public static void init(Context context) throws Exception {
@@ -81,29 +102,39 @@ public class Dispatch {
 	}
 
 	public synchronized String nextTestFile() {
-		if (isFinished)
-			return null;
+		while (true) {
+			if (isFinished) {
+				return null;
+			}
 
-		// First, process all normal test cases
-		if (this.nextTestFileIndex < totalTbdSize) {
 			if (this.nextTestFileIndex < 0) {
 				this.nextTestFileIndex = 0;
 			}
-			String nextTestFile = tbdList.get(this.nextTestFileIndex);
-			this.nextTestFileIndex++;
-			return nextTestFile;
-		}
+			if (this.nextTestFileIndex < totalTbdSize) {
+				String nextTestFile = tbdList.get(this.nextTestFileIndex);
+				this.nextTestFileIndex++;
+				return nextTestFile;
+			}
 
-		// After all normal cases are done, process retry cases
-		if (!retryCountMap.isEmpty()) {
-			// Get first retry case
-			String retryTestFile = retryCountMap.keySet().iterator().next();
-			return retryTestFile;
-		}
+			if (normalCompletedCount < totalTbdSize) {
+				try { wait(1000); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); }
+				continue;
+			}
 
-		// All done
-		isFinished = true;
-		return null;
+			String retryTestFile = retryQueue.poll();
+			if (retryTestFile != null) {
+				activeRetrySet.add(retryTestFile);
+				return retryTestFile;
+			}
+
+			if (!activeRetrySet.isEmpty()) {
+				try { wait(1000); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); }
+				continue;
+			}
+
+			isFinished = true;
+			return null;
+		}
 	}
 	
 	public synchronized void addFailedTestCaseForRetry(String testCase) {
@@ -111,10 +142,13 @@ public class Dispatch {
 		if (currentRetryCount == null) {
 			currentRetryCount = 0;
 		}
-		
-		if (currentRetryCount < context.getMaxRetryCount()) {
+		if (currentRetryCount < maxRetryCount) {
 			retryCountMap.put(testCase, currentRetryCount + 1);
+			retryQueue.offer(testCase);
 		}
+		activeRetrySet.remove(testCase);
+		isFinished = false;
+		notifyAll();
 	}
 	
 	public synchronized Integer getRetryCount(String testCase) {
@@ -122,8 +156,16 @@ public class Dispatch {
 		return count != null ? count : 0;
 	}
 	
+	public synchronized void markNormalTestCaseCompleted() {
+		normalCompletedCount++;
+		notifyAll();
+	}
+
 	public synchronized void removeFromRetryQueue(String testCase) {
 		retryCountMap.remove(testCase);
+		retryQueue.remove(testCase);
+		activeRetrySet.remove(testCase);
+		notifyAll();
 	}
 	
 

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
@@ -216,6 +216,10 @@ public class Test {
 					Dispatch.getInstance().removeFromRetryQueue(this.testCaseFullName);
 				}
 
+				if (currentRetryCount == 0) {
+					Dispatch.getInstance().markNormalTestCaseCompleted();
+				}
+
 				workerLog.println("");
 			}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1366

# Purpose
두 커밋(`f2e3c54`, `66e5cce`)의 목적은 shell retry 실행의 **정확성**과 **종료 안정성**을 함께 보장하는 것입니다.

- `f2e3c54`: retry 활성화 시 `execute_rate`가 100%를 초과할 수 있던 문제를 해결하기 위해, normal 실행과 retry 실행의 순서를 명시적으로 분리했습니다.
- `66e5cce`: `Dispatch.nextTestFile()` 대기 루프에서 인터럽트 발생 시 루프 재진입 위험을 제거해 worker가 안전하게 종료되도록 보완했습니다.

# Implementation

## 1) execute_rate 초과 문제 수정 (f2e3c54)

### Dispatch.java
- retry 관리 구조는 기존 `retryCountMap`에 더해 다음 필드를 추가했습니다.
  - `retryQueue: ArrayDeque<String>`
  - `activeRetrySet: HashSet<String>`
  - `maxRetryCount: int`
  - `normalCompletedCount: int`

- `nextTestFile()` 흐름을 `while (true)` 기반으로 재구성했습니다.
  1. 정상 케이스(`tbdList`)를 먼저 배포
  2. 정상 배포가 끝나도 `normalCompletedCount < totalTbdSize`이면 `wait(1000)` 대기
  3. 정상 완료 신호가 충족되면 `retryQueue.poll()`로 retry 케이스 배포
  4. `activeRetrySet`이 비어있지 않으면 대기하여 retry in-flight 종료를 보장
  5. 더 이상 normal/retry 작업이 없을 때 `isFinished = true`로 종료

- `addFailedTestCaseForRetry(String)`에서
  - retry 횟수 조건(`currentRetryCount < maxRetryCount`) 만족 시 `retryCountMap` 증가 + `retryQueue.offer(testCase)`
  - `activeRetrySet.remove(testCase)`
  - `isFinished = false` 및 `notifyAll()` 호출

- `markNormalTestCaseCompleted()` 추가:
  - `normalCompletedCount++`
  - `notifyAll()`로 대기 중 dispatcher 깨움

- `removeFromRetryQueue(String)` 확장:
  - `retryCountMap`, `retryQueue`, `activeRetrySet` 동시 정리
  - `notifyAll()` 호출

### Test.java
- 정상 실행 완료 시점에 completion signal을 연결했습니다.
  - `if (currentRetryCount == 0) Dispatch.getInstance().markNormalTestCaseCompleted();`
  - 즉, 성공/실패와 무관하게 최초 실행(`currentRetryCount == 0`) 완료만 `normalCompletedCount`에 반영됩니다.

## 2) 인터럽트 대기 루프 보완 (66e5cce)

- 파일: `CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java`
- 대상: `nextTestFile()` 내부의 두 `wait(1000)` 구간
  - `normalCompletedCount < totalTbdSize` 대기 구간
  - `!activeRetrySet.isEmpty()` 대기 구간

- 변경 전:
  - `InterruptedException` 발생 시 `Thread.currentThread().interrupt();` 후 루프 계속
- 변경 후:
  - `Thread.currentThread().interrupt();`
  - `return null;`로 즉시 종료

# Remarks
- 커밋 기준 변경 파일:
  - `f2e3c54`: `Dispatch.java`, `Test.java`
  - `66e5cce`: `Dispatch.java`
- 핵심 효과:
  - normal-before-retry 순서 보장
  - retry in-flight 추적(`activeRetrySet`) 기반의 안정적 재시도
  - 인터럽트 시 busy loop 가능성 제거

