### PR TITLE
[CUBRIDQA-1370] [CTP] Stabilize shell last-pass writer flow and pass full success log

### DIFF
--- a/CTP/isolation/src/com/navercorp/cubridqa/isolation/impl/FeedbackDB.java
+++ b/CTP/isolation/src/com/navercorp/cubridqa/isolation/impl/FeedbackDB.java
@@ -392,6 +392,11 @@ public class FeedbackDB implements Feedback {
 		PreparedStatement selectStmt = null;
 		PreparedStatement insertStmt = null;
 		ResultSet rs = null;
+		boolean hasLastPass = false;
+		Integer lastPassMainId = null;
+		String lastPassBuildId = null;
+		String lastPassResultCont = null;
+		Timestamp lastPassEndTime = null;
 
 		try {
 			selectStmt = conn.prepareStatement(
@@ -403,19 +408,33 @@ public class FeedbackDB implements Feedback {
 			rs = selectStmt.executeQuery();
 
 			if (rs.next()) {
-				int lastPassMainId = rs.getInt("main_id");
-				boolean isMainIdNull = rs.wasNull();
+				hasLastPass = true;
+				int fetchedLastPassMainId = rs.getInt("main_id");
+				if (rs.wasNull() == false) {
+					lastPassMainId = Integer.valueOf(fetchedLastPassMainId);
+				}
+				lastPassBuildId = rs.getString("build_id");
+				lastPassResultCont = rs.getString("result_cont");
+				lastPassEndTime = rs.getTimestamp("end_time");
+			}
+
+			close(rs);
+			rs = null;
+			close(selectStmt);
+			selectStmt = null;
+
+			if (hasLastPass) {
 				insertStmt = conn.prepareStatement(
 						"insert into shell_last_pass_snapshot(item_id, last_pass_main_id, last_pass_build_id, last_pass_result_cont, last_pass_end_time) values(?, ?, ?, ?, ?)");
 				insertStmt.setInt(1, itemId);
-				if (isMainIdNull) {
+				if (lastPassMainId == null) {
 					insertStmt.setNull(2, Types.INTEGER);
 				} else {
 					insertStmt.setInt(2, lastPassMainId);
 				}
-				insertStmt.setString(3, rs.getString("build_id"));
-				insertStmt.setString(4, rs.getString("result_cont"));
-				insertStmt.setTimestamp(5, rs.getTimestamp("end_time"));
+				insertStmt.setString(3, lastPassBuildId);
+				insertStmt.setString(4, lastPassResultCont);
+				insertStmt.setTimestamp(5, lastPassEndTime);
 				insertStmt.executeUpdate();
 			}
 		} catch (Exception e) {
@@ -432,6 +451,9 @@ public class FeedbackDB implements Feedback {
 		PreparedStatement updateStmt = null;
 		PreparedStatement insertStmt = null;
 		ResultSet rs = null;
+		boolean hasStoredLastPass = false;
+		String storedBuildId = null;
+		String storedBuildWid = null;
 
 		try {
 			selectStmt = conn.prepareStatement("select build_id, build_wid from shell_last_pass where category=? and version_id=? and case_file=?");
@@ -441,8 +463,17 @@ public class FeedbackDB implements Feedback {
 			rs = selectStmt.executeQuery();
 
 			if (rs.next()) {
-				String storedBuildId = rs.getString("build_id");
-				String storedBuildWid = rs.getString("build_wid");
+				hasStoredLastPass = true;
+				storedBuildId = rs.getString("build_id");
+				storedBuildWid = rs.getString("build_wid");
+			}
+
+			close(rs);
+			rs = null;
+			close(selectStmt);
+			selectStmt = null;
+
+			if (hasStoredLastPass) {
 				if (shouldReplaceLastPass(storedBuildId, storedBuildWid, buildId)) {
 					updateStmt = conn.prepareStatement(
 							"update shell_last_pass set build_id=?, build_wid=?, main_id=?, result_cont=?, end_time=? where category=? and version_id=? and case_file=?");

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/Feedback.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/Feedback.java
@@ -40,6 +40,9 @@ public interface Feedback {
 
 	public void onTestCaseStopEvent(String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedKind, int retryCount);
 
+	public void onTestCaseStopEvent(String testCase, boolean flag, long elapseTime, String resultCont, String lastPassResultCont, String envIdentify, boolean isTimeOut, boolean hasCore,
+			String skippedKind, int retryCount);
+
 	public void onTestCaseStopEventForRetry(String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedKind,
 			int retryCount);
 

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
@@ -194,14 +194,17 @@ public class Test {
 					needRetry = false;
 				}
 				
+				String resultContString = resultCont.toString();
+				String lastPassResultCont = buildLastPassResultCont(resultContString, consoleOutput, testCaseSuccess);
+
 				// Send appropriate feedback based on retry status
 				if (needRetry) {
 					// This is a retry case (doesn't count in statistics)
-					context.getFeedback().onTestCaseStopEventForRetry(this.testCaseFullName, testCaseSuccess, endTime - startTime, resultCont.toString(), envIdentify, isTimeOut, hasCore,
+					context.getFeedback().onTestCaseStopEventForRetry(this.testCaseFullName, testCaseSuccess, endTime - startTime, resultContString, envIdentify, isTimeOut, hasCore,
 							Constants.SKIP_TYPE_NO, currentRetryCount);
 				} else {
 					// This is the final result (counts in statistics)
-					context.getFeedback().onTestCaseStopEvent(this.testCaseFullName, testCaseSuccess, endTime - startTime, resultCont.toString(), envIdentify, isTimeOut, hasCore,
+					context.getFeedback().onTestCaseStopEvent(this.testCaseFullName, testCaseSuccess, endTime - startTime, resultContString, lastPassResultCont, envIdentify, isTimeOut, hasCore,
 							Constants.SKIP_TYPE_NO, currentRetryCount);
 					System.out.println("[TESTCASE] " + this.testCaseFullName + " EnvId=" + this.currEnvId + " "
 							+ (testCaseSuccess ? "[OK]" : "[NOK]" + (this.maxRetryCount != 0 ? ", " + Constants.RETRY_FLAG + currentRetryCount : "")));
@@ -229,6 +232,20 @@ public class Test {
 		context.getFeedback().onStopEnvEvent(currEnvId);
 		System.out.println("[ENV STOP] " + currEnvId);
 		isStopped = true;
+	}
+
+	private String buildLastPassResultCont(String resultCont, String consoleOutput, boolean testCaseSuccess) {
+		if (testCaseSuccess == false || consoleOutput == null || consoleOutput.length() == 0) {
+			return resultCont;
+		}
+
+		StringBuffer fullResultCont = new StringBuffer();
+		if (resultCont != null) {
+			fullResultCont.append(resultCont);
+		}
+		fullResultCont.append("============================= CONSOLE OUTPUT =============================").append(Constants.LINE_SEPARATOR);
+		fullResultCont.append(consoleOutput);
+		return fullResultCont.toString();
 	}
 
 	public String runTestCase() throws Exception {

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
@@ -454,6 +454,11 @@ public class FeedbackDB implements Feedback {
 		PreparedStatement selectStmt = null;
 		PreparedStatement insertStmt = null;
 		ResultSet rs = null;
+		boolean hasLastPass = false;
+		Integer lastPassMainId = null;
+		String lastPassBuildId = null;
+		String lastPassResultCont = null;
+		Timestamp lastPassEndTime = null;
 
 		try {
 			selectStmt = conn.prepareStatement(
@@ -465,19 +470,33 @@ public class FeedbackDB implements Feedback {
 			rs = selectStmt.executeQuery();
 
 			if (rs.next()) {
-				int lastPassMainId = rs.getInt("main_id");
-				boolean isMainIdNull = rs.wasNull();
+				hasLastPass = true;
+				int fetchedLastPassMainId = rs.getInt("main_id");
+				if (rs.wasNull() == false) {
+					lastPassMainId = Integer.valueOf(fetchedLastPassMainId);
+				}
+				lastPassBuildId = rs.getString("build_id");
+				lastPassResultCont = rs.getString("result_cont");
+				lastPassEndTime = rs.getTimestamp("end_time");
+			}
+
+			close(rs);
+			rs = null;
+			close(selectStmt);
+			selectStmt = null;
+
+			if (hasLastPass) {
 				insertStmt = conn.prepareStatement(
 						"insert into shell_last_pass_snapshot(item_id, last_pass_main_id, last_pass_build_id, last_pass_result_cont, last_pass_end_time) values(?, ?, ?, ?, ?)");
 				insertStmt.setInt(1, itemId);
-				if (isMainIdNull) {
+				if (lastPassMainId == null) {
 					insertStmt.setNull(2, Types.INTEGER);
 				} else {
 					insertStmt.setInt(2, lastPassMainId);
 				}
-				insertStmt.setString(3, rs.getString("build_id"));
-				insertStmt.setString(4, rs.getString("result_cont"));
-				insertStmt.setTimestamp(5, rs.getTimestamp("end_time"));
+				insertStmt.setString(3, lastPassBuildId);
+				insertStmt.setString(4, lastPassResultCont);
+				insertStmt.setTimestamp(5, lastPassEndTime);
 				insertStmt.executeUpdate();
 			}
 		} catch (Exception e) {
@@ -494,6 +513,9 @@ public class FeedbackDB implements Feedback {
 		PreparedStatement updateStmt = null;
 		PreparedStatement insertStmt = null;
 		ResultSet rs = null;
+		boolean hasStoredLastPass = false;
+		String storedBuildId = null;
+		String storedBuildWid = null;
 
 		try {
 			selectStmt = conn.prepareStatement("select build_id, build_wid from shell_last_pass where category=? and version_id=? and case_file=?");
@@ -503,8 +525,17 @@ public class FeedbackDB implements Feedback {
 			rs = selectStmt.executeQuery();
 
 			if (rs.next()) {
-				String storedBuildId = rs.getString("build_id");
-				String storedBuildWid = rs.getString("build_wid");
+				hasStoredLastPass = true;
+				storedBuildId = rs.getString("build_id");
+				storedBuildWid = rs.getString("build_wid");
+			}
+
+			close(rs);
+			rs = null;
+			close(selectStmt);
+			selectStmt = null;
+
+			if (hasStoredLastPass) {
 				if (shouldReplaceLastPass(storedBuildId, storedBuildWid, buildId)) {
 					updateStmt = conn.prepareStatement(
 							"update shell_last_pass set build_id=?, build_wid=?, main_id=?, result_cont=?, end_time=? where category=? and version_id=? and case_file=?");

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
@@ -323,9 +323,17 @@ public class FeedbackDB implements Feedback {
 
 	@Override
 	public void onTestCaseStopEvent(String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedType, int retryCount) {
+		onTestCaseStopEvent(testCase, flag, elapseTime, resultCont, resultCont, envIdentify, isTimeOut, hasCore, skippedType, retryCount);
+	}
+
+	@Override
+	public void onTestCaseStopEvent(String testCase, boolean flag, long elapseTime, String resultCont, String lastPassResultCont, String envIdentify, boolean isTimeOut, boolean hasCore,
+			String skippedType, int retryCount) {
 		String category = context.getTestCategory();
 		Timestamp d = new Timestamp(System.currentTimeMillis());
-		String lastPassResultCont = resultCont;
+		if (lastPassResultCont == null) {
+			lastPassResultCont = resultCont;
+		}
 		String shellItemResultCont = trimResultContent(resultCont);
 		boolean isExecutedCase = isExecutedCase(skippedType);
 

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackFile.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackFile.java
@@ -233,6 +233,12 @@ public class FeedbackFile implements Feedback {
 	}
 
 	@Override
+	public void onTestCaseStopEvent(String testCase, boolean flag, long elapseTime, String resultCont, String lastPassResultCont, String envIdentify, boolean isTimeOut, boolean hasCore,
+			String skippedType, int retryCount) {
+		onTestCaseStopEvent(testCase, flag, elapseTime, resultCont, envIdentify, isTimeOut, hasCore, skippedType, retryCount);
+	}
+
+	@Override
 	public void onTestCaseStopEventForRetry(String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedType,
 			int retryCount) {
 		String head;

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackNull.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackNull.java
@@ -61,6 +61,13 @@ public class FeedbackNull implements Feedback {
 	}
 
 	@Override
+	public void onTestCaseStopEvent(String testCase, boolean flag, long elapseTime, String resultCont, String lastPassResultCont, String envIdentify, boolean isTimeOut, boolean hasCore,
+			String skippedType, int retryCount) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
 	public void onTestCaseStopEventForRetry(String testCase, boolean flag, long elapseTime, String resultCont, String envIdentify, boolean isTimeOut, boolean hasCore, String skippedKind,
 			int retryCount) {
 		// TODO Auto-generated method stub


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1370
Continued from: https://github.com/CUBRID/cubrid-testtools/pull/758

QAHome shell last-pass 기능 머지 이후, legacy shell/cc writer의 `shell_last_pass`/`shell_last_pass_snapshot` write 경로에서 조회용 `ResultSet`을 먼저 정리하도록 보강하고, legacy shell 성공 경로에서는 `shell_items`/retry의 기존 condensed payload는 유지한 채 `shell_last_pass`에만 full success log를 전달하도록 보강한 후속 **안정화** 수정

Follow-up stabilization for the legacy shell-family last-pass path after the QAHome shell last-pass merge. This preserves existing `shell_items` and retry behavior, closes the read-side JDBC resources before the follow-up write, and makes only `shell_last_pass` receive a separate full success log on successful legacy shell cases.

## Changes

- Updated legacy shell/cc last-pass refresh and snapshot flow to close the read-side `ResultSet` and statement before the follow-up write
- Kept existing last-pass feature behavior and normal row storage policy unchanged
- Updated the legacy shell runner path so normal `shell_items` and retry logs still use the existing condensed payload
- Added a separate success-only last-pass payload so `shell_last_pass` stores the full success log, including console output