### PR TITLE
[CUBRIDQA-1378] Migrate CTP build baseline from JDK 1.6 to JDK 1.8

### DIFF
--- a/CTP/README.md
+++ b/CTP/README.md
@@ -6,7 +6,7 @@ CTP is a testing tool for an open source project CUBRID. It is written in Java a
 
 ## Requirements
 * It supports Linux and Windows (Cygwin is required)
-* Install Java 6 or higher version, and you also need to set ``JAVA_HOME`` environment variable to point to the installation directory
+* Install Java 8 or higher version, and you also need to set ``JAVA_HOME`` environment variable to point to the installation directory
 * CUBRID and CUBRID_DATABASES environment variables should be configured before executing testing, please refer to http://www.cubrid.org/ for configuration guides
 
 ## Quick Start

--- a/CTP/build.xml
+++ b/CTP/build.xml
@@ -33,32 +33,32 @@
 
 	<target name="compile" depends="init" description="compile the source ">
 		<!-- Compile the java code from ${src} into ${build} -->
-		<javac target="1.6" source="1.6"  includeantruntime="false" srcdir="common/src" destdir="${build}">			
+		<javac target="1.8" source="1.8"  includeantruntime="false" srcdir="common/src" destdir="${build}">			
 			<!--<compilerarg value="-Xlint:unchecked"/>-->
 			<classpath refid="libs" />
 		</javac>
-		<javac target="1.6" source="1.6"  includeantruntime="false" srcdir="sql/src" destdir="${build}">
+		<javac target="1.8" source="1.8"  includeantruntime="false" srcdir="sql/src" destdir="${build}">
 			<!--<compilerarg value="-Xlint:unchecked"/>-->
 			<classpath refid="libs" />
 		</javac>
-		<javac target="1.6" source="1.6"  includeantruntime="false" srcdir="common/sched/src" destdir="${build}">
+		<javac target="1.8" source="1.8"  includeantruntime="false" srcdir="common/sched/src" destdir="${build}">
 			<!--<compilerarg value="-Xlint:unchecked"/>-->
 			<classpath refid="libs" />
 		</javac>
-		<javac target="1.6" source="1.6"  includeantruntime="false" srcdir="shell/src" destdir="${build}">
+		<javac target="1.8" source="1.8"  includeantruntime="false" srcdir="shell/src" destdir="${build}">
 			<!--<compilerarg value="-Xlint:unchecked"/>-->
 			<classpath refid="libs" />
 		</javac>
-		<javac target="1.6" source="1.6"  includeantruntime="false" srcdir="isolation/src" destdir="${build}">
+		<javac target="1.8" source="1.8"  includeantruntime="false" srcdir="isolation/src" destdir="${build}">
 			<classpath refid="libs" />
 		</javac>
-		<javac target="1.6" source="1.6"  includeantruntime="false" srcdir="ha_repl/src" destdir="${build}">
+		<javac target="1.8" source="1.8"  includeantruntime="false" srcdir="ha_repl/src" destdir="${build}">
 			<classpath refid="libs" />
 		</javac>
-		<javac target="1.6" source="1.6"  includeantruntime="false" srcdir="cdc_repl/src" destdir="${build}">
+		<javac target="1.8" source="1.8"  includeantruntime="false" srcdir="cdc_repl/src" destdir="${build}">
 			<classpath refid="libs" />
 		</javac>
-		<javac target="1.6" source="1.6"  includeantruntime="false" srcdir="shell/init_path/commonforjdbc_src" destdir="${build}">
+		<javac target="1.8" source="1.8"  includeantruntime="false" srcdir="shell/init_path/commonforjdbc_src" destdir="${build}">
 		</javac>
 	</target>
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1378

## Purpose

앞으로의 CTP 개발·빌드 기준을 JDK 1.8로 전환합니다. origin/develop의 CTP는 javac source/target=1.6으로 설정되어 있어 JDK 8로 빌드하면 JDK 8 비호환 경고가 발생합니다. 본 PR은 이 비호환 경고만 제거하며, **코드 로직 변경이나 기능 추가는 포함하지 않습니다.**

## Implementation

- `CTP/build.xml`: javac `source`/`target`을 `1.6` → `1.8`로 변경 (8개 컴파일 단위: common, sql, common/sched, shell, isolation, ha_repl, cdc_repl, shell/init_path/commonforjdbc_src)
- `CTP/README.md`: 요구사항 표기를 "Install Java 6 or higher" → "Install Java 8 or higher"로 갱신 (산출 클래스파일 버전이 50→52로 올라가 JRE 8+가 필요해지므로)

변경 규모는 2 files, +9/−9. build.xml 외 코드 변경 없음.

## Verification

**빌드 (JDK 1.8.0_462 + Ant 1.10.9)**

- origin/develop을 그대로 빌드하면 컴파일 에러는 없고, 컴파일 단위마다 `warning: [options] bootstrap class path not set in conjunction with -source 1.6` 경고(총 8건)가 발생.
- source/target을 1.8로 올리면 이 경고 8건이 모두 사라지고 신규 에러/경고는 0건 (BUILD SUCCESSFUL). `-Xlint:all`을 켜고 1.6/1.8 빌드 로그를 전수 비교해도 1.8에서 새로 생기는 경고는 없음.

**동작 불변 (바이트코드 비교)**

- 1.6 빌드와 1.8 빌드의 산출 클래스 **309개 전체**를 `javap`로 디스어셈블해 비교한 결과, 실행되는 opcode+operand 명령 스트림이 **바이트 단위로 동일** (mismatch 0/309).
- class-file 버전 헤더(50→52)를 제외하면 차이나는 클래스는 단 2개이며, 그 차이마저 JVM 검증용 StackMapTable 메타데이터 + constant-pool 인덱스 재정렬일 뿐 실행 명령은 동일.
- `invokedynamic`/`BootstrapMethods` 신규 생성 없음, 문자열 연결도 양쪽 모두 `StringBuilder` 유지. 즉 이 변경은 **런타임 동작을 바꾸지 않으며 산출물의 클래스 버전과 컴파일 경고만 바꿉니다.**

**실행 환경 (lab 장비 JRE)**

- func 테스트 장비 **88대 전수 확인 결과 전부 JRE 8** (1.8.0_462 73대 / _472 14대 / _452 1대). class-file 52 산출물 로드에 문제 없음.

## Remarks

- 기존 `Note: ... deprecated API / unchecked or unsafe operations` 메시지는 1.6/1.8 설정 모두에서 동일하게 발생하는 기존 코드 사항으로, JDK 8 비호환이 아니므로 본 PR 범위 밖입니다.
- jar 아티팩트는 cubridci의 "Deploy new build artifacts" 커밋으로 별도 배포되므로 포함하지 않았습니다.
- CI(`.github/workflows/check.yml`)는 이미 JDK 8(adopt)을 사용 중입니다.
- 테스트 실행 시점에 javac를 호출하는 스크립트 3곳(`common/script/start_grepo_server.sh`, `sql/bin/run.sh`, `jdbc/bin/run.sh`)은 `-source/-target` 미지정으로 설치된 JDK를 따르므로 본 변경의 영향을 받지 않습니다.
