### PR TITLE
[CUBRIDQA-1466] Apply toPlainString() for NUMERIC/DECIMAL type

### DIFF
--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -68,8 +68,6 @@ import org.apache.commons.dbcp.BasicDataSource;
 public class ConsoleDAO extends Executor {
     private static final String driver = "cubrid.jdbc.driver.CUBRIDDriver";
 
-    private static Boolean cubrid115OrAbove = null;
-
     private String url = null;
 
     private String user = null;
@@ -945,14 +943,13 @@ public class ConsoleDAO extends Executor {
             }
      }
 
-    private boolean isCubrid115OrAbove() {
-        if (cubrid115OrAbove == null) {
-            cubrid115OrAbove = checkCubrid115OrAbove();
-        }
-        return cubrid115OrAbove;
-    }
-
-    private static boolean checkCubrid115OrAbove() {
+    /**
+     * Whether the currently connected server is CUBRID 11.5 or above. The
+     * version is read live from {@link MyDriverManager#getDatabaseVersion()},
+     * which is refreshed on every connection, so this always reflects the
+     * server that produced the result being formatted (no cached state).
+     */
+    private static boolean isCubrid115OrAbove() {
         try {
             String ver = MyDriverManager.getDatabaseVersion();
             if (ver == null) return false;

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -963,7 +963,13 @@ public class ConsoleDAO extends Executor {
 
         StringBuilder sb = new StringBuilder();
         try {
-            if (colType == Types.VARBINARY && colTypeName.equalsIgnoreCase("BIT VARYING")) {
+            if (value instanceof BigDecimal) {
+                // NUMERIC/DECIMAL values always print in plain form. Host-variable
+                // (PREPARE/EXECUTE USING) results are reported as OTHER with an empty
+                // type name but still arrive as BigDecimal, so this check must come
+                // before the column-type branching to avoid the OTHER/OID fallback.
+                sb.append(((BigDecimal) value).toPlainString());
+            } else if (colType == Types.VARBINARY && colTypeName.equalsIgnoreCase("BIT VARYING")) {
                 byte[] bytes = (byte[]) value;
                 sb.append(StringUtil.toHexString(bytes));
             } else if (colType == Types.BINARY && colTypeName.equalsIgnoreCase("BIT")) {
@@ -1011,11 +1017,7 @@ public class ConsoleDAO extends Executor {
                     }
                 }
             } else {
-                if (value instanceof BigDecimal) {
-                    sb.append(((BigDecimal) value).toPlainString());
-                } else {
-                    sb.append(value.toString());
-                }
+                sb.append(value.toString());
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -43,6 +43,7 @@ import com.navercorp.cubridqa.cqt.console.util.SystemUtil;
 import com.navercorp.cubridqa.cqt.console.util.TestUtil;
 import com.navercorp.cubridqa.cqt.console.util.XstreamHelper;
 import java.io.File;
+import java.math.BigDecimal;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
@@ -66,6 +67,8 @@ import org.apache.commons.dbcp.BasicDataSource;
 
 public class ConsoleDAO extends Executor {
     private static final String driver = "cubrid.jdbc.driver.CUBRIDDriver";
+
+    private static Boolean cubrid115OrAbove = null;
 
     private String url = null;
 
@@ -942,6 +945,31 @@ public class ConsoleDAO extends Executor {
             }
      }
 
+    private boolean isCubrid115OrAbove() {
+        if (cubrid115OrAbove == null) {
+            cubrid115OrAbove = checkCubrid115OrAbove();
+        }
+        return cubrid115OrAbove;
+    }
+
+    private static boolean checkCubrid115OrAbove() {
+        try {
+            String ver = MyDriverManager.getDatabaseVersion();
+            if (ver == null) return false;
+            for (String token : ver.split("[\\s()]+")) {
+                String[] parts = token.split("\\.");
+                if (parts.length >= 2 && parts[0].matches("\\d+")) {
+                    int p1 = Integer.parseInt(parts[0]);
+                    int p2 = Integer.parseInt(parts[1]);
+                    return p1 > 11 || (p1 == 11 && p2 >= 5);
+                }
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        return false;
+    }
+
     /**
      * @Title: getColumnValue @Description:Get every column's result.
      *
@@ -1010,7 +1038,11 @@ public class ConsoleDAO extends Executor {
                     }
                 }
             } else {
-                sb.append(value.toString());
+                if (value instanceof BigDecimal && isCubrid115OrAbove()) {
+                    sb.append(((BigDecimal) value).toPlainString());
+                } else {
+                    sb.append(value.toString());
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -944,30 +944,6 @@ public class ConsoleDAO extends Executor {
      }
 
     /**
-     * Whether the currently connected server is CUBRID 11.5 or above. The
-     * version is read live from {@link MyDriverManager#getDatabaseVersion()},
-     * which is refreshed on every connection, so this always reflects the
-     * server that produced the result being formatted (no cached state).
-     */
-    private static boolean isCubrid115OrAbove() {
-        try {
-            String ver = MyDriverManager.getDatabaseVersion();
-            if (ver == null) return false;
-            for (String token : ver.split("[\\s()]+")) {
-                String[] parts = token.split("\\.");
-                if (parts.length >= 2 && parts[0].matches("\\d+")) {
-                    int p1 = Integer.parseInt(parts[0]);
-                    int p2 = Integer.parseInt(parts[1]);
-                    return p1 > 11 || (p1 == 11 && p2 >= 5);
-                }
-            }
-        } catch (Exception e) {
-            // ignore
-        }
-        return false;
-    }
-
-    /**
      * @Title: getColumnValue @Description:Get every column's result.
      *
      * @param @param colType
@@ -1035,7 +1011,7 @@ public class ConsoleDAO extends Executor {
                     }
                 }
             } else {
-                if (value instanceof BigDecimal && isCubrid115OrAbove()) {
+                if (value instanceof BigDecimal) {
                     sb.append(((BigDecimal) value).toPlainString());
                 } else {
                     sb.append(value.toString());

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -92,11 +92,6 @@ static SqlStateStruce sqlstate[MAX_SQL_NUM];
 
 static bool is_server_message_on = 0;
 
-/* CUBRID server version flag: -1 unknown, 0 below 11.5, 1 is 11.5 or above.
-   On 11.5+, NUMERIC values are printed as-is (plain) instead of being
-   trimmed to scientific notation, matching the JDBC runner (CBRD-26006). */
-static int cubrid_115_or_above = -1;
-
 char *
 get_err_msg (int err_code)
 {
@@ -322,63 +317,6 @@ formatdatetime (FILE * fp, char *buffer)
     {
       fprintf (fp, "%s", buffer);
     }
-}
-
-void
-trimnumeric (FILE * fp, char *buffer)
-{
-  int dot_position = chrindex (buffer, ".");
-  int length = strlen (buffer);
-  int allzero = 1;
-  int i;
-  char *p;
-
-  p = (char *) malloc ((length + 1) * sizeof (char));
-  memcpy (p, buffer, (length + 1) * sizeof (char));
-
-  if (!isdouble (p))
-    {
-      printf ("wrong date %s", p);
-    }
-
-  if (dot_position < 1)
-    {
-      fprintf (fp, "%s", p);
-      free (p);
-      return;
-    }
-
-  for (i = dot_position + 1; i < length; i++)
-    {
-      if (buffer[i] != '0')
-	{
-	  allzero = 0;
-	  break;
-	}
-    }
-
-  if (allzero && length < 20)
-    {
-      p[dot_position + 1] = '0';
-      p[dot_position + 2] = 0;
-      fprintf (fp, "%s", p);
-      free (p);
-      return;
-    }
-
-  if (length > 19)
-    {
-      sprintf (p, "%le", atof (buffer));
-    }
-  else
-    {
-      if ((length - dot_position - 1) > 11)
-	{
-	  p[dot_position + 11] = 0;
-	}
-    }
-  fprintf (fp, "%s", p);
-  free (p);
 }
 
 void
@@ -1605,14 +1543,7 @@ _NEXT_MULTIPLE_LINE_SQL:
 		    }
 		  if (itemp == CCI_U_TYPE_NUMERIC)
 		    {
-		      if (cubrid_115_or_above == 1)
-			{
-			  fprintf (fp, "%s", (char *) buffer);
-			}
-		      else
-			{
-			  trimnumeric (fp, (char *) buffer);
-			}
+		      fprintf (fp, "%s", (char *) buffer);
 		    }
 		  else if (itemp == CCI_U_TYPE_DATETIME)
 		    {
@@ -2311,37 +2242,6 @@ _END:
   return ret;
 }
 
-/* Query the connected server version once and cache whether it is 11.5+. */
-static void
-set_cubrid_version_flag (int conn)
-{
-  char ver[64];
-  char *p;
-
-  cubrid_115_or_above = 0;
-  ver[0] = '\0';
-  if (cci_get_db_version (conn, ver, sizeof (ver)) < 0)
-    {
-      return;
-    }
-
-  /* skip any leading non-digit prefix (e.g. "CUBRID ") before major.minor */
-  for (p = ver; *p != '\0' && (*p < '0' || *p > '9'); p++)
-    ;
-
-  if (*p != '\0')
-    {
-      int major = 0, minor = 0;
-      if (sscanf (p, "%d.%d", &major, &minor) >= 2)
-	{
-	  if (major > 11 || (major == 11 && minor >= 5))
-	    {
-	      cubrid_115_or_above = 1;
-	    }
-	}
-    }
-}
-
 int
 test (FILE * fp)
 {
@@ -2372,8 +2272,6 @@ test (FILE * fp)
 
       count++;
     }
-
-  set_cubrid_version_flag (conn);
 
   for (sql_count = 0; sql_count < total_sql; sql_count++)
     {

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -92,6 +92,11 @@ static SqlStateStruce sqlstate[MAX_SQL_NUM];
 
 static bool is_server_message_on = 0;
 
+/* CUBRID server version flag: -1 unknown, 0 below 11.5, 1 is 11.5 or above.
+   On 11.5+, NUMERIC values are printed as-is (plain) instead of being
+   trimmed to scientific notation, matching the JDBC runner (CBRD-26006). */
+static int cubrid_115_or_above = -1;
+
 char *
 get_err_msg (int err_code)
 {
@@ -1600,7 +1605,14 @@ _NEXT_MULTIPLE_LINE_SQL:
 		    }
 		  if (itemp == CCI_U_TYPE_NUMERIC)
 		    {
-		      trimnumeric (fp, (char *) buffer);
+		      if (cubrid_115_or_above == 1)
+			{
+			  fprintf (fp, "%s", (char *) buffer);
+			}
+		      else
+			{
+			  trimnumeric (fp, (char *) buffer);
+			}
 		    }
 		  else if (itemp == CCI_U_TYPE_DATETIME)
 		    {
@@ -2299,6 +2311,37 @@ _END:
   return ret;
 }
 
+/* Query the connected server version once and cache whether it is 11.5+. */
+static void
+set_cubrid_version_flag (int conn)
+{
+  char ver[64];
+  char *p;
+
+  cubrid_115_or_above = 0;
+  ver[0] = '\0';
+  if (cci_get_db_version (conn, ver, sizeof (ver)) < 0)
+    {
+      return;
+    }
+
+  /* skip any leading non-digit prefix (e.g. "CUBRID ") before major.minor */
+  for (p = ver; *p != '\0' && (*p < '0' || *p > '9'); p++)
+    ;
+
+  if (*p != '\0')
+    {
+      int major = 0, minor = 0;
+      if (sscanf (p, "%d.%d", &major, &minor) >= 2)
+	{
+	  if (major > 11 || (major == 11 && minor >= 5))
+	    {
+	      cubrid_115_or_above = 1;
+	    }
+	}
+    }
+}
+
 int
 test (FILE * fp)
 {
@@ -2329,6 +2372,8 @@ test (FILE * fp)
 
       count++;
     }
+
+  set_cubrid_version_flag (conn);
 
   for (sql_count = 0; sql_count < total_sql; sql_count++)
     {


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-26006

100자리, 200자리 대용량 숫자가 CSQL/JDBC를 통해 들어올 때 정상 출력되는지에 대한 테스트케이스가 필요한데, CTP 툴은 결과 출력 시 toString()을 사용하고 있어, 자릿수가 크면 지수 표기로 나오는 문제로 인해 sql TC로는 검증이 불가합니다.
TC답안 수정 영향 범위를 최소화하기 위해 numeric 타입 (BigDecimal) 일 경우만 toPlainString() 를 적용하도록 CTP를 수정하였습니다.

현재 develop (CBRD-26006 머지됨)수정 범위는 47건입니다. CBRD-26006이 머지되면 수정해야할 TC들이 추가로 발생할 수 있습니다.
+ sql_by_cci : 170건입니다.