### PR TITLE
[CBRD-25862] Update cdc_repl, ha_repl common.inc to exclude time columns from system catalog queries

### DIFF
--- a/CTP/cdc_repl/lib/common.inc
+++ b/CTP/cdc_repl/lib/common.inc
@@ -4,7 +4,7 @@ HC_CHECK_FOR_CMD_EACH_STATEMENT_0=cmd: sleep 3
 
 HC_CHECK_FOR_EACH_STATEMENT_1=select 'db_stored_procedure_args' TABLE_NAME, db_stored_procedure_args.* from db_stored_procedure_args order by 1,2,3,4,5,6,7;
 HC_CHECK_FOR_EACH_STATEMENT_2=select 'db_stored_procedure' TABLE_NAME, sp_name, pkg_name, sp_type, return_type, arg_count, lang, authid, owner, code, comment from db_stored_procedure order by 1,2,3,4,5,6,7,8,9;
-HC_CHECK_FOR_EACH_STATEMENT_3=select 'db_partition' TABLE_NAME, db_partition.* from db_partition order by 1,2,3,4,5,6,7,8,9;
+HC_CHECK_FOR_EACH_STATEMENT_3=select 'db_partition' TABLE_NAME, class_name, owner_name, partition_name, partition_class_name, partition_type, partition_expr, partition_values, class_partition_type, comment from db_partition order by 1,2,3,4,5,6,7,8,9;
 HC_CHECK_FOR_EACH_STATEMENT_4=select 'db_trigger' TABLE_NAME, trigger_name, owner_name, target_class_name, target_owner_name, target_attr_name, target_attr_type, action_type, action_time, comment from db_trigger order by 1,2,3,4,5,6,7,8;
 HC_CHECK_FOR_EACH_STATEMENT_5=select 'db_index_key' TABLE_NAME, db_index_key.* from db_index_key order by 1,2,3,4,5,6,7,8;
 HC_CHECK_FOR_EACH_STATEMENT_6=select 'db_index' TABLE_NAME, index_name, is_unique, is_reverse, class_name, owner_name, key_count, is_primary_key, is_foreign_key, filter_expression, have_function, status, referential_index_class_owner_name, referential_index_class_name, referential_index_name, delete_rule, update_rule, referential_match_option, index_type, deduplicate_key_level, comment from db_index order by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20;
@@ -13,17 +13,17 @@ HC_CHECK_FOR_EACH_STATEMENT_8=select 'db_meth_arg_setdomain_elm' TABLE_NAME, db_
 HC_CHECK_FOR_EACH_STATEMENT_9=select 'db_method' TABLE_NAME, db_method.* from db_method order by 1,2,3,4,5,6,7;
 HC_CHECK_FOR_EACH_STATEMENT_10=select 'db_attr_setdomain_elm' TABLE_NAME, db_attr_setdomain_elm.* from db_attr_setdomain_elm order by 1,2,3,4,5,6,7,8;
 HC_CHECK_FOR_EACH_STATEMENT_11=select 'db_attribute' TABLE_NAME, db_attribute.* from db_attribute order by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
-HC_CHECK_FOR_EACH_STATEMENT_12=select 'db_vclass' TABLE_NAME, db_vclass.* from db_vclass order by 1,2,3,4;
+HC_CHECK_FOR_EACH_STATEMENT_12=select 'db_vclass' TABLE_NAME, vclass_name, owner_name, vclass_def, comment from db_vclass order by 1,2,3,4;
 HC_CHECK_FOR_EACH_STATEMENT_13=select 'db_direct_super_class' TABLE_NAME, db_direct_super_class.* from db_direct_super_class order by 1,2;
 HC_CHECK_FOR_EACH_STATEMENT_14=select 'db_class' TABLE_NAME, class_name, owner_name, class_type, is_system_class, tde_algorithm, statistics_strategy, partitioned, is_reuse_oid_class, collation, comment from db_class order by 1,2,3,4,5,6,7,8,9,10;
-HC_CHECK_FOR_EACH_STATEMENT_15=select '_db_serial' TABLE_NAME, if(owner is null, USER, (select name from db_user where db_user=owner)) owner, _db_serial.name, _db_serial.current_val, _db_serial.increment_val, _db_serial.max_val, _db_serial.min_val, _db_serial.start_val, _db_serial.cyclic, _db_serial.started, _db_serial.class_name, _db_serial.att_name, _db_serial.cached_num, _db_serial.comment from _db_serial;
+HC_CHECK_FOR_EACH_STATEMENT_15=select '_db_serial' TABLE_NAME, if(owner is null, USER, (select name from db_user where db_user=owner)) owner, _db_serial.name, _db_serial.current_val, _db_serial.increment_val, _db_serial.max_val, _db_serial.min_val, _db_serial.start_val, _db_serial.cyclic, _db_serial.started, _db_serial.class_name, _db_serial.attr_name, _db_serial.cached_num, _db_serial.comment from _db_serial;
 HC_CHECK_FOR_EACH_STATEMENT_16=select '_db_collation' TABLE_NAME, _db_collation.* from _db_collation order by 1,2,3,4,5,6,7,8,9;
 HC_CHECK_FOR_EACH_STATEMENT_17=select '_db_data_type' TABLE_NAME, _db_data_type.* from _db_data_type order by 1,2,3;
-HC_CHECK_FOR_EACH_STATEMENT_18=select '_db_query_spec' TABLE_NAME, _db_query_spec.* from _db_query_spec order by 3,1,2;
+HC_CHECK_FOR_EACH_STATEMENT_18=select '_db_query_spec' TABLE_NAME, class_of, spec from _db_query_spec order by 3,1,2;
 HC_CHECK_FOR_EACH_STATEMENT_19=select '_db_meth_arg' TABLE_NAME, _db_meth_arg.* from _db_meth_arg order by 1,2,3,4,5;
 HC_CHECK_FOR_EACH_STATEMENT_20=select '_db_meth_sig' TABLE_NAME, _db_meth_sig.* from _db_meth_sig order by 1,2,3,4,5;
-HC_CHECK_FOR_EACH_STATEMENT_21=select '_db_trigger' TABLE_NAME, unique_name, owner, name, status, priority, event, target_class, target_attribute, target_class_attribute, condition_type, condition, condition_time, action_type, action_definition, action_time, comment from db_trigger order by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
-HC_CHECK_FOR_EACH_STATEMENT_22=select 'db_password' TABLE_NAME, db_password.* from db_password order by 1,2;
+HC_CHECK_FOR_EACH_STATEMENT_21=select '_db_trigger' TABLE_NAME, unique_name, owner, name, status, priority, event, target_class, target_attribute, target_class_attribute, condition_type, condition, condition_time, action_type, action_definition, action_time, comment from _db_trigger order by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
+HC_CHECK_FOR_EACH_STATEMENT_22=select '_db_password' TABLE_NAME, password from _db_password order by 1,2;
 HC_CHECK_FOR_EACH_STATEMENT_23=select 'db_root' TABLE_NAME, db_root.* from db_root order by 1,2,3,4,5;
 
 

--- a/CTP/ha_repl/lib/common.inc
+++ b/CTP/ha_repl/lib/common.inc
@@ -4,7 +4,7 @@ HC_CHECK_FOR_CMD_EACH_STATEMENT_0=cmd: sleep 3
 
 HC_CHECK_FOR_EACH_STATEMENT_1=select 'db_stored_procedure_args' TABLE_NAME, db_stored_procedure_args.* from db_stored_procedure_args order by 1,2,3,4,5,6,7;
 HC_CHECK_FOR_EACH_STATEMENT_2=select 'db_stored_procedure' TABLE_NAME, sp_name, pkg_name, sp_type, return_type, arg_count, lang, authid, owner, code, comment from db_stored_procedure order by 1,2,3,4,5,6,7,8,9;
-HC_CHECK_FOR_EACH_STATEMENT_3=select 'db_partition' TABLE_NAME, db_partition.* from db_partition order by 1,2,3,4,5,6,7,8,9;
+HC_CHECK_FOR_EACH_STATEMENT_3=select 'db_partition' TABLE_NAME, class_name, owner_name, partition_name, partition_class_name, partition_type, partition_expr, partition_values, class_partition_type, comment from db_partition order by 1,2,3,4,5,6,7,8,9;
 HC_CHECK_FOR_EACH_STATEMENT_4=select 'db_trigger' TABLE_NAME, trigger_name, owner_name, target_class_name, target_owner_name, target_attr_name, target_attr_type, action_type, action_time, comment from db_trigger order by 1,2,3,4,5,6,7,8;
 HC_CHECK_FOR_EACH_STATEMENT_5=select 'db_index_key' TABLE_NAME, db_index_key.* from db_index_key order by 1,2,3,4,5,6,7,8;
 HC_CHECK_FOR_EACH_STATEMENT_6=select 'db_index' TABLE_NAME, index_name, is_unique, is_reverse, class_name, owner_name, key_count, is_primary_key, is_foreign_key, filter_expression, have_function, status, referential_index_class_owner_name, referential_index_class_name, referential_index_name, delete_rule, update_rule, referential_match_option, index_type, deduplicate_key_level, comment from db_index order by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20;
@@ -13,17 +13,17 @@ HC_CHECK_FOR_EACH_STATEMENT_8=select 'db_meth_arg_setdomain_elm' TABLE_NAME, db_
 HC_CHECK_FOR_EACH_STATEMENT_9=select 'db_method' TABLE_NAME, db_method.* from db_method order by 1,2,3,4,5,6,7;
 HC_CHECK_FOR_EACH_STATEMENT_10=select 'db_attr_setdomain_elm' TABLE_NAME, db_attr_setdomain_elm.* from db_attr_setdomain_elm order by 1,2,3,4,5,6,7,8;
 HC_CHECK_FOR_EACH_STATEMENT_11=select 'db_attribute' TABLE_NAME, db_attribute.* from db_attribute order by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
-HC_CHECK_FOR_EACH_STATEMENT_12=select 'db_vclass' TABLE_NAME, db_vclass.* from db_vclass order by 1,2,3,4;
+HC_CHECK_FOR_EACH_STATEMENT_12=select 'db_vclass' TABLE_NAME, vclass_name, owner_name, vclass_def, comment from db_vclass order by 1,2,3,4;
 HC_CHECK_FOR_EACH_STATEMENT_13=select 'db_direct_super_class' TABLE_NAME, db_direct_super_class.* from db_direct_super_class order by 1,2;
 HC_CHECK_FOR_EACH_STATEMENT_14=select 'db_class' TABLE_NAME, class_name, owner_name, class_type, is_system_class, tde_algorithm, statistics_strategy, partitioned, is_reuse_oid_class, collation, comment from db_class order by 1,2,3,4,5,6,7,8,9,10;
 HC_CHECK_FOR_EACH_STATEMENT_15=select '_db_serial' TABLE_NAME, if(owner is null, USER, (select name from db_user where db_user=owner)) owner, _db_serial.name, _db_serial.current_val, _db_serial.increment_val, _db_serial.max_val, _db_serial.min_val, _db_serial.start_val, _db_serial.cyclic, _db_serial.started, _db_serial.class_name, _db_serial.attr_name, _db_serial.cached_num, _db_serial.comment from _db_serial;
 HC_CHECK_FOR_EACH_STATEMENT_16=select '_db_collation' TABLE_NAME, _db_collation.* from _db_collation order by 1,2,3,4,5,6,7,8,9;
 HC_CHECK_FOR_EACH_STATEMENT_17=select '_db_data_type' TABLE_NAME, _db_data_type.* from _db_data_type order by 1,2,3;
-HC_CHECK_FOR_EACH_STATEMENT_18=select '_db_query_spec' TABLE_NAME, _db_query_spec.* from _db_query_spec order by 3,1,2;
+HC_CHECK_FOR_EACH_STATEMENT_18=select '_db_query_spec' TABLE_NAME, class_of, spec from _db_query_spec order by 3,1,2;
 HC_CHECK_FOR_EACH_STATEMENT_19=select '_db_meth_arg' TABLE_NAME, _db_meth_arg.* from _db_meth_arg order by 1,2,3,4,5;
 HC_CHECK_FOR_EACH_STATEMENT_20=select '_db_meth_sig' TABLE_NAME, _db_meth_sig.* from _db_meth_sig order by 1,2,3,4,5;
 HC_CHECK_FOR_EACH_STATEMENT_21=select '_db_trigger' TABLE_NAME, unique_name, owner, name, status, priority, event, target_class, target_attribute, target_class_attribute, condition_type, condition, condition_time, action_type, action_definition, action_time, comment from _db_trigger order by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
-HC_CHECK_FOR_EACH_STATEMENT_22=select 'db_password' TABLE_NAME, db_password.* from db_password order by 1,2;
+HC_CHECK_FOR_EACH_STATEMENT_22=select '_db_password' TABLE_NAME, password from _db_password order by 1,2;
 HC_CHECK_FOR_EACH_STATEMENT_23=select 'db_root' TABLE_NAME, db_root.* from db_root order by 1,2,3,4,5;
 
 


### PR DESCRIPTION
## 개요 (Summary)
https://github.com/CUBRID/cubrid/pull/6903 PR에 의한 시스템 카탈로그 변경사항을 common.inc에 반영합니다.

## 변경 사항 (Changes)
| 테이블명 | 대상 라인 | AS-IS | TO-BE |
| :--- | :---: | :--- | :--- |
| `db_partition` | 7 | `.*` 전체 조회 | `created_time`, `updated_time`, `invalidate_time`을 제외한 명시적 컬럼 사용 |
| `db_vclass` | 16 | `.*` 전체 조회 | 상동 |
| `_db_query_spec` | 22 | `.*` 전체 조회 | 상동 |
| `_db_password` | 26 | `.*` 전체 조회 | 상동, db_password -> _db_password로 수정 |
## 수정 목적 (Reason)
와일드카드(`.*`) 조회 시 카탈로그 내부 변경(시간 데이터 갱신 등)으로 인해 master/slave diff 결과 차이로 인해 대량 fail이 발생하므로 이를 수정하여 해결합니다.

