### PR TITLE
[CUBRIDQA-1395] sql_by_cci: Issue where the first value of the resultof the next executed query is output as '?' when the 'show trace' result is null.

### DIFF
--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -2025,17 +2025,6 @@ execute (FILE * fp, char conn, const SqlStateStruce *pSqlState)
       goto _END;
     }
 
-  //if find the sql was "show trace;". then mark it.
-  //add by charlie for format the show trace
-  if (startswithCI (sql, "show trace;"))
-    {
-      has_st = 1;
-    }
-  else
-    {
-      has_st = 0;
-    }
-
   //getting column information when the prepared statement is the SELECT query
   res_col_info = cci_get_result_info (req, &cmd_type, &col_count);
   if (cmd_type == CUBRID_STMT_SELECT || cmd_type == CUBRID_STMT_CALL || cmd_type == CUBRID_STMT_EVALUATE
@@ -2482,6 +2471,16 @@ test (FILE * fp)
 	}
       else
 	{
+	  /* reset has_st for every SQL (execute + executebind) */
+	  if (startswithCI (sqlstate[sql_count].sql, "show trace;"))
+	    {
+	      has_st = 1;
+	    }
+	  else
+	    {
+	      has_st = 0;
+	    }
+
 	  if (parameter[sql_count] != NULL)
 	    {
 	      executebind (fp, conn, parameter[sql_count], &sqlstate[sql_count]); 

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -2031,6 +2031,10 @@ execute (FILE * fp, char conn, const SqlStateStruce *pSqlState)
     {
       has_st = 1;
     }
+  else
+    {
+      has_st = 0;
+    }
 
   //getting column information when the prepared statement is the SELECT query
   res_col_info = cci_get_result_info (req, &cmd_type, &col_count);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1395

## 요약
- `CTP/sql_by_cci/execute.c`에서 `show trace;` 실행 시 `has_st`가 1로 설정되지만, trace 결과가 null이거나 특수 타입 분기로 처리되면 리셋되지 않는 정적 플래그 누출 버그를 수정합니다.
- 누출된 플래그로 인해 다음 SELECT의 첫 번째 컬럼에 `trannum()`이 적용되어 숫자 값(예: `1`)이 `?`로 출력됩니다.
## 근본 원인
`has_st`는 trace 통계의 숫자를 `trannum()`으로 `?`로 정규화하기 위한 정적 변수입니다. `show trace;` 실행 시 1로 설정되며, trace 결과의 첫 컬럼이 `dumptable()`의 일반 문자열 분기를 통과할 때만 0으로 초기화됩니다.
`show trace;` 결과가 **null**이거나, null/특수 타입 분기(NUMERIC, DATETIME, NULL, OBJECT 등)로 처리되면 `has_st`가 1로 남아 **다음 쿼리의 첫 번째 셀**에 영향을 줍니다.
## 재현 방법
1. 다음 순서의 sql_by_cci 테스트케이스 실행:
   - `null`을 반환하는 `show trace;` (예: `create table ... as with cte ...` 직후)
   - 이어서 첫 컬럼이 숫자인 SELECT
2. 수정 전: 첫 셀이 `1` 대신 `?`로 출력됨

## 수정 내용
초기 수정은 execute()만 대상이었음
parameter[]가 있는 SQL은 executebind() 경로라 동일 버그 잔존함
test() 루프 공통 리셋으로 두 경로 모두 커버하도록 수정함.