### PR TITLE
[CUBRIDQA-1402] Improved ctp shell regression test

### DIFF
--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/CommonUtils.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/CommonUtils.java
@@ -239,6 +239,9 @@ public class CommonUtils {
 		}
 	}
 
+	/* prefix of the string returned by resetProcess() when cleanup failed; callers check this to detect failure */
+	public static final String RESET_PROCESS_FAIL_PREFIX = "fail to reset processes:";
+
 	public static String resetProcess(SSHConnect ssh, boolean isWindows, boolean executeAtLocal) {
 		try {
 			if (isWindows) {
@@ -248,7 +251,7 @@ public class CommonUtils {
 				return ssh.execute(executeAtLocal ? Constants.LIN_KILL_PROCESS_LOCAL : Constants.LIN_KILL_PROCESS);
 			}
 		} catch (Exception e) {
-			return "fail to reset processes: " + e.getMessage();
+			return RESET_PROCESS_FAIL_PREFIX + " " + e.getMessage();
 		}
 	}
 

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/CommonUtils.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/CommonUtils.java
@@ -239,8 +239,8 @@ public class CommonUtils {
 		}
 	}
 
-	/* prefix of the string returned by resetProcess() when cleanup failed; callers check this to detect failure */
-	public static final String RESET_PROCESS_FAIL_PREFIX = "fail to reset processes:";
+    /* prefix of the string returned by resetProcess() when cleanup failed; callers check this to detect failure */
+    public static final String RESET_PROCESS_FAIL_PREFIX = "fail to reset processes:";
 
 	public static String resetProcess(SSHConnect ssh, boolean isWindows, boolean executeAtLocal) {
 		try {
@@ -251,7 +251,7 @@ public class CommonUtils {
 				return ssh.execute(executeAtLocal ? Constants.LIN_KILL_PROCESS_LOCAL : Constants.LIN_KILL_PROCESS);
 			}
 		} catch (Exception e) {
-			return RESET_PROCESS_FAIL_PREFIX + " " + e.getMessage();
+            return RESET_PROCESS_FAIL_PREFIX + " " + e.getMessage();
 		}
 	}
 

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/Constants.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/Constants.java
@@ -179,7 +179,7 @@ public class Constants {
 		scripts.addCommand("ctp_java_pid_list=`ps -u $USER -o pid,command| grep -v grep | grep -E 'com.navercorp.cubridqa|service.Server' | awk '{print $1}'`");
 		scripts.addCommand("all_java_pid_list=`ps -u $USER -o pid,comm| grep -v grep | grep -i java | awk '{print $1}'`");
 		scripts.addCommand("final_list=\"\"");
-		scripts.addCommand("for x in ${all_java_pid_list};do isExistPid=`echo ${ctp_java_pid_list}|grep -w $x|wc -l`;if [ $isExistPid -eq 0];then final_list=\"${final_list} $x\" ;fi;done");
+		scripts.addCommand("for x in ${all_java_pid_list};do isExistPid=`echo ${ctp_java_pid_list}|grep -w $x|wc -l`;if [ $isExistPid -eq 0 ];then final_list=\"${final_list} $x\" ;fi;done");
 		scripts.addCommand(bothKill("echo ${final_list}"));
 		scripts.addCommand(bothKill("ps -u $USER -o pid,comm| grep -v grep | grep -i sleep | awk '{print $1}'"));
 		scripts.addCommand(bothKill("ps -u $USER -o pid,comm| grep -v grep | grep -i expect | awk '{print $1}'"));

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/Constants.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/Constants.java
@@ -179,7 +179,7 @@ public class Constants {
 		scripts.addCommand("ctp_java_pid_list=`ps -u $USER -o pid,command| grep -v grep | grep -E 'com.navercorp.cubridqa|service.Server' | awk '{print $1}'`");
 		scripts.addCommand("all_java_pid_list=`ps -u $USER -o pid,comm| grep -v grep | grep -i java | awk '{print $1}'`");
 		scripts.addCommand("final_list=\"\"");
-		scripts.addCommand("for x in ${all_java_pid_list};do isExistPid=`echo ${ctp_java_pid_list}|grep -w $x|wc -l`;if [ $isExistPid -eq 0 ];then final_list=\"${final_list} $x\" ;fi;done");
+        scripts.addCommand("for x in ${all_java_pid_list};do isExistPid=`echo ${ctp_java_pid_list}|grep -w $x|wc -l`;if [ $isExistPid -eq 0 ];then final_list=\"${final_list} $x\" ;fi;done");
 		scripts.addCommand(bothKill("echo ${final_list}"));
 		scripts.addCommand(bothKill("ps -u $USER -o pid,comm| grep -v grep | grep -i sleep | awk '{print $1}'"));
 		scripts.addCommand(bothKill("ps -u $USER -o pid,comm| grep -v grep | grep -i expect | awk '{print $1}'"));

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHConnect.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHConnect.java
@@ -228,31 +228,42 @@ public class SSHConnect {
 		}
 
 		try {
-			int len = 0;
-			while ((len = in.read(b)) > 0) {
-				out.write(b, 0, len);
-				if (out.toString().indexOf(ScriptInput.COMP_FLAG) > 0) {
-					break;
+			try {
+				int len = 0;
+				while ((len = in.read(b)) > 0) {
+					out.write(b, 0, len);
+					if (out.toString().indexOf(ScriptInput.COMP_FLAG) > 0) {
+						break;
+					}
 				}
+			} catch (Exception readEx) {
+				if (timedOut.get()) {
+					throw new SSHTimeoutException("SSH exec timeout after " + readTimeoutSecs + " seconds on " + toString());
+				}
+				throw readEx;
 			}
-		} catch (Exception readEx) {
+
 			if (timedOut.get()) {
 				throw new SSHTimeoutException("SSH exec timeout after " + readTimeoutSecs + " seconds on " + toString());
 			}
-			throw readEx;
+
+			return extractOutput(out.toString());
 		} finally {
+			/*
+			 * Always release the channel and cancel the watchdog, regardless of
+			 * normal completion, timeout, or a read error. Otherwise a non-timeout
+			 * I/O/JSch exception would leave the ChannelExec open and leak channels
+			 * on the reused session over a long regression run. disconnect() is
+			 * idempotent, so it is safe even if the watchdog already disconnected.
+			 */
 			if (watch != null) {
 				watch.cancel(false);
 			}
+			try {
+				exec.disconnect();
+			} catch (Exception e) {
+			}
 		}
-
-		if (timedOut.get()) {
-			throw new SSHTimeoutException("SSH exec timeout after " + readTimeoutSecs + " seconds on " + toString());
-		}
-
-		exec.disconnect();
-
-		return extractOutput(out.toString());
 	}
 
 	private static String extractOutput(String raw) {

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHConnect.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHConnect.java
@@ -30,6 +30,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.rmi.Naming;
 import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSch;
@@ -53,6 +59,35 @@ public class SSHConnect {
 	String serviceProtocol;
 
 	final int MAX_TRY_TIME = 10;
+
+	/*
+	 * Connect timeout and keepalive settings (milliseconds) to detect dead
+	 * nodes/sockets. Keepalive is kept generous (60s x 10 = 10 minutes) so a
+	 * healthy but heavily-loaded/swapping test node is not falsely severed while
+	 * still making progress; the execute() read deadline (testCaseTimeout + 300)
+	 * is the real upper bound. Keepalive only shortens detection of a truly dead
+	 * node from the full read deadline down to ~10 minutes.
+	 */
+	private static final int CONNECT_TIMEOUT_MS = 30 * 1000;
+	private static final int SERVER_ALIVE_INTERVAL_MS = 60 * 1000;
+	private static final int SERVER_ALIVE_COUNT_MAX = 10;
+
+	/*
+	 * Total read deadline for a single execute() over SSH, in seconds. -1 means
+	 * disabled (legacy behavior: block until ALL_COMPLETED or channel EOF). When
+	 * set, a watchdog forcibly disconnects the channel/session after the deadline
+	 * so a hung test case cannot block the worker thread forever.
+	 */
+	private int readTimeoutSecs = -1;
+
+	/* shared daemon watchdog scheduler for all SSHConnect instances */
+	private static final ScheduledExecutorService WATCHDOG = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+		public Thread newThread(Runnable r) {
+			Thread t = new Thread(r, "ssh-exec-watchdog");
+			t.setDaemon(true);
+			return t;
+		}
+	});
 
 	public SSHConnect() throws JSchException {
 		this(null, -1, null, null, SERVICE_TYPE_LOCAL);
@@ -96,12 +131,26 @@ public class SSHConnect {
 			config.setProperty("StrictHostKeyChecking", "no");
 			session.setConfig("PreferredAuthentications", "password,publickey,keyboard-interactive,");
 			this.session.setConfig(config);
-			this.session.connect();
+			this.session.setServerAliveInterval(SERVER_ALIVE_INTERVAL_MS);
+			this.session.setServerAliveCountMax(SERVER_ALIVE_COUNT_MAX);
+			this.session.connect(CONNECT_TIMEOUT_MS);
 			if ((session != null && session.isConnected()) || count > MAX_TRY_TIME) {
 				break;
 			}
 			count++;
 		}
+	}
+
+	/**
+	 * Set the total read deadline (in seconds) for a single SSH execute(). A value
+	 * of -1 (default) disables the deadline and keeps the legacy blocking behavior.
+	 */
+	public void setReadTimeoutSecs(int readTimeoutSecs) {
+		this.readTimeoutSecs = readTimeoutSecs;
+	}
+
+	public int getReadTimeoutSecs() {
+		return this.readTimeoutSecs;
 	}
 
 	public String execute(ScriptInput scripts) throws Exception {
@@ -146,12 +195,59 @@ public class SSHConnect {
 		exec.setCommand(scripts);
 		exec.connect();
 
-		int len = 0;
-		while ((len = in.read(b)) > 0) {
-			out.write(b, 0, len);
-			if (out.toString().indexOf(ScriptInput.COMP_FLAG) > 0) {
-				break;
+		/*
+		 * A hung test case never prints ALL_COMPLETED and may keep the channel's
+		 * stdout fd open (background/grandchild processes), so neither the
+		 * COMP_FLAG nor the channel EOF condition is ever reached and in.read()
+		 * blocks forever. JSch's socket read is not interruptible via
+		 * Thread.interrupt(), so we arm a watchdog that forcibly disconnects the
+		 * channel and session once the read deadline passes; that makes in.read()
+		 * return/throw and lets the worker thread escape with an exception.
+		 */
+		final ChannelExec execRef = exec;
+		final Session sessionRef = this.session;
+		final AtomicBoolean timedOut = new AtomicBoolean(false);
+		ScheduledFuture<?> watch = null;
+		if (readTimeoutSecs > 0) {
+			watch = WATCHDOG.schedule(new Runnable() {
+				public void run() {
+					timedOut.set(true);
+					try {
+						execRef.disconnect();
+					} catch (Exception e) {
+					}
+					try {
+						/* disconnect only the session this watchdog was armed for, never a later reused session */
+						if (sessionRef != null) {
+							sessionRef.disconnect();
+						}
+					} catch (Exception e) {
+					}
+				}
+			}, readTimeoutSecs, TimeUnit.SECONDS);
+		}
+
+		try {
+			int len = 0;
+			while ((len = in.read(b)) > 0) {
+				out.write(b, 0, len);
+				if (out.toString().indexOf(ScriptInput.COMP_FLAG) > 0) {
+					break;
+				}
 			}
+		} catch (Exception readEx) {
+			if (timedOut.get()) {
+				throw new SSHTimeoutException("SSH exec timeout after " + readTimeoutSecs + " seconds on " + toString());
+			}
+			throw readEx;
+		} finally {
+			if (watch != null) {
+				watch.cancel(false);
+			}
+		}
+
+		if (timedOut.get()) {
+			throw new SSHTimeoutException("SSH exec timeout after " + readTimeoutSecs + " seconds on " + toString());
 		}
 
 		exec.disconnect();

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHConnect.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHConnect.java
@@ -30,9 +30,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.rmi.Naming;
 import java.util.Properties;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -80,8 +79,13 @@ public class SSHConnect {
 	 */
 	private int readTimeoutSecs = -1;
 
-	/* shared daemon watchdog scheduler for all SSHConnect instances */
-	private static final ScheduledExecutorService WATCHDOG = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+	/*
+	 * Shared daemon watchdog scheduler for all SSHConnect instances. A single
+	 * thread is intentional (low volume); the per-execute task is explicitly
+	 * removed from the queue on normal completion (see execute()) so cancelled
+	 * tasks do not retain their captured ChannelExec/Session until the deadline.
+	 */
+	private static final ScheduledThreadPoolExecutor WATCHDOG = new ScheduledThreadPoolExecutor(1, new ThreadFactory() {
 		public Thread newThread(Runnable r) {
 			Thread t = new Thread(r, "ssh-exec-watchdog");
 			t.setDaemon(true);
@@ -163,6 +167,13 @@ public class SSHConnect {
 
 	public String execute(String scripts, boolean pureWindows) throws Exception {
 		// System.out.println(scripts);
+		/*
+		 * NOTE: the read deadline (readTimeoutSecs / watchdog below) applies ONLY to
+		 * the SSH path. The RMI and LOCAL branches return before the watchdog is
+		 * armed, so setReadTimeoutSecs has no effect there. A LOCAL/RMI hang is still
+		 * mitigated by the monitor's resetProcess, but the hard read backstop added
+		 * by this change is SSH-only.
+		 */
 		if (serviceProtocol.equals(SERVICE_TYPE_RMI)) {
 			ShellService srv = null;
 			String url = "rmi://" + host + ":" + port + "/shellService";
@@ -243,11 +254,19 @@ public class SSHConnect {
 				throw readEx;
 			}
 
-			if (timedOut.get()) {
+			/*
+			 * If the full output (COMP_FLAG) was received, return success even if the
+			 * watchdog happened to fire in the tiny window between the read break and
+			 * here; otherwise a case that completed right at the deadline would be
+			 * wrongly recorded as a timeout (and excluded from retry). Only treat it
+			 * as a timeout when we did NOT receive the completion marker.
+			 */
+			String outString = out.toString();
+			if (outString.indexOf(ScriptInput.COMP_FLAG) < 0 && timedOut.get()) {
 				throw new SSHTimeoutException("SSH exec timeout after " + readTimeoutSecs + " seconds on " + toString());
 			}
 
-			return extractOutput(out.toString());
+			return extractOutput(outString);
 		} finally {
 			/*
 			 * Always release the channel and cancel the watchdog, regardless of
@@ -258,6 +277,8 @@ public class SSHConnect {
 			 */
 			if (watch != null) {
 				watch.cancel(false);
+				/* drop the cancelled task from the queue so it does not retain the captured channel/session until its deadline */
+				WATCHDOG.remove((Runnable) watch);
 			}
 			try {
 				exec.disconnect();

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHConnect.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHConnect.java
@@ -240,11 +240,26 @@ public class SSHConnect {
 
 		try {
 			try {
+				/*
+				 * Detect COMP_FLAG incrementally instead of re-decoding the whole
+				 * buffer every chunk (which was O(n^2)). The raw bytes still go to
+				 * `out` (decoded once at the end for the returned result); the flag
+				 * search runs over a small rolling tail decoded as ISO-8859-1, a
+				 * byte-exact 1:1 mapping that is safe because COMP_FLAG is ASCII and
+				 * cannot be corrupted by a multi-byte char split at a chunk boundary.
+				 */
+				final int flagLen = ScriptInput.COMP_FLAG.length();
+				StringBuilder tail = new StringBuilder();
 				int len = 0;
 				while ((len = in.read(b)) > 0) {
 					out.write(b, 0, len);
-					if (out.toString().indexOf(ScriptInput.COMP_FLAG) > 0) {
+					tail.append(new String(b, 0, len, "ISO-8859-1"));
+					if (tail.indexOf(ScriptInput.COMP_FLAG) >= 0) {
 						break;
+					}
+					/* keep only the last (flagLen-1) chars so a flag split across chunks is still found */
+					if (tail.length() > flagLen - 1) {
+						tail.delete(0, tail.length() - (flagLen - 1));
 					}
 				}
 			} catch (Exception readEx) {

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHConnect.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHConnect.java
@@ -59,39 +59,39 @@ public class SSHConnect {
 
 	final int MAX_TRY_TIME = 10;
 
-	/*
-	 * Connect timeout and keepalive settings (milliseconds) to detect dead
-	 * nodes/sockets. Keepalive is kept generous (60s x 10 = 10 minutes) so a
-	 * healthy but heavily-loaded/swapping test node is not falsely severed while
-	 * still making progress; the execute() read deadline (testCaseTimeout + 300)
-	 * is the real upper bound. Keepalive only shortens detection of a truly dead
-	 * node from the full read deadline down to ~10 minutes.
-	 */
-	private static final int CONNECT_TIMEOUT_MS = 30 * 1000;
-	private static final int SERVER_ALIVE_INTERVAL_MS = 60 * 1000;
-	private static final int SERVER_ALIVE_COUNT_MAX = 10;
+    /*
+     * Connect timeout and keepalive settings (milliseconds) to detect dead
+     * nodes/sockets. Keepalive is kept generous (60s x 10 = 10 minutes) so a
+     * healthy but heavily-loaded/swapping test node is not falsely severed while
+     * still making progress; the execute() read deadline (testCaseTimeout + 300)
+     * is the real upper bound. Keepalive only shortens detection of a truly dead
+     * node from the full read deadline down to ~10 minutes.
+     */
+    private static final int CONNECT_TIMEOUT_MS = 30 * 1000;
+    private static final int SERVER_ALIVE_INTERVAL_MS = 60 * 1000;
+    private static final int SERVER_ALIVE_COUNT_MAX = 10;
 
-	/*
-	 * Total read deadline for a single execute() over SSH, in seconds. -1 means
-	 * disabled (legacy behavior: block until ALL_COMPLETED or channel EOF). When
-	 * set, a watchdog forcibly disconnects the channel/session after the deadline
-	 * so a hung test case cannot block the worker thread forever.
-	 */
-	private int readTimeoutSecs = -1;
+    /*
+     * Total read deadline for a single execute() over SSH, in seconds. -1 means
+     * disabled (legacy behavior: block until ALL_COMPLETED or channel EOF). When
+     * set, a watchdog forcibly disconnects the channel/session after the deadline
+     * so a hung test case cannot block the worker thread forever.
+     */
+    private int readTimeoutSecs = -1;
 
-	/*
-	 * Shared daemon watchdog scheduler for all SSHConnect instances. A single
-	 * thread is intentional (low volume); the per-execute task is explicitly
-	 * removed from the queue on normal completion (see execute()) so cancelled
-	 * tasks do not retain their captured ChannelExec/Session until the deadline.
-	 */
-	private static final ScheduledThreadPoolExecutor WATCHDOG = new ScheduledThreadPoolExecutor(1, new ThreadFactory() {
-		public Thread newThread(Runnable r) {
-			Thread t = new Thread(r, "ssh-exec-watchdog");
-			t.setDaemon(true);
-			return t;
-		}
-	});
+    /*
+     * Shared daemon watchdog scheduler for all SSHConnect instances. A single
+     * thread is intentional (low volume); the per-execute task is explicitly
+     * removed from the queue on normal completion (see execute()) so cancelled
+     * tasks do not retain their captured ChannelExec/Session until the deadline.
+     */
+    private static final ScheduledThreadPoolExecutor WATCHDOG = new ScheduledThreadPoolExecutor(1, new ThreadFactory() {
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(r, "ssh-exec-watchdog");
+            t.setDaemon(true);
+            return t;
+        }
+    });
 
 	public SSHConnect() throws JSchException {
 		this(null, -1, null, null, SERVICE_TYPE_LOCAL);
@@ -135,9 +135,9 @@ public class SSHConnect {
 			config.setProperty("StrictHostKeyChecking", "no");
 			session.setConfig("PreferredAuthentications", "password,publickey,keyboard-interactive,");
 			this.session.setConfig(config);
-			this.session.setServerAliveInterval(SERVER_ALIVE_INTERVAL_MS);
-			this.session.setServerAliveCountMax(SERVER_ALIVE_COUNT_MAX);
-			this.session.connect(CONNECT_TIMEOUT_MS);
+            this.session.setServerAliveInterval(SERVER_ALIVE_INTERVAL_MS);
+            this.session.setServerAliveCountMax(SERVER_ALIVE_COUNT_MAX);
+            this.session.connect(CONNECT_TIMEOUT_MS);
 			if ((session != null && session.isConnected()) || count > MAX_TRY_TIME) {
 				break;
 			}
@@ -145,17 +145,17 @@ public class SSHConnect {
 		}
 	}
 
-	/**
-	 * Set the total read deadline (in seconds) for a single SSH execute(). A value
-	 * of -1 (default) disables the deadline and keeps the legacy blocking behavior.
-	 */
-	public void setReadTimeoutSecs(int readTimeoutSecs) {
-		this.readTimeoutSecs = readTimeoutSecs;
-	}
+    /**
+     * Set the total read deadline (in seconds) for a single SSH execute(). A value
+     * of -1 (default) disables the deadline and keeps the legacy blocking behavior.
+     */
+    public void setReadTimeoutSecs(int readTimeoutSecs) {
+        this.readTimeoutSecs = readTimeoutSecs;
+    }
 
-	public int getReadTimeoutSecs() {
-		return this.readTimeoutSecs;
-	}
+    public int getReadTimeoutSecs() {
+        return this.readTimeoutSecs;
+    }
 
 	public String execute(ScriptInput scripts) throws Exception {
 		return execute(scripts.getCommands(), scripts.isPureWindows);
@@ -167,13 +167,13 @@ public class SSHConnect {
 
 	public String execute(String scripts, boolean pureWindows) throws Exception {
 		// System.out.println(scripts);
-		/*
-		 * NOTE: the read deadline (readTimeoutSecs / watchdog below) applies ONLY to
-		 * the SSH path. The RMI and LOCAL branches return before the watchdog is
-		 * armed, so setReadTimeoutSecs has no effect there. A LOCAL/RMI hang is still
-		 * mitigated by the monitor's resetProcess, but the hard read backstop added
-		 * by this change is SSH-only.
-		 */
+        /*
+         * NOTE: the read deadline (readTimeoutSecs / watchdog below) applies ONLY to
+         * the SSH path. The RMI and LOCAL branches return before the watchdog is
+         * armed, so setReadTimeoutSecs has no effect there. A LOCAL/RMI hang is still
+         * mitigated by the monitor's resetProcess, but the hard read backstop added
+         * by this change is SSH-only.
+         */
 		if (serviceProtocol.equals(SERVICE_TYPE_RMI)) {
 			ShellService srv = null;
 			String url = "rmi://" + host + ":" + port + "/shellService";
@@ -206,100 +206,100 @@ public class SSHConnect {
 		exec.setCommand(scripts);
 		exec.connect();
 
-		/*
-		 * A hung test case never prints ALL_COMPLETED and may keep the channel's
-		 * stdout fd open (background/grandchild processes), so neither the
-		 * COMP_FLAG nor the channel EOF condition is ever reached and in.read()
-		 * blocks forever. JSch's socket read is not interruptible via
-		 * Thread.interrupt(), so we arm a watchdog that forcibly disconnects the
-		 * channel and session once the read deadline passes; that makes in.read()
-		 * return/throw and lets the worker thread escape with an exception.
-		 */
-		final ChannelExec execRef = exec;
-		final Session sessionRef = this.session;
-		final AtomicBoolean timedOut = new AtomicBoolean(false);
-		ScheduledFuture<?> watch = null;
-		if (readTimeoutSecs > 0) {
-			watch = WATCHDOG.schedule(new Runnable() {
-				public void run() {
-					timedOut.set(true);
-					try {
-						execRef.disconnect();
-					} catch (Exception e) {
-					}
-					try {
-						/* disconnect only the session this watchdog was armed for, never a later reused session */
-						if (sessionRef != null) {
-							sessionRef.disconnect();
-						}
-					} catch (Exception e) {
-					}
-				}
-			}, readTimeoutSecs, TimeUnit.SECONDS);
+        /*
+         * A hung test case never prints ALL_COMPLETED and may keep the channel's
+         * stdout fd open (background/grandchild processes), so neither the
+         * COMP_FLAG nor the channel EOF condition is ever reached and in.read()
+         * blocks forever. JSch's socket read is not interruptible via
+         * Thread.interrupt(), so we arm a watchdog that forcibly disconnects the
+         * channel and session once the read deadline passes; that makes in.read()
+         * return/throw and lets the worker thread escape with an exception.
+         */
+        final ChannelExec execRef = exec;
+        final Session sessionRef = this.session;
+        final AtomicBoolean timedOut = new AtomicBoolean(false);
+        ScheduledFuture<?> watch = null;
+        if (readTimeoutSecs > 0) {
+            watch = WATCHDOG.schedule(new Runnable() {
+                public void run() {
+                    timedOut.set(true);
+                    try {
+                        execRef.disconnect();
+                    } catch (Exception e) {
+                    }
+                    try {
+                        /* disconnect only the session this watchdog was armed for, never a later reused session */
+                        if (sessionRef != null) {
+                            sessionRef.disconnect();
+                        }
+                    } catch (Exception e) {
+                    }
+                }
+            }, readTimeoutSecs, TimeUnit.SECONDS);
 		}
 
-		try {
-			try {
-				/*
-				 * Detect COMP_FLAG incrementally instead of re-decoding the whole
-				 * buffer every chunk (which was O(n^2)). The raw bytes still go to
-				 * `out` (decoded once at the end for the returned result); the flag
-				 * search runs over a small rolling tail decoded as ISO-8859-1, a
-				 * byte-exact 1:1 mapping that is safe because COMP_FLAG is ASCII and
-				 * cannot be corrupted by a multi-byte char split at a chunk boundary.
-				 */
-				final int flagLen = ScriptInput.COMP_FLAG.length();
-				StringBuilder tail = new StringBuilder();
-				int len = 0;
-				while ((len = in.read(b)) > 0) {
-					out.write(b, 0, len);
-					tail.append(new String(b, 0, len, "ISO-8859-1"));
-					if (tail.indexOf(ScriptInput.COMP_FLAG) >= 0) {
-						break;
-					}
-					/* keep only the last (flagLen-1) chars so a flag split across chunks is still found */
-					if (tail.length() > flagLen - 1) {
-						tail.delete(0, tail.length() - (flagLen - 1));
-					}
-				}
-			} catch (Exception readEx) {
-				if (timedOut.get()) {
-					throw new SSHTimeoutException("SSH exec timeout after " + readTimeoutSecs + " seconds on " + toString());
-				}
-				throw readEx;
-			}
+        try {
+            try {
+                /*
+                 * Detect COMP_FLAG incrementally instead of re-decoding the whole
+                 * buffer every chunk (which was O(n^2)). The raw bytes still go to
+                 * `out` (decoded once at the end for the returned result); the flag
+                 * search runs over a small rolling tail decoded as ISO-8859-1, a
+                 * byte-exact 1:1 mapping that is safe because COMP_FLAG is ASCII and
+                 * cannot be corrupted by a multi-byte char split at a chunk boundary.
+                 */
+                final int flagLen = ScriptInput.COMP_FLAG.length();
+                StringBuilder tail = new StringBuilder();
+                int len = 0;
+                while ((len = in.read(b)) > 0) {
+                    out.write(b, 0, len);
+                    tail.append(new String(b, 0, len, "ISO-8859-1"));
+                    if (tail.indexOf(ScriptInput.COMP_FLAG) >= 0) {
+                        break;
+                    }
+                    /* keep only the last (flagLen-1) chars so a flag split across chunks is still found */
+                    if (tail.length() > flagLen - 1) {
+                        tail.delete(0, tail.length() - (flagLen - 1));
+                    }
+                }
+            } catch (Exception readEx) {
+                if (timedOut.get()) {
+                    throw new SSHTimeoutException("SSH exec timeout after " + readTimeoutSecs + " seconds on " + toString());
+                }
+                throw readEx;
+            }
 
-			/*
-			 * If the full output (COMP_FLAG) was received, return success even if the
-			 * watchdog happened to fire in the tiny window between the read break and
-			 * here; otherwise a case that completed right at the deadline would be
-			 * wrongly recorded as a timeout (and excluded from retry). Only treat it
-			 * as a timeout when we did NOT receive the completion marker.
-			 */
-			String outString = out.toString();
-			if (outString.indexOf(ScriptInput.COMP_FLAG) < 0 && timedOut.get()) {
-				throw new SSHTimeoutException("SSH exec timeout after " + readTimeoutSecs + " seconds on " + toString());
-			}
+            /*
+             * If the full output (COMP_FLAG) was received, return success even if the
+             * watchdog happened to fire in the tiny window between the read break and
+             * here; otherwise a case that completed right at the deadline would be
+             * wrongly recorded as a timeout (and excluded from retry). Only treat it
+             * as a timeout when we did NOT receive the completion marker.
+             */
+            String outString = out.toString();
+            if (outString.indexOf(ScriptInput.COMP_FLAG) < 0 && timedOut.get()) {
+                throw new SSHTimeoutException("SSH exec timeout after " + readTimeoutSecs + " seconds on " + toString());
+            }
 
-			return extractOutput(outString);
-		} finally {
-			/*
-			 * Always release the channel and cancel the watchdog, regardless of
-			 * normal completion, timeout, or a read error. Otherwise a non-timeout
-			 * I/O/JSch exception would leave the ChannelExec open and leak channels
-			 * on the reused session over a long regression run. disconnect() is
-			 * idempotent, so it is safe even if the watchdog already disconnected.
-			 */
-			if (watch != null) {
-				watch.cancel(false);
-				/* drop the cancelled task from the queue so it does not retain the captured channel/session until its deadline */
-				WATCHDOG.remove((Runnable) watch);
-			}
-			try {
-				exec.disconnect();
-			} catch (Exception e) {
-			}
-		}
+            return extractOutput(outString);
+        } finally {
+            /*
+             * Always release the channel and cancel the watchdog, regardless of
+             * normal completion, timeout, or a read error. Otherwise a non-timeout
+             * I/O/JSch exception would leave the ChannelExec open and leak channels
+             * on the reused session over a long regression run. disconnect() is
+             * idempotent, so it is safe even if the watchdog already disconnected.
+             */
+            if (watch != null) {
+                watch.cancel(false);
+                /* drop the cancelled task from the queue so it does not retain the captured channel/session until its deadline */
+                WATCHDOG.remove((Runnable) watch);
+            }
+            try {
+                exec.disconnect();
+            } catch (Exception e) {
+            }
+        }
 	}
 
 	private static String extractOutput(String raw) {

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHTimeoutException.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHTimeoutException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2016, Search Solution Corporation. All rights reserved.
+
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.navercorp.cubridqa.shell.common;
+
+/**
+ * Thrown when a single SSH execute() exceeds its read deadline and the watchdog
+ * forcibly disconnects the channel. The worker uses this to mark the test case
+ * as a timeout (isTimeOut) and to exclude it from retry, so a hung case is not
+ * re-run only to hang again.
+ */
+public class SSHTimeoutException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public SSHTimeoutException(String message) {
+		super(message);
+	}
+}

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHTimeoutException.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/common/SSHTimeoutException.java
@@ -34,9 +34,9 @@ package com.navercorp.cubridqa.shell.common;
  */
 public class SSHTimeoutException extends Exception {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	public SSHTimeoutException(String message) {
-		super(message);
-	}
+    public SSHTimeoutException(String message) {
+        super(message);
+    }
 }

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
@@ -158,7 +158,7 @@ public class Dispatch {
 		return null;
 	}
 
-	public synchronized boolean complete(DispatchTicket ticket, boolean success, boolean hasCore, boolean isTimeOut) {
+    public synchronized boolean complete(DispatchTicket ticket, boolean success, boolean hasCore, boolean isTimeOut) {
 		if (ticket == null) {
 			return false;
 		}
@@ -169,8 +169,8 @@ public class Dispatch {
 			normalCompletedCount++;
 		}
 
-		/* do not retry a timeout: re-running a hung case would just hang again for another deadline */
-		boolean needRetry = !success && !hasCore && !isTimeOut && ticket.getRetryCount() < maxRetryCount;
+        /* do not retry a timeout: re-running a hung case would just hang again for another deadline */
+        boolean needRetry = !success && !hasCore && !isTimeOut && ticket.getRetryCount() < maxRetryCount;
 		if (needRetry) {
 			enqueueRetry(ticket.getTestCase(), ticket.getRetryCount() + 1);
 		} else {

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/dispatch/Dispatch.java
@@ -158,7 +158,7 @@ public class Dispatch {
 		return null;
 	}
 
-	public synchronized boolean complete(DispatchTicket ticket, boolean success, boolean hasCore) {
+	public synchronized boolean complete(DispatchTicket ticket, boolean success, boolean hasCore, boolean isTimeOut) {
 		if (ticket == null) {
 			return false;
 		}
@@ -169,7 +169,8 @@ public class Dispatch {
 			normalCompletedCount++;
 		}
 
-		boolean needRetry = !success && !hasCore && ticket.getRetryCount() < maxRetryCount;
+		/* do not retry a timeout: re-running a hung case would just hang again for another deadline */
+		boolean needRetry = !success && !hasCore && !isTimeOut && ticket.getRetryCount() < maxRetryCount;
 		if (needRetry) {
 			enqueueRetry(ticket.getTestCase(), ticket.getRetryCount() + 1);
 		} else {

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
@@ -79,11 +79,53 @@ public class ShellHelper {
 
 		/*
 		 * NOTE: the SSH read deadline is intentionally NOT set here. This factory is
-		 * shared by discovery (Dispatch's one-time ~17k-file find) and monitor
-		 * connections, where a per-testcase deadline would be wrong (it could abort
-		 * the whole run or stall the monitor). The deadline is applied only to the
-		 * worker's own connection, in Test.applyReadDeadline().
+		 * shared by discovery (Dispatch's one-time ~17k-file find), where a per-test
+		 * deadline would wrongly abort the whole run. Callers that need a backstop
+		 * apply one explicitly via applyTestcaseReadDeadline (worker main exec) or
+		 * applySecondaryReadTimeout (related-host / monitor / cleanup exec).
 		 */
 		return ssh;
+	}
+
+	/*
+	 * Shorter read timeout (seconds) for secondary/cleanup exec — related-host
+	 * checks and the monitor's cleanup/trace exec. These are quick operations, so a
+	 * tight bound lets the worker and the (single) monitor thread recover from a
+	 * reachable-but-wedged node quickly instead of blocking for the full
+	 * per-testcase deadline. Kept >= the keepalive window (60s x 10 = 600s).
+	 */
+	public static final int SECONDARY_READ_TIMEOUT_SECS = 600;
+
+	/*
+	 * Apply the per-testcase read deadline (testCaseTimeout + margin) to the
+	 * worker's MAIN connection, the one that runs the test case. This is the hard
+	 * backstop guaranteeing a hung case cannot block the worker forever.
+	 * testCaseTimeout <= 0 keeps the legacy unbounded behavior.
+	 */
+	public final static void applyTestcaseReadDeadline(SSHConnect conn, Context context) {
+		if (conn == null) {
+			return;
+		}
+		try {
+			int testCaseTimeout = Integer.parseInt(context.getTestCaseTimeout());
+			if (testCaseTimeout > 0) {
+				conn.setReadTimeoutSecs(testCaseTimeout + 300);
+			}
+		} catch (Exception e) {
+			// leave default (-1, disabled)
+		}
+	}
+
+	/*
+	 * Apply the shorter secondary read timeout to a related-host / monitor /
+	 * cleanup connection so every blocking SSH exec on a worker/monitor thread is
+	 * bounded (not just the worker's main connection). Discovery connections are
+	 * deliberately left unbounded.
+	 */
+	public final static void applySecondaryReadTimeout(SSHConnect conn) {
+		if (conn == null) {
+			return;
+		}
+		conn.setReadTimeoutSecs(SECONDARY_READ_TIMEOUT_SECS);
 	}
 }

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
@@ -77,55 +77,55 @@ public class ShellHelper {
 			ssh = new SSHConnect(host, port, user, pwd, context.getServiceProtocolType());
 		}
 
-		/*
-		 * NOTE: the SSH read deadline is intentionally NOT set here. This factory is
-		 * shared by discovery (Dispatch's one-time ~17k-file find), where a per-test
-		 * deadline would wrongly abort the whole run. Callers that need a backstop
-		 * apply one explicitly via applyTestcaseReadDeadline (worker main exec) or
-		 * applySecondaryReadTimeout (related-host / monitor / cleanup exec).
-		 */
+        /*
+         * NOTE: the SSH read deadline is intentionally NOT set here. This factory is
+         * shared by discovery (Dispatch's one-time ~17k-file find), where a per-test
+         * deadline would wrongly abort the whole run. Callers that need a backstop
+         * apply one explicitly via applyTestcaseReadDeadline (worker main exec) or
+         * applySecondaryReadTimeout (related-host / monitor / cleanup exec).
+         */
 		return ssh;
 	}
 
-	/*
-	 * Shorter read timeout (seconds) for secondary/cleanup exec — related-host
-	 * checks and the monitor's cleanup/trace exec. These are quick operations, so a
-	 * tight bound lets the worker and the (single) monitor thread recover from a
-	 * reachable-but-wedged node quickly instead of blocking for the full
-	 * per-testcase deadline. Kept >= the keepalive window (60s x 10 = 600s).
-	 */
-	public static final int SECONDARY_READ_TIMEOUT_SECS = 600;
+    /*
+     * Shorter read timeout (seconds) for secondary/cleanup exec — related-host
+     * checks and the monitor's cleanup/trace exec. These are quick operations, so a
+     * tight bound lets the worker and the (single) monitor thread recover from a
+     * reachable-but-wedged node quickly instead of blocking for the full
+     * per-testcase deadline. Kept >= the keepalive window (60s x 10 = 600s).
+     */
+    public static final int SECONDARY_READ_TIMEOUT_SECS = 600;
 
-	/*
-	 * Apply the per-testcase read deadline (testCaseTimeout + margin) to the
-	 * worker's MAIN connection, the one that runs the test case. This is the hard
-	 * backstop guaranteeing a hung case cannot block the worker forever.
-	 * testCaseTimeout <= 0 keeps the legacy unbounded behavior.
-	 */
-	public final static void applyTestcaseReadDeadline(SSHConnect conn, Context context) {
-		if (conn == null) {
-			return;
-		}
-		try {
-			int testCaseTimeout = Integer.parseInt(context.getTestCaseTimeout());
-			if (testCaseTimeout > 0) {
-				conn.setReadTimeoutSecs(testCaseTimeout + 300);
-			}
-		} catch (Exception e) {
-			// leave default (-1, disabled)
-		}
-	}
+    /*
+     * Apply the per-testcase read deadline (testCaseTimeout + margin) to the
+     * worker's MAIN connection, the one that runs the test case. This is the hard
+     * backstop guaranteeing a hung case cannot block the worker forever.
+     * testCaseTimeout <= 0 keeps the legacy unbounded behavior.
+     */
+    public final static void applyTestcaseReadDeadline(SSHConnect conn, Context context) {
+        if (conn == null) {
+            return;
+        }
+        try {
+            int testCaseTimeout = Integer.parseInt(context.getTestCaseTimeout());
+            if (testCaseTimeout > 0) {
+                conn.setReadTimeoutSecs(testCaseTimeout + 300);
+            }
+        } catch (Exception e) {
+            // leave default (-1, disabled)
+        }
+    }
 
-	/*
-	 * Apply the shorter secondary read timeout to a related-host / monitor /
-	 * cleanup connection so every blocking SSH exec on a worker/monitor thread is
-	 * bounded (not just the worker's main connection). Discovery connections are
-	 * deliberately left unbounded.
-	 */
-	public final static void applySecondaryReadTimeout(SSHConnect conn) {
-		if (conn == null) {
-			return;
-		}
-		conn.setReadTimeoutSecs(SECONDARY_READ_TIMEOUT_SECS);
-	}
+    /*
+     * Apply the shorter secondary read timeout to a related-host / monitor /
+     * cleanup connection so every blocking SSH exec on a worker/monitor thread is
+     * bounded (not just the worker's main connection). Discovery connections are
+     * deliberately left unbounded.
+     */
+    public final static void applySecondaryReadTimeout(SSHConnect conn) {
+        if (conn == null) {
+            return;
+        }
+        conn.setReadTimeoutSecs(SECONDARY_READ_TIMEOUT_SECS);
+    }
 }

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
@@ -76,6 +76,24 @@ public class ShellHelper {
 
 			ssh = new SSHConnect(host, port, user, pwd, context.getServiceProtocolType());
 		}
+
+		/*
+		 * Give the SSH read loop a hard deadline so a hung test case cannot block
+		 * the worker thread forever. The monitor resolves a timeout at
+		 * testCaseTimeout; the read deadline is set slightly larger so the monitor
+		 * (and channel EOF after its process cleanup) gets the first chance to
+		 * resolve gracefully, and this is only the hard backstop. -1 keeps the
+		 * legacy unbounded behavior.
+		 */
+		try {
+			int testCaseTimeout = Integer.parseInt(context.getTestCaseTimeout());
+			if (testCaseTimeout > 0) {
+				ssh.setReadTimeoutSecs(testCaseTimeout + 300);
+			}
+		} catch (Exception e) {
+			// leave default (-1, disabled)
+		}
+
 		return ssh;
 	}
 }

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/ShellHelper.java
@@ -78,22 +78,12 @@ public class ShellHelper {
 		}
 
 		/*
-		 * Give the SSH read loop a hard deadline so a hung test case cannot block
-		 * the worker thread forever. The monitor resolves a timeout at
-		 * testCaseTimeout; the read deadline is set slightly larger so the monitor
-		 * (and channel EOF after its process cleanup) gets the first chance to
-		 * resolve gracefully, and this is only the hard backstop. -1 keeps the
-		 * legacy unbounded behavior.
+		 * NOTE: the SSH read deadline is intentionally NOT set here. This factory is
+		 * shared by discovery (Dispatch's one-time ~17k-file find) and monitor
+		 * connections, where a per-testcase deadline would be wrong (it could abort
+		 * the whole run or stall the monitor). The deadline is applied only to the
+		 * worker's own connection, in Test.applyReadDeadline().
 		 */
-		try {
-			int testCaseTimeout = Integer.parseInt(context.getTestCaseTimeout());
-			if (testCaseTimeout > 0) {
-				ssh.setReadTimeoutSecs(testCaseTimeout + 300);
-			}
-		} catch (Exception e) {
-			// leave default (-1, disabled)
-		}
-
 		return ssh;
 	}
 }

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
@@ -53,6 +53,8 @@ public class Test {
 	/* written by the monitor thread (resolveTimeout) and read by the worker thread, so keep them visible */
 	volatile boolean testCaseSuccess;
 	volatile boolean isTimeOut = false;
+	/* set by the monitor once it has successfully cleaned up a timed-out case; lets a failed cleanup be retried */
+	volatile boolean timeoutCleanupDone = false;
 	boolean hasCore = false;
 
 	boolean shouldStop = false;
@@ -69,6 +71,7 @@ public class Test {
 		this.shouldStop = false;
 		this.isStopped = false;
 		this.isTimeOut = false;
+		this.timeoutCleanupDone = false;
 		this.hasCore = false;
 		this.context = context;
 		this.currEnvId = currEnvId;
@@ -128,6 +131,7 @@ public class Test {
 
 			resultItemList.clear();
 			this.isTimeOut = false;
+			this.timeoutCleanupDone = false;
 			this.testCaseSuccess = true;
 			this.hasCore = false;
 			int retryCount = dispatchTicket.getRetryCount();

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
@@ -50,20 +50,20 @@ public class Test {
 	Log dispatchLog;
 	Log workerLog;
 
-	/* written by the monitor thread (resolveTimeout) and read by the worker thread, so keep them visible */
-	volatile boolean testCaseSuccess;
-	volatile boolean isTimeOut = false;
-	/* set by the monitor once it has successfully cleaned up a timed-out case; lets a failed cleanup be retried */
-	volatile boolean timeoutCleanupDone = false;
+    /* written by the monitor thread (resolveTimeout) and read by the worker thread, so keep them visible */
+    volatile boolean testCaseSuccess;
+    volatile boolean isTimeOut = false;
+    /* set by the monitor once it has successfully cleaned up a timed-out case; lets a failed cleanup be retried */
+    volatile boolean timeoutCleanupDone = false;
 	boolean hasCore = false;
 
-	/* written by the worker, read by the monitor/config-monitor threads to detect shutdown, so keep them visible */
-	volatile boolean shouldStop = false;
-	volatile boolean isStopped = false;
+    /* written by the worker, read by the monitor/config-monitor threads to detect shutdown, so keep them visible */
+    volatile boolean shouldStop = false;
+    volatile boolean isStopped = false;
 	boolean needDropTestCase = false;
 
-	/* written by the worker, read by the monitor (resolveTimeout) to measure elapsed time, so keep it visible */
-	volatile long startTime = 0;
+    /* written by the worker, read by the monitor (resolveTimeout) to measure elapsed time, so keep it visible */
+    volatile long startTime = 0;
 	int maxRetryCount = 0;
 
 	ArrayList<String> resultItemList = new ArrayList<String>();
@@ -73,7 +73,7 @@ public class Test {
 		this.shouldStop = false;
 		this.isStopped = false;
 		this.isTimeOut = false;
-		this.timeoutCleanupDone = false;
+        this.timeoutCleanupDone = false;
 		this.hasCore = false;
 		this.context = context;
 		this.currEnvId = currEnvId;
@@ -133,7 +133,7 @@ public class Test {
 
 			resultItemList.clear();
 			this.isTimeOut = false;
-			this.timeoutCleanupDone = false;
+            this.timeoutCleanupDone = false;
 			this.testCaseSuccess = true;
 			this.hasCore = false;
 			int retryCount = dispatchTicket.getRetryCount();
@@ -151,30 +151,30 @@ public class Test {
 				doFinalCheck();
 				collectGeneralResult();
 			} catch (Exception e) {
-				/* a hung case that escaped via the SSH read watchdog is a timeout, not a generic failure */
-				if (e instanceof SSHTimeoutException) {
-					this.isTimeOut = true;
-					/* classify as "timeout" (consistent with the monitor path), not a generic runtime error */
-					this.addResultItem("NOK", "timeout (" + e.getMessage() + ")");
-				} else {
-					this.addResultItem("NOK", "Runtime error (" + e.getMessage() + ")");
-				}
+                /* a hung case that escaped via the SSH read watchdog is a timeout, not a generic failure */
+                if (e instanceof SSHTimeoutException) {
+                    this.isTimeOut = true;
+                    /* classify as "timeout" (consistent with the monitor path), not a generic runtime error */
+                    this.addResultItem("NOK", "timeout (" + e.getMessage() + ")");
+                } else {
+                    this.addResultItem("NOK", "Runtime error (" + e.getMessage() + ")");
+                }
 			} finally {
 				try {
 					endTime = System.currentTimeMillis();
 					long elapseTime = startTime > 0 ? endTime - startTime : 0;
 
 					StringBuffer resultCont = new StringBuffer();
-					/*
-					 * Snapshot the result list under the lock (the monitor thread may add a
-					 * timeout item concurrently), then do the blocking file I/O OUTSIDE the
-					 * lock so slow disk/NFS cannot delay the monitor's timeout detection.
-					 */
-					ArrayList<String> resultSnapshot;
-					synchronized (this) {
-						resultSnapshot = new ArrayList<String>(this.resultItemList);
-					}
-					for (String item : resultSnapshot) {
+                    /*
+                     * Snapshot the result list under the lock (the monitor thread may add a
+                     * timeout item concurrently), then do the blocking file I/O OUTSIDE the
+                     * lock so slow disk/NFS cannot delay the monitor's timeout detection.
+                     */
+                    ArrayList<String> resultSnapshot;
+                    synchronized (this) {
+                        resultSnapshot = new ArrayList<String>(this.resultItemList);
+                    }
+                    for (String item : resultSnapshot) {
 						if (testCaseSuccess) {
 							if (item.indexOf("NOK") != -1) {
 								this.testCaseSuccess = false;
@@ -190,8 +190,8 @@ public class Test {
 						resultCont.append(item).append(Constants.LINE_SEPARATOR);
 					}
 
-					/* exclude timeouts from retry: a hung case would simply hang again for another deadline */
-					boolean needRetry = Dispatch.getInstance().complete(dispatchTicket, testCaseSuccess, hasCore, isTimeOut);
+                    /* exclude timeouts from retry: a hung case would simply hang again for another deadline */
+                    boolean needRetry = Dispatch.getInstance().complete(dispatchTicket, testCaseSuccess, hasCore, isTimeOut);
 
 					if (testCaseSuccess == false && hasCore == false && context.getEnableSaveNormalErrorLog() == true) {
 						String saveErrorLogResult = doSaveNormalErrorLog();
@@ -443,7 +443,7 @@ public class Test {
 				sshRelated = null;
 				try {
 					sshRelated = ShellHelper.createTestNodeConnect(context, currEnvId, h);
-					ShellHelper.applySecondaryReadTimeout(sshRelated);
+                    ShellHelper.applySecondaryReadTimeout(sshRelated);
 					sshRelated.execute(scripts);
 					workerLog.println("[INFO] remove core file successfully on " + h + ".");
 				} catch (Exception e) {
@@ -477,8 +477,8 @@ public class Test {
 			e.printStackTrace();
 		}
 		this.ssh = ShellHelper.createTestNodeConnect(context, currEnvId);
-		/* worker's MAIN connection runs the test case -> per-testcase hard deadline */
-		ShellHelper.applyTestcaseReadDeadline(this.ssh, context);
+        /* worker's MAIN connection runs the test case -> per-testcase hard deadline */
+        ShellHelper.applyTestcaseReadDeadline(this.ssh, context);
 	}
 
 	public void resetProcess() {
@@ -495,7 +495,7 @@ public class Test {
 			sshRelated = null;
 			try {
 				sshRelated = ShellHelper.createTestNodeConnect(context, currEnvId);
-				ShellHelper.applySecondaryReadTimeout(sshRelated);
+                ShellHelper.applySecondaryReadTimeout(sshRelated);
 				result = CommonUtils.resetProcess(sshRelated, context.isWindows, context.isExecuteAtLocal());
 				workerLog.println("[INFO] CLEAN PROCESSES(" + h + "): " + result);
 			} catch (Exception e) {
@@ -594,7 +594,7 @@ public class Test {
 				result = null;
 				try {
 					sshRelated = ShellHelper.createTestNodeConnect(context, currEnvId, h);
-					ShellHelper.applySecondaryReadTimeout(sshRelated);
+                    ShellHelper.applySecondaryReadTimeout(sshRelated);
 					result = sshRelated.execute(scripts);
 					String[] itemArrary = result.split("\n");
 					if (itemArrary != null) {
@@ -615,7 +615,7 @@ public class Test {
 		}
 	}
 
-	public synchronized void addResultItem(String flag, String message) {
+    public synchronized void addResultItem(String flag, String message) {
 		if (flag == null)
 			this.resultItemList.add(message);
 		else
@@ -642,7 +642,7 @@ public class Test {
 			SSHConnect sshRelated;
 			for (String h : relatedHosts) {
 				sshRelated = ShellHelper.createTestNodeConnect(context, currEnvId, h);
-				ShellHelper.applySecondaryReadTimeout(sshRelated);
+                ShellHelper.applySecondaryReadTimeout(sshRelated);
 				checkDiskSpace(sshRelated, true);
 			}
 		}
@@ -694,7 +694,7 @@ public class Test {
 				sshRelated = null;
 				try {
 					sshRelated = ShellHelper.createTestNodeConnect(context, currEnvId, h);
-					ShellHelper.applySecondaryReadTimeout(sshRelated);
+                    ShellHelper.applySecondaryReadTimeout(sshRelated);
 					sshRelated.execute(scripts);
 					sb.append("[INFO] Normal error log locations on related server:" + result).append(Constants.LINE_SEPARATOR);
 					workerLog.println("[INFO] finish save log successfully on " + h + ".");

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
@@ -57,8 +57,9 @@ public class Test {
 	volatile boolean timeoutCleanupDone = false;
 	boolean hasCore = false;
 
-	boolean shouldStop = false;
-	boolean isStopped = false;
+	/* written by the worker, read by the monitor/config-monitor threads to detect shutdown, so keep them visible */
+	volatile boolean shouldStop = false;
+	volatile boolean isStopped = false;
 	boolean needDropTestCase = false;
 
 	/* written by the worker, read by the monitor (resolveTimeout) to measure elapsed time, so keep it visible */
@@ -442,6 +443,7 @@ public class Test {
 				sshRelated = null;
 				try {
 					sshRelated = ShellHelper.createTestNodeConnect(context, currEnvId, h);
+					ShellHelper.applySecondaryReadTimeout(sshRelated);
 					sshRelated.execute(scripts);
 					workerLog.println("[INFO] remove core file successfully on " + h + ".");
 				} catch (Exception e) {
@@ -475,29 +477,8 @@ public class Test {
 			e.printStackTrace();
 		}
 		this.ssh = ShellHelper.createTestNodeConnect(context, currEnvId);
-		applyReadDeadline(this.ssh);
-	}
-
-	/*
-	 * Apply the SSH read deadline only to the worker's own connection so a hung
-	 * test case cannot block the worker forever. The monitor resolves a timeout at
-	 * testCaseTimeout; the read deadline is set slightly larger (testCaseTimeout +
-	 * 300) so the monitor gets the first chance to resolve gracefully and this is
-	 * only the hard backstop. testCaseTimeout <= 0 keeps the legacy unbounded
-	 * behavior. Discovery and monitor connections deliberately get no deadline.
-	 */
-	private void applyReadDeadline(SSHConnect conn) {
-		if (conn == null) {
-			return;
-		}
-		try {
-			int testCaseTimeout = Integer.parseInt(context.getTestCaseTimeout());
-			if (testCaseTimeout > 0) {
-				conn.setReadTimeoutSecs(testCaseTimeout + 300);
-			}
-		} catch (Exception e) {
-			// leave default (-1, disabled)
-		}
+		/* worker's MAIN connection runs the test case -> per-testcase hard deadline */
+		ShellHelper.applyTestcaseReadDeadline(this.ssh, context);
 	}
 
 	public void resetProcess() {
@@ -514,6 +495,7 @@ public class Test {
 			sshRelated = null;
 			try {
 				sshRelated = ShellHelper.createTestNodeConnect(context, currEnvId);
+				ShellHelper.applySecondaryReadTimeout(sshRelated);
 				result = CommonUtils.resetProcess(sshRelated, context.isWindows, context.isExecuteAtLocal());
 				workerLog.println("[INFO] CLEAN PROCESSES(" + h + "): " + result);
 			} catch (Exception e) {
@@ -612,6 +594,7 @@ public class Test {
 				result = null;
 				try {
 					sshRelated = ShellHelper.createTestNodeConnect(context, currEnvId, h);
+					ShellHelper.applySecondaryReadTimeout(sshRelated);
 					result = sshRelated.execute(scripts);
 					String[] itemArrary = result.split("\n");
 					if (itemArrary != null) {
@@ -659,6 +642,7 @@ public class Test {
 			SSHConnect sshRelated;
 			for (String h : relatedHosts) {
 				sshRelated = ShellHelper.createTestNodeConnect(context, currEnvId, h);
+				ShellHelper.applySecondaryReadTimeout(sshRelated);
 				checkDiskSpace(sshRelated, true);
 			}
 		}
@@ -710,6 +694,7 @@ public class Test {
 				sshRelated = null;
 				try {
 					sshRelated = ShellHelper.createTestNodeConnect(context, currEnvId, h);
+					ShellHelper.applySecondaryReadTimeout(sshRelated);
 					sshRelated.execute(scripts);
 					sb.append("[INFO] Normal error log locations on related server:" + result).append(Constants.LINE_SEPARATOR);
 					workerLog.println("[INFO] finish save log successfully on " + h + ".");

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
@@ -35,6 +35,7 @@ import com.navercorp.cubridqa.shell.common.CommonUtils;
 import com.navercorp.cubridqa.shell.common.Constants;
 import com.navercorp.cubridqa.shell.common.Log;
 import com.navercorp.cubridqa.shell.common.SSHConnect;
+import com.navercorp.cubridqa.shell.common.SSHTimeoutException;
 import com.navercorp.cubridqa.shell.common.ShellScriptInput;
 import com.navercorp.cubridqa.shell.dispatch.Dispatch;
 
@@ -49,8 +50,9 @@ public class Test {
 	Log dispatchLog;
 	Log workerLog;
 
-	boolean testCaseSuccess;
-	boolean isTimeOut = false;
+	/* written by the monitor thread (resolveTimeout) and read by the worker thread, so keep them visible */
+	volatile boolean testCaseSuccess;
+	volatile boolean isTimeOut = false;
 	boolean hasCore = false;
 
 	boolean shouldStop = false;
@@ -143,6 +145,10 @@ public class Test {
 				doFinalCheck();
 				collectGeneralResult();
 			} catch (Exception e) {
+				/* a hung case that escaped via the SSH read watchdog is a timeout, not a generic failure */
+				if (e instanceof SSHTimeoutException) {
+					this.isTimeOut = true;
+				}
 				this.addResultItem("NOK", "Runtime error (" + e.getMessage() + ")");
 			} finally {
 				try {
@@ -150,23 +156,27 @@ public class Test {
 					long elapseTime = startTime > 0 ? endTime - startTime : 0;
 
 					StringBuffer resultCont = new StringBuffer();
-					for (String item : this.resultItemList) {
-						if (testCaseSuccess) {
-							if (item.indexOf("NOK") != -1) {
-								this.testCaseSuccess = false;
+					/* the monitor thread may add a timeout result item concurrently; iterate under the same lock as addResultItem */
+					synchronized (this) {
+						for (String item : this.resultItemList) {
+							if (testCaseSuccess) {
+								if (item.indexOf("NOK") != -1) {
+									this.testCaseSuccess = false;
+								}
 							}
-						}
-						if (hasCore == false) {
-							if (item.indexOf("NOK found core file") != -1 || item.indexOf("NOK found fatal error") != -1) {
-								this.hasCore = true;
+							if (hasCore == false) {
+								if (item.indexOf("NOK found core file") != -1 || item.indexOf("NOK found fatal error") != -1) {
+									this.hasCore = true;
+								}
 							}
-						}
 
-						workerLog.println(item);
-						resultCont.append(item).append(Constants.LINE_SEPARATOR);
+							workerLog.println(item);
+							resultCont.append(item).append(Constants.LINE_SEPARATOR);
+						}
 					}
 
-					boolean needRetry = Dispatch.getInstance().complete(dispatchTicket, testCaseSuccess, hasCore);
+					/* exclude timeouts from retry: a hung case would simply hang again for another deadline */
+					boolean needRetry = Dispatch.getInstance().complete(dispatchTicket, testCaseSuccess, hasCore, isTimeOut);
 
 					if (testCaseSuccess == false && hasCore == false && context.getEnableSaveNormalErrorLog() == true) {
 						String saveErrorLogResult = doSaveNormalErrorLog();

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/Test.java
@@ -61,7 +61,8 @@ public class Test {
 	boolean isStopped = false;
 	boolean needDropTestCase = false;
 
-	long startTime = 0;
+	/* written by the worker, read by the monitor (resolveTimeout) to measure elapsed time, so keep it visible */
+	volatile long startTime = 0;
 	int maxRetryCount = 0;
 
 	ArrayList<String> resultItemList = new ArrayList<String>();
@@ -152,31 +153,40 @@ public class Test {
 				/* a hung case that escaped via the SSH read watchdog is a timeout, not a generic failure */
 				if (e instanceof SSHTimeoutException) {
 					this.isTimeOut = true;
+					/* classify as "timeout" (consistent with the monitor path), not a generic runtime error */
+					this.addResultItem("NOK", "timeout (" + e.getMessage() + ")");
+				} else {
+					this.addResultItem("NOK", "Runtime error (" + e.getMessage() + ")");
 				}
-				this.addResultItem("NOK", "Runtime error (" + e.getMessage() + ")");
 			} finally {
 				try {
 					endTime = System.currentTimeMillis();
 					long elapseTime = startTime > 0 ? endTime - startTime : 0;
 
 					StringBuffer resultCont = new StringBuffer();
-					/* the monitor thread may add a timeout result item concurrently; iterate under the same lock as addResultItem */
+					/*
+					 * Snapshot the result list under the lock (the monitor thread may add a
+					 * timeout item concurrently), then do the blocking file I/O OUTSIDE the
+					 * lock so slow disk/NFS cannot delay the monitor's timeout detection.
+					 */
+					ArrayList<String> resultSnapshot;
 					synchronized (this) {
-						for (String item : this.resultItemList) {
-							if (testCaseSuccess) {
-								if (item.indexOf("NOK") != -1) {
-									this.testCaseSuccess = false;
-								}
+						resultSnapshot = new ArrayList<String>(this.resultItemList);
+					}
+					for (String item : resultSnapshot) {
+						if (testCaseSuccess) {
+							if (item.indexOf("NOK") != -1) {
+								this.testCaseSuccess = false;
 							}
-							if (hasCore == false) {
-								if (item.indexOf("NOK found core file") != -1 || item.indexOf("NOK found fatal error") != -1) {
-									this.hasCore = true;
-								}
-							}
-
-							workerLog.println(item);
-							resultCont.append(item).append(Constants.LINE_SEPARATOR);
 						}
+						if (hasCore == false) {
+							if (item.indexOf("NOK found core file") != -1 || item.indexOf("NOK found fatal error") != -1) {
+								this.hasCore = true;
+							}
+						}
+
+						workerLog.println(item);
+						resultCont.append(item).append(Constants.LINE_SEPARATOR);
 					}
 
 					/* exclude timeouts from retry: a hung case would simply hang again for another deadline */
@@ -465,6 +475,29 @@ public class Test {
 			e.printStackTrace();
 		}
 		this.ssh = ShellHelper.createTestNodeConnect(context, currEnvId);
+		applyReadDeadline(this.ssh);
+	}
+
+	/*
+	 * Apply the SSH read deadline only to the worker's own connection so a hung
+	 * test case cannot block the worker forever. The monitor resolves a timeout at
+	 * testCaseTimeout; the read deadline is set slightly larger (testCaseTimeout +
+	 * 300) so the monitor gets the first chance to resolve gracefully and this is
+	 * only the hard backstop. testCaseTimeout <= 0 keeps the legacy unbounded
+	 * behavior. Discovery and monitor connections deliberately get no deadline.
+	 */
+	private void applyReadDeadline(SSHConnect conn) {
+		if (conn == null) {
+			return;
+		}
+		try {
+			int testCaseTimeout = Integer.parseInt(context.getTestCaseTimeout());
+			if (testCaseTimeout > 0) {
+				conn.setReadTimeoutSecs(testCaseTimeout + 300);
+			}
+		} catch (Exception e) {
+			// leave default (-1, disabled)
+		}
 	}
 
 	public void resetProcess() {
@@ -599,7 +632,7 @@ public class Test {
 		}
 	}
 
-	public void addResultItem(String flag, String message) {
+	public synchronized void addResultItem(String flag, String message) {
 		if (flag == null)
 			this.resultItemList.add(message);
 		else

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/TestMonitor.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/TestMonitor.java
@@ -53,6 +53,8 @@ public class TestMonitor {
 		this.log = new Log(CommonUtils.concatFile(context.getCurrentLogDir(), "monitor_" + test.getCurrentEnvId() + ".log"), false, context.isContinueMode);
 
 		this.ssh = ShellHelper.createTestNodeConnect(context, test.getCurrentEnvId());
+		/* monitor exec (resetProcess cleanup / trace) must be bounded so a wedged node cannot block the single monitor thread forever */
+		ShellHelper.applySecondaryReadTimeout(this.ssh);
 		this.initRelatedSSH();
 
 		try {
@@ -93,6 +95,7 @@ public class TestMonitor {
 			for (String host : relatedHosts) {
 				try {
 					s = ShellHelper.createTestNodeConnect(context, test.getCurrentEnvId(), host);
+					ShellHelper.applySecondaryReadTimeout(s);
 					this.sshRelateds.add(s);
 				} catch (Exception e) {
 					e.printStackTrace();

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/TestMonitor.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/TestMonitor.java
@@ -204,18 +204,9 @@ public class TestMonitor {
 		long elapse_time;
 		String tcName;
 		String envId;
+		boolean justDetected = false;
 
 		synchronized (test) {
-			/*
-			 * Resolve a timeout only once per test case. Without this guard the
-			 * monitor re-runs resetProcess() (the CLEAN PROCESSES block) every 3
-			 * seconds for as long as the worker stays blocked, which is the
-			 * infinite "[RESOLVE] ... CLEAN PROCESSES:" loop. isTimeOut is reset
-			 * to false for each new case in Test.runAll().
-			 */
-			if (test.isTimeOut)
-				return;
-
 			if (testCaseTimeout < 0 || test.startTime <= 0)
 				return;
 
@@ -230,18 +221,46 @@ public class TestMonitor {
 			envId = test.envIdentify;
 
 			/*
-			 * Mark the result while holding the lock (the result list is shared
-			 * with the worker thread), and set isTimeOut up front so this case is
-			 * resolved exactly once. The slow network work (resetProcess / agent
-			 * restart / feedback) is done OUTSIDE the lock so the worker is never
-			 * blocked on the monitor's remote calls.
+			 * Record the timeout result exactly once (the result list is shared
+			 * with the worker thread). isTimeOut tracks ONLY "timeout detected /
+			 * result recorded"; it is reset for each new case in Test.runAll().
 			 */
-			test.testCaseSuccess = false;
-			test.addResultItem("NOK", "timeout");
-			test.isTimeOut = true;
+			if (test.isTimeOut == false) {
+				test.testCaseSuccess = false;
+				test.addResultItem("NOK", "timeout");
+				test.isTimeOut = true;
+				justDetected = true;
+			}
+
+			/*
+			 * Cleanup completion is tracked separately (timeoutCleanupDone) so a
+			 * failed cleanup is retried on the next monitor cycle instead of being
+			 * permanently skipped by the detection guard. Once cleanup has
+			 * succeeded there is nothing more to do for this case.
+			 */
+			if (test.timeoutCleanupDone) {
+				return;
+			}
 		}
 
+		if (justDetected) {
+			this.log.println("[RESOLVE] " + testCaseTimeout + " timeout detected (actual: " + elapse_time + " seconds) for " + tcName + ", cleaning up processes...");
+		}
+
+		/*
+		 * Do the slow work OUTSIDE the lock so the worker is never blocked on the
+		 * monitor's remote calls. resetProcess() returns an error string (it does
+		 * not throw) on SSH/RMI failure; treat that as a failed cleanup and leave
+		 * timeoutCleanupDone false so the next cycle retries while the worker is
+		 * still stuck on this case.
+		 */
 		String result = CommonUtils.resetProcess(ssh, context.isWindows, context.isExecuteAtLocal());
+		boolean cleanupFailed = (result == null) || result.startsWith("fail to reset processes:");
+
+		if (cleanupFailed) {
+			this.log.println("[RESOLVE] process cleanup failed, will retry next cycle: " + result);
+			return;
+		}
 
 		if (elapse_time > 120 && context.isWindows()) {
 			this.log.println("Try to restart remote aganet to resovle timeout problem.");
@@ -252,6 +271,13 @@ public class TestMonitor {
 				this.log.println("Restart fail: " + e.getMessage());
 			}
 		}
+
+		/*
+		 * Mark cleanup done before sending feedback: cleanup has already succeeded,
+		 * so a feedback/logging failure must not trigger another full cleanup.
+		 */
+		test.timeoutCleanupDone = true;
+
 		context.getFeedback().onTestCaseMonitor(tcName,
 				"[RESOLVE] " + testCaseTimeout + " + timeout (actual: " + elapse_time + " seconds)" + Constants.LINE_SEPARATOR + "CLEAN PROCESSES: " + Constants.LINE_SEPARATOR + result,
 				envId);

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/TestMonitor.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/TestMonitor.java
@@ -53,8 +53,8 @@ public class TestMonitor {
 		this.log = new Log(CommonUtils.concatFile(context.getCurrentLogDir(), "monitor_" + test.getCurrentEnvId() + ".log"), false, context.isContinueMode);
 
 		this.ssh = ShellHelper.createTestNodeConnect(context, test.getCurrentEnvId());
-		/* monitor exec (resetProcess cleanup / trace) must be bounded so a wedged node cannot block the single monitor thread forever */
-		ShellHelper.applySecondaryReadTimeout(this.ssh);
+        /* monitor exec (resetProcess cleanup / trace) must be bounded so a wedged node cannot block the single monitor thread forever */
+        ShellHelper.applySecondaryReadTimeout(this.ssh);
 		this.initRelatedSSH();
 
 		try {
@@ -95,7 +95,7 @@ public class TestMonitor {
 			for (String host : relatedHosts) {
 				try {
 					s = ShellHelper.createTestNodeConnect(context, test.getCurrentEnvId(), host);
-					ShellHelper.applySecondaryReadTimeout(s);
+                    ShellHelper.applySecondaryReadTimeout(s);
 					this.sshRelateds.add(s);
 				} catch (Exception e) {
 					e.printStackTrace();
@@ -204,11 +204,11 @@ public class TestMonitor {
 
 	private void resolveTimeout() {
 
-		long elapse_time;
-		String tcName;
-		String envId;
-		long detectedStartTime;
-		boolean justDetected = false;
+        long elapse_time;
+        String tcName;
+        String envId;
+        long detectedStartTime;
+        boolean justDetected = false;
 
 		synchronized (test) {
 			if (testCaseTimeout < 0 || test.startTime <= 0)
@@ -220,79 +220,79 @@ public class TestMonitor {
 				return;
 			}
 
-			elapse_time = (endTime - test.startTime) / 1000;
-			tcName = test.testCaseFullName;
-			envId = test.envIdentify;
-			detectedStartTime = test.startTime;
+            elapse_time = (endTime - test.startTime) / 1000;
+            tcName = test.testCaseFullName;
+            envId = test.envIdentify;
+            detectedStartTime = test.startTime;
 
-			/*
-			 * Record the timeout result exactly once (the result list is shared
-			 * with the worker thread). isTimeOut tracks ONLY "timeout detected /
-			 * result recorded"; it is reset for each new case in Test.runAll().
-			 */
-			if (test.isTimeOut == false) {
-				test.testCaseSuccess = false;
-				test.addResultItem("NOK", "timeout");
-				test.isTimeOut = true;
-				justDetected = true;
-			}
+            /*
+             * Record the timeout result exactly once (the result list is shared
+             * with the worker thread). isTimeOut tracks ONLY "timeout detected /
+             * result recorded"; it is reset for each new case in Test.runAll().
+             */
+            if (test.isTimeOut == false) {
+                test.testCaseSuccess = false;
+                test.addResultItem("NOK", "timeout");
+                test.isTimeOut = true;
+                justDetected = true;
+            }
 
-			/*
-			 * Cleanup completion is tracked separately (timeoutCleanupDone) so a
-			 * failed cleanup is retried on the next monitor cycle instead of being
-			 * permanently skipped by the detection guard. Once cleanup has
-			 * succeeded there is nothing more to do for this case.
-			 */
-			if (test.timeoutCleanupDone) {
-				return;
-			}
-		}
+            /*
+             * Cleanup completion is tracked separately (timeoutCleanupDone) so a
+             * failed cleanup is retried on the next monitor cycle instead of being
+             * permanently skipped by the detection guard. Once cleanup has
+             * succeeded there is nothing more to do for this case.
+             */
+            if (test.timeoutCleanupDone) {
+                return;
+            }
+        }
 
-		if (justDetected) {
-			this.log.println("[RESOLVE] " + testCaseTimeout + " timeout detected (actual: " + elapse_time + " seconds) for " + tcName + ", cleaning up processes...");
-		}
+        if (justDetected) {
+            this.log.println("[RESOLVE] " + testCaseTimeout + " timeout detected (actual: " + elapse_time + " seconds) for " + tcName + ", cleaning up processes...");
+        }
 
-		/*
-		 * Do the slow work OUTSIDE the lock so the worker is never blocked on the
-		 * monitor's remote calls. resetProcess() returns an error string (it does
-		 * not throw) on SSH/RMI failure; treat null/blank output or the failure
-		 * marker as a failed cleanup (a wedged channel can return empty output with
-		 * no kill evidence) and leave timeoutCleanupDone false so the next cycle
-		 * retries while the worker is still stuck on this case.
-		 */
-		String result = CommonUtils.resetProcess(ssh, context.isWindows, context.isExecuteAtLocal());
-		boolean cleanupFailed = (result == null) || (result.trim().length() == 0) || result.startsWith(CommonUtils.RESET_PROCESS_FAIL_PREFIX);
+        /*
+         * Do the slow work OUTSIDE the lock so the worker is never blocked on the
+         * monitor's remote calls. resetProcess() returns an error string (it does
+         * not throw) on SSH/RMI failure; treat null/blank output or the failure
+         * marker as a failed cleanup (a wedged channel can return empty output with
+         * no kill evidence) and leave timeoutCleanupDone false so the next cycle
+         * retries while the worker is still stuck on this case.
+         */
+        String result = CommonUtils.resetProcess(ssh, context.isWindows, context.isExecuteAtLocal());
+        boolean cleanupFailed = (result == null) || (result.trim().length() == 0) || result.startsWith(CommonUtils.RESET_PROCESS_FAIL_PREFIX);
 
-		if (cleanupFailed) {
-			this.log.println("[RESOLVE] process cleanup failed, will retry next cycle: " + result);
-			return;
-		}
+        if (cleanupFailed) {
+            this.log.println("[RESOLVE] process cleanup failed, will retry next cycle: " + result);
+            return;
+        }
 
-		if (elapse_time > 120 && context.isWindows()) {
-			this.log.println("Try to restart remote aganet to resovle timeout problem.");
-			try {
-				ssh.restartRemoteAgent();
-				this.log.println("Restart done");
-			} catch (Exception e) {
-				this.log.println("Restart fail: " + e.getMessage());
-			}
-		}
-
-		/*
-		 * Mark cleanup done under the lock, but only if the worker is still on the
-		 * SAME timed-out case (startTime unchanged). If it has advanced to the next
-		 * case (which resets timeoutCleanupDone), stamping it now would wrongly skip
-		 * cleanup for that new case.
-		 */
-		synchronized (test) {
-			if (test.startTime == detectedStartTime && test.isTimeOut) {
-				test.timeoutCleanupDone = true;
+        if (elapse_time > 120 && context.isWindows()) {
+            this.log.println("Try to restart remote aganet to resovle timeout problem.");
+            try {
+                ssh.restartRemoteAgent();
+                this.log.println("Restart done");
+            } catch (Exception e) {
+                this.log.println("Restart fail: " + e.getMessage());
 			}
 		}
 
-		context.getFeedback().onTestCaseMonitor(tcName,
-				"[RESOLVE] " + testCaseTimeout + " + timeout (actual: " + elapse_time + " seconds)" + Constants.LINE_SEPARATOR + "CLEAN PROCESSES: " + Constants.LINE_SEPARATOR + result,
-				envId);
+        /*
+         * Mark cleanup done under the lock, but only if the worker is still on the
+         * SAME timed-out case (startTime unchanged). If it has advanced to the next
+         * case (which resets timeoutCleanupDone), stamping it now would wrongly skip
+         * cleanup for that new case.
+         */
+        synchronized (test) {
+            if (test.startTime == detectedStartTime && test.isTimeOut) {
+                test.timeoutCleanupDone = true;
+            }
+        }
+
+        context.getFeedback().onTestCaseMonitor(tcName,
+                "[RESOLVE] " + testCaseTimeout + " + timeout (actual: " + elapse_time + " seconds)" + Constants.LINE_SEPARATOR + "CLEAN PROCESSES: " + Constants.LINE_SEPARATOR + result,
+                envId);
 	}
 
 	public void close() {

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/TestMonitor.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/TestMonitor.java
@@ -201,7 +201,21 @@ public class TestMonitor {
 
 	private void resolveTimeout() {
 
+		long elapse_time;
+		String tcName;
+		String envId;
+
 		synchronized (test) {
+			/*
+			 * Resolve a timeout only once per test case. Without this guard the
+			 * monitor re-runs resetProcess() (the CLEAN PROCESSES block) every 3
+			 * seconds for as long as the worker stays blocked, which is the
+			 * infinite "[RESOLVE] ... CLEAN PROCESSES:" loop. isTimeOut is reset
+			 * to false for each new case in Test.runAll().
+			 */
+			if (test.isTimeOut)
+				return;
+
 			if (testCaseTimeout < 0 || test.startTime <= 0)
 				return;
 
@@ -211,26 +225,36 @@ public class TestMonitor {
 				return;
 			}
 
-			long elapse_time = (endTime - test.startTime) / 1000;
+			elapse_time = (endTime - test.startTime) / 1000;
+			tcName = test.testCaseFullName;
+			envId = test.envIdentify;
 
-			String result = CommonUtils.resetProcess(ssh, context.isWindows, context.isExecuteAtLocal());
-
+			/*
+			 * Mark the result while holding the lock (the result list is shared
+			 * with the worker thread), and set isTimeOut up front so this case is
+			 * resolved exactly once. The slow network work (resetProcess / agent
+			 * restart / feedback) is done OUTSIDE the lock so the worker is never
+			 * blocked on the monitor's remote calls.
+			 */
 			test.testCaseSuccess = false;
 			test.addResultItem("NOK", "timeout");
 			test.isTimeOut = true;
-			if (elapse_time > 120 && context.isWindows()) {
-				this.log.println("Try to restart remote aganet to resovle timeout problem.");
-				try {
-					ssh.restartRemoteAgent();
-					this.log.println("Restart done");
-				} catch (Exception e) {
-					this.log.println("Restart fail: " + e.getMessage());
-				}
-			}
-			context.getFeedback().onTestCaseMonitor(test.testCaseFullName,
-					"[RESOLVE] " + testCaseTimeout + " + timeout (actual: " + elapse_time + " seconds)" + Constants.LINE_SEPARATOR + "CLEAN PROCESSES: " + Constants.LINE_SEPARATOR + result,
-					test.envIdentify);
 		}
+
+		String result = CommonUtils.resetProcess(ssh, context.isWindows, context.isExecuteAtLocal());
+
+		if (elapse_time > 120 && context.isWindows()) {
+			this.log.println("Try to restart remote aganet to resovle timeout problem.");
+			try {
+				ssh.restartRemoteAgent();
+				this.log.println("Restart done");
+			} catch (Exception e) {
+				this.log.println("Restart fail: " + e.getMessage());
+			}
+		}
+		context.getFeedback().onTestCaseMonitor(tcName,
+				"[RESOLVE] " + testCaseTimeout + " + timeout (actual: " + elapse_time + " seconds)" + Constants.LINE_SEPARATOR + "CLEAN PROCESSES: " + Constants.LINE_SEPARATOR + result,
+				envId);
 	}
 
 	public void close() {

--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/TestMonitor.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/TestMonitor.java
@@ -204,6 +204,7 @@ public class TestMonitor {
 		long elapse_time;
 		String tcName;
 		String envId;
+		long detectedStartTime;
 		boolean justDetected = false;
 
 		synchronized (test) {
@@ -219,6 +220,7 @@ public class TestMonitor {
 			elapse_time = (endTime - test.startTime) / 1000;
 			tcName = test.testCaseFullName;
 			envId = test.envIdentify;
+			detectedStartTime = test.startTime;
 
 			/*
 			 * Record the timeout result exactly once (the result list is shared
@@ -250,12 +252,13 @@ public class TestMonitor {
 		/*
 		 * Do the slow work OUTSIDE the lock so the worker is never blocked on the
 		 * monitor's remote calls. resetProcess() returns an error string (it does
-		 * not throw) on SSH/RMI failure; treat that as a failed cleanup and leave
-		 * timeoutCleanupDone false so the next cycle retries while the worker is
-		 * still stuck on this case.
+		 * not throw) on SSH/RMI failure; treat null/blank output or the failure
+		 * marker as a failed cleanup (a wedged channel can return empty output with
+		 * no kill evidence) and leave timeoutCleanupDone false so the next cycle
+		 * retries while the worker is still stuck on this case.
 		 */
 		String result = CommonUtils.resetProcess(ssh, context.isWindows, context.isExecuteAtLocal());
-		boolean cleanupFailed = (result == null) || result.startsWith("fail to reset processes:");
+		boolean cleanupFailed = (result == null) || (result.trim().length() == 0) || result.startsWith(CommonUtils.RESET_PROCESS_FAIL_PREFIX);
 
 		if (cleanupFailed) {
 			this.log.println("[RESOLVE] process cleanup failed, will retry next cycle: " + result);
@@ -273,10 +276,16 @@ public class TestMonitor {
 		}
 
 		/*
-		 * Mark cleanup done before sending feedback: cleanup has already succeeded,
-		 * so a feedback/logging failure must not trigger another full cleanup.
+		 * Mark cleanup done under the lock, but only if the worker is still on the
+		 * SAME timed-out case (startTime unchanged). If it has advanced to the next
+		 * case (which resets timeoutCleanupDone), stamping it now would wrongly skip
+		 * cleanup for that new case.
 		 */
-		test.timeoutCleanupDone = true;
+		synchronized (test) {
+			if (test.startTime == detectedStartTime && test.isTimeOut) {
+				test.timeoutCleanupDone = true;
+			}
+		}
 
 		context.getFeedback().onTestCaseMonitor(tcName,
 				"[RESOLVE] " + testCaseTimeout + " + timeout (actual: " + elapse_time + " seconds)" + Constants.LINE_SEPARATOR + "CLEAN PROCESSES: " + Constants.LINE_SEPARATOR + result,


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CUBRIDQA-1402

CTP shell regression 수행 중 특정 케이스가 hang하면 worker가 영구 블로킹되고, monitor가 "[RESOLVE] ... CLEAN PROCESSES:" 블록을 3초마다 무한 반복하며 테스트가 종료되지 않는 문제가 간헐적으로 발생했다.
버그 1, 2가 원인으로 판단되며, 이를 보완한다.
버그 3은 직접적인 연관은 없으나, 문법 오류로 판단되어 함께 수정한다.



[버그 1] SSHConnect.execute()의 무한 블로킹 read (hang 원인)
- 파일: common/SSHConnect.java, common/SSHTimeoutException.java(신규), main/ShellHelper.java
- 원인: read 루프의 탈출 조건이 ALL_COMPLETED 출력 또는 채널 EOF 둘뿐이고, read 타임아웃/keepalive가 없었다.
케이스가 hang하면 둘 다 충족되지 않아 in.read()가 무기한 멈춘다.
JSch 소켓 read는 interrupt로도 풀리지 않는다.
- 수정: read 경로에 총 deadline watchdog를 도입. deadline 초과 시 채널/세션을 disconnect하여 read를 풀고 SSHTimeoutException으로 탈출시킨다.

      - read 탈출 조건
          As-is : ALL_COMPLETED 출력 OR 채널 EOF (2가지)
          To-be : 위 2가지 + read deadline 초과
      - hung 케이스
          As-is : in.read() 무기한 블로킹 → worker 영구 정지
          To-be : (testCaseTimeout + 300)초에 watchdog가 끊고 예외로 탈출
      - 죽은 노드/네트워크 단절
          As-is : 감지 수단 없음 (영구 대기)
          To-be : keepalive(60s x 10 = 10분) + connect 타임아웃(30s)로 감지
      - deadline 값
          As-is : 없음
          To-be : ShellHelper에서 주입, testCaseTimeout>0이면 +300초,
                  아니면 -1(비활성, 기존 동작 유지)


[버그 2] TestMonitor.resolveTimeout()의 가드 부재 (무한 로그)
- 파일: main/TestMonitor.java
- 원인: 경과시간이 testCaseTimeout을 넘으면 매번 resetProcess(CLEAN PROCESSES)를 실행했고 "이미 처리했다" 가드가 없어, 버그1로 worker가 풀리지 않는 동안 3초마다 무한 반복했다.
- 수정: 진입부에 1회 가드를 추가하고, 락 보유 범위를 좁혀 네트워크 호출을 임계구역 밖으로 옮겼다.

      - timeout 처리 횟수
          As-is : 케이스당 무제한 (3초마다 반복)
          To-be : 케이스당 1회 (if (test.isTimeOut) return;)
      - CLEAN PROCESSES 로그
          As-is : 3초 간격 무한 출력
          To-be : 1회만 출력
      - 락(synchronized(test)) 보유 범위
          As-is : 네트워크 호출(resetProcess)까지 락 안에서 수행
          To-be : 가드/플래그/결과추가만 락 안, 네트워크는 락 밖
                  → worker가 monitor 원격 호출에 묶이지 않음


[버그 3] cleanup 스크립트 셸 문법 오류
- 파일: common/Constants.java (createLinKillScripts)
- 원인: ] 앞 공백 누락으로 "[: missing ']'" 에러 → stray-java 정리 로직 깨짐.

      - 코드
          As-is : if [ $isExistPid -eq 0];then
          To-be : if [ $isExistPid -eq 0 ];then


[개선 1] timeout 케이스 retry 제외
- 파일: dispatch/Dispatch.java, main/Test.java
- 사유: hang으로 끝난 케이스를 retry하면 다시 hang할 뿐이다.

      - retry 판정 인자 (Dispatch.complete)
          As-is : (success, hasCore)
          To-be : (success, hasCore, isTimeOut)
      - timeout 케이스
          As-is : 일반 실패와 동일 → retry 큐 등록 → 재hang
          To-be : retry 제외
      - timeout 식별 경로
          As-is : monitor 경로만 isTimeOut 설정
          To-be : monitor + watchdog(SSHTimeoutException) 양 경로 일관 설정
      - DB feedback timeout 분류
          As-is : watchdog 경로는 'N'으로 오분류
          To-be : 양 경로 정확히 'Y'


[개선 2] 결과 자료구조 스레드 안전성
- 파일: main/Test.java
- 사유: monitor와 worker 두 스레드가 결과 필드/리스트를 동시 접근.

      - 공유 필드(testCaseSuccess, isTimeOut)
          As-is : 일반 필드 (가시성 미보장)
          To-be : volatile
      - resultItemList 접근
          As-is : 락 없이 동시 add/순회 (ConcurrentModification 위험)
          To-be : addResultItem/결과조립 루프 synchronized(this)

