### PR TITLE
[CBRD-26006] Add --@plainnumeric hint to print NUMERIC values without E-notation

### DIFF
--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/common/SQLParser.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/common/SQLParser.java
@@ -61,8 +61,9 @@ public class SQLParser {
             boolean isCall = false;
             boolean isNewStatement = true;
             boolean isQueryplan = false;
-            boolean isJoingraph = false;    
+            boolean isJoingraph = false;
             boolean isFullplan = false;
+            boolean isPlainNumeric = false;
 
             LineScanner lineScanner = new LineScanner();
 
@@ -79,6 +80,8 @@ public class SQLParser {
                         isJoingraph = true;
                     } else if ("--@fullplan".equals(line.trim())) {
                         isFullplan = true;
+                    } else if ("--@plainnumeric".equals(line.trim())) {
+                        isPlainNumeric = true;
                     } else {
                         String controlCmd = getControlCommand(line);
                         if (controlCmd != null) {
@@ -123,6 +126,7 @@ public class SQLParser {
                         sql.setQueryplan(isQueryplan);
                         sql.setJoingraph(isJoingraph);
                         sql.setFullplan(isFullplan);
+                        sql.setPlainNumeric(isPlainNumeric);
                         list.add(sql);
 
                         // initialize state variables
@@ -130,6 +134,7 @@ public class SQLParser {
                         isQueryplan = false;
                         isJoingraph = false;
                         isFullplan = false;
+                        isPlainNumeric = false;
                         ret.setLength(0);
                         paramList = null;
                         isCall = false;

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Sql.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/bean/Sql.java
@@ -47,6 +47,9 @@ public class Sql {
     // Adds both join graph and query plan
     private boolean isFullplan = false;
 
+    // Print NUMERIC/DECIMAL values without scientific notation (BigDecimal.toPlainString)
+    private boolean isPlainNumeric = false;
+
     private int type;
 
     private String result = "";
@@ -181,5 +184,13 @@ public class Sql {
 
     public void setFullplan(boolean isFullplan) {
         this.isFullplan = isFullplan;
+    }
+
+    public boolean isPlainNumeric() {
+        return isPlainNumeric;
+    }
+
+    public void setPlainNumeric(boolean isPlainNumeric) {
+        this.isPlainNumeric = isPlainNumeric;
     }
 }

--- a/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
+++ b/CTP/sql/src/com/navercorp/cubridqa/cqt/console/dao/ConsoleDAO.java
@@ -45,6 +45,7 @@ import com.navercorp.cubridqa.cqt.console.util.XstreamHelper;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.net.URLClassLoader;
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -896,7 +897,14 @@ public class ConsoleDAO extends Executor {
                          (columnType == Types.OTHER && isNumeric(data != null ? data.toString() : "")))) {
                         value = rs.getString(index);
                     } else {
-                        value = getColumnValue(columnType, columnTypeName, data, rs, index);
+                        value =
+                                getColumnValue(
+                                        columnType,
+                                        columnTypeName,
+                                        data,
+                                        rs,
+                                        index,
+                                        sql.isPlainNumeric());
                     }
                     ret.append(value + "     ");
                 }
@@ -955,7 +963,12 @@ public class ConsoleDAO extends Executor {
      * @throws
      */
     private String getColumnValue(
-            int colType, String colTypeName, Object value, ResultSet rs, int index) {
+            int colType,
+            String colTypeName,
+            Object value,
+            ResultSet rs,
+            int index,
+            boolean isPlainNumeric) {
         if (value == null) {
             return null;
         }
@@ -1010,7 +1023,11 @@ public class ConsoleDAO extends Executor {
                     }
                 }
             } else {
-                sb.append(value.toString());
+                if (isPlainNumeric && value instanceof BigDecimal) {
+                    sb.append(((BigDecimal) value).toPlainString());
+                } else {
+                    sb.append(value.toString());
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -57,10 +57,13 @@ typedef struct SqlStateStruct
   char *sql;
   // query plan
   struct {
-    bool hasqp; 
+    bool hasqp;
     bool onlyjg; /*join graph without queryplan */
     bool hasfullp;
   };
+
+  /* print NUMERIC values as-is without trimming/scientific notation */
+  bool isplain;
 
   bool iscallwithoutvalue;
 } SqlStateStruce;
@@ -990,7 +993,7 @@ readFile (char *fileName)
   int ascii1 = 0, ascii2 = 0;
   char line[MAX_SQL_LEN];
   char sql_buf[MAXLINELENGH];
-  bool hasqp = 0, hasjg = 0, hasfullp = 0;
+  bool hasqp = 0, hasjg = 0, hasfullp = 0, isplain = 0;
 
   //initial the total sql count.
   total_sql = 0;
@@ -1022,6 +1025,10 @@ readFile (char *fileName)
 		  hasfullp = 1;
 		  hasqp = 1;
 		}
+	      else if (startswith (line, "--@plainnumeric"))
+		{
+		  isplain = 1;
+		}
 	      else if (startswithCI (line, "--+ server-message") ||
 		       startswithCI (line, "--+server-message") ||
 		       startswithCI (line, "--+ holdcas") || startswithCI (line, "--+holdcas"))
@@ -1031,6 +1038,7 @@ readFile (char *fileName)
 		  sqlstate[total_sql].hasqp = 0;
 		  sqlstate[total_sql].onlyjg = 0;
 		  sqlstate[total_sql].hasfullp = 0;
+		  sqlstate[total_sql].isplain = 0;
 		  //if script like "? = call"
 		  sqlstate[total_sql].iscallwithoutvalue = 0;
 
@@ -1064,6 +1072,7 @@ readFile (char *fileName)
 		  sqlstate[total_sql].hasqp = hasqp;
 		  sqlstate[total_sql].onlyjg = hasjg;
 		  sqlstate[total_sql].hasfullp = hasfullp;
+		  sqlstate[total_sql].isplain = isplain;
 		  //if script like "? = call"
 		  sqlstate[total_sql].iscallwithoutvalue = startswith (line, "?");
 
@@ -1074,6 +1083,7 @@ readFile (char *fileName)
 		  hasqp = 0;
 		  hasjg = 0;
 		  hasfullp = 0;
+		  isplain = 0;
 		}
 
 	      if (is_statement_end ())
@@ -1400,7 +1410,7 @@ formatfullplan (FILE * fp, char *queryPlan)
 
 
 int
-dumptable (FILE * fp, int req, char con, bool hasqueryplan, bool onlyjoingraph, bool hasfullplan)
+dumptable (FILE * fp, int req, char con, bool hasqueryplan, bool onlyjoingraph, bool hasfullplan, bool isplainnumeric)
 {
   int res = 0;
   int ind = 0, index_count = 0, col_count = 0, setsize = -1, index_set = 0;
@@ -1600,7 +1610,14 @@ _NEXT_MULTIPLE_LINE_SQL:
 		    }
 		  if (itemp == CCI_U_TYPE_NUMERIC)
 		    {
-		      trimnumeric (fp, (char *) buffer);
+		      if (isplainnumeric)
+			{
+			  fprintf (fp, "%s", (char *) buffer);
+			}
+		      else
+			{
+			  trimnumeric (fp, (char *) buffer);
+			}
 		    }
 		  else if (itemp == CCI_U_TYPE_DATETIME)
 		    {
@@ -1984,6 +2001,7 @@ execute (FILE * fp, char conn, const SqlStateStruce *pSqlState)
   bool hasqueryplan = pSqlState->hasqp;
   bool onlyjoingraph = pSqlState->onlyjg;
   bool hasfullplan = pSqlState->hasfullp;
+  bool isplainnumeric = pSqlState->isplain;
   bool executed = false;
 
   fprintf (fp, "===================================================\n");
@@ -2030,7 +2048,7 @@ execute (FILE * fp, char conn, const SqlStateStruce *pSqlState)
   if (cmd_type == CUBRID_STMT_SELECT || cmd_type == CUBRID_STMT_CALL || cmd_type == CUBRID_STMT_EVALUATE
       || cmd_type == CUBRID_STMT_GET_STATS)
     {
-      dumptable (fp, req, conn, hasqueryplan, onlyjoingraph, hasfullplan);
+      dumptable (fp, req, conn, hasqueryplan, onlyjoingraph, hasfullplan, isplainnumeric);
       goto _END;
     }
   else if (cmd_type == CUBRID_STMT_UPDATE || cmd_type == CUBRID_STMT_DELETE)
@@ -2083,7 +2101,7 @@ execute (FILE * fp, char conn, const SqlStateStruce *pSqlState)
       res_col_info = cci_get_result_info (req, &cmd_type, &col_count);
       if (cmd_type == CUBRID_STMT_SELECT || cmd_type == CUBRID_STMT_CALL)
 	{
-	  dumptable (fp, req, conn, hasqueryplan, onlyjoingraph, hasfullplan);
+	  dumptable (fp, req, conn, hasqueryplan, onlyjoingraph, hasfullplan, isplainnumeric);
 	}
       else
 	{
@@ -2126,6 +2144,7 @@ executebind (FILE * fp, char conn, char *param, const SqlStateStruce *pSqlState)
   bool hasqueryplan = pSqlState->hasqp;
   bool onlyjoingraph = pSqlState->onlyjg;
   bool hasfullplan = pSqlState->hasfullp;
+  bool isplainnumeric = pSqlState->isplain;
   bool iscall = pSqlState->iscallwithoutvalue;
   bool executed = false;
 
@@ -2249,7 +2268,7 @@ executebind (FILE * fp, char conn, char *param, const SqlStateStruce *pSqlState)
   res_col_info = cci_get_result_info (req, &cmd_type, &col_count);
   if (cmd_type == CUBRID_STMT_SELECT || cmd_type == CUBRID_STMT_CALL)
     {
-      dumptable (fp, req, conn, hasqueryplan, onlyjoingraph, hasfullplan);
+      dumptable (fp, req, conn, hasqueryplan, onlyjoingraph, hasfullplan, isplainnumeric);
     }
   else
     {
@@ -2269,7 +2288,7 @@ executebind (FILE * fp, char conn, char *param, const SqlStateStruce *pSqlState)
 	  res_col_info = cci_get_result_info (req, &cmd_type, &col_count);
 	  if (cmd_type == CUBRID_STMT_SELECT || cmd_type == CUBRID_STMT_CALL)
 	    {
-	      dumptable (fp, req, conn, hasqueryplan, onlyjoingraph, hasfullplan);
+	      dumptable (fp, req, conn, hasqueryplan, onlyjoingraph, hasfullplan, isplainnumeric);
 	    }
 	  else
 	    {


### PR DESCRIPTION
CTP 툴은 결과 출력 시 toString()을 사용하고 있어, 자릿수가 크면 지수 표기로 나오는 문제가 있습니다.
이를 해결하기 위한 방안으로, #766 을 고안했으나, 버전별로 관리하게 될 경우 이전 버전들과의 호환성 등 영향도가 커지게 됩니다.
따라서 버전별로 관리하지 않고, 쿼리마다 힌트를 둬서 온전한 자릿수가 나오도록 하는 방법을 고안했습니다.
이 경우, 11.5버전에서 새로 추가되는 TC들에 대해 온전한 자릿수가 나올 것이고, 하위버전에 대한 영향도는 없을 것으로 예상됩니다.

하위버전에 대한 영향도가 없다면 버전별 관리(#766)가 맞을 것이고, 그렇지 않고 영향범위가 과도하게 크다면 힌트 사용이 맞을 것 같습니다.
-> 팀 내 논의후 결정하겠습니다.

사용법: 

```
--@plainnumeric
-- 128 digits (39,128): rounded at 127 fractional digits
SELECT CAST(
  0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000123456789012345678901234567890123456789
  AS NUMERIC(38,127)
);
```
결과
```
cast(0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000123456789012345678901234567890123456789 as numeric(38,127))
0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000123456789012345678901234567890123456
```

hint사용하지 않았을 때
```
cast(0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000123456789012345678901234567890123456789 as numeric(38,127))
1.23456789012345678901234567890123456E-90
```
