### PR TITLE
[CUBRIDQA-1435] Use ERROR_BACKUP and private-only SSH in core-dump JIRA comment

### DIFF
--- a/CTP/common/script/analyze_failure.sh
+++ b/CTP/common/script/analyze_failure.sh
@@ -28,7 +28,7 @@ core_file_name=
 error_msg_keyword=
 pkg_file=
 login_info=""
-fix_backup_dir_name="do_not_delete_core"
+fix_backup_dir_name="ERROR_BACKUP"
 json_create_suffix="_CREATE.json"
 json_comment_suffix="_COMMENT.json"
 export CTP_HOME=$(cd $(dirname $(readlink -f $0))/../..; pwd)
@@ -234,11 +234,6 @@ ISSUEFILDDATA
 
 	#generate comment data file content
 	user_info=`cat readme.txt |grep TEST_INFO_ENV|grep -v export|awk -F '=' '{print $NF}'|sed "s/'//g"`
-	if [ ! "${login_info}" == "" ]; then
-		gateway_ip=`echo ${login_info} | awk -F ":" '{print $1}'`
-		mapping_port=`echo ${login_info} | awk -F ":" '{print $2}'`
-		user_info="ssh -p ${mapping_port} ${USER}@${gateway_ip} or ${user_info}"
-	fi
 
 	related_case=`cat readme.txt |grep "TEST CASE:"|grep -v grep|grep -v freadme|sed 's/^.*TEST CASE://g'|tr -d '[[:space:]]'`
 	is_only_demodb=`find ./ -name "*_vinf"|grep -v "demodb_vinf"|wc -l`


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1435

코어 덤프 리포팅 시 `analyze_failure.sh`가 생성하는 JIRA 코멘트의 백업 경로와 `Test Server` 접속 정보를 실제 상태에 맞게 정정함. 코멘트 경로를 실제 백업 위치인 `~/ERROR_BACKUP`으로 통일하고, `Test Server`에는 사설 IP 접속 명령만 노출하도록 변경함.

Changes

- `CTP/common/script/analyze_failure.sh`의 `fix_backup_dir_name`을 `do_not_delete_core`에서 `ERROR_BACKUP`으로 변경하여 `All Info`/`Core Location`/`DB-Volume Location`/`Error Log Location`이 모두 실제 백업 루트(`~/ERROR_BACKUP`, `CTP/shell/init_path/shell_utils.sh` 기준)를 사용하도록 정정
- `login_info`(`-l gateway:port`) 기반 게이트웨이 SSH 프리픽스 조합 로직을 제거하여 `Test Server`의 `user@IP`가 `TEST_INFO_ENV`의 사설 IP 접속 명령(`ssh -p <port> <user>@<private_ip>`)만 노출하도록 변경
- `-l` 옵션 파싱 자체는 유지하여 기존 호출부 호환성 유지
- build/timestamp/case명/core 파일명/`Related Case` 등 나머지 코멘트 포맷은 변경 없이 유지