### PR TITLE
[CUBRIDQA-1431] Modified execute.c and compile.sh the output logic so that if the fractional p…

### DIFF
--- a/CTP/sql_by_cci/compile.sh
+++ b/CTP/sql_by_cci/compile.sh
@@ -41,6 +41,17 @@ else
 fi
 CFLAGS="-O0 -g -W -Wall"
 
+# numeric : A global version variable is set to produce different outputs based on the regression test version.
+# (outputting 10 to 15 decimal places) CUBRIDQA-1431
+build_ver=`cubrid_rel|grep "CUBRID"|awk -F '(' '{print $2}'|sed 's/)//g'`
+cubrid_major=${build_ver%%.*}
+cubrid_minor=`echo $build_ver|awk -F '.' '{print $2}'`
+if [ "$cubrid_major" -gt 11 ] || { [ "$cubrid_major" -eq 11 ] && [ "$cubrid_minor" -ge 5 ]; }; then
+	NUMERIC_MACRO_OPTION="-D NUMERIC_TRUNC_GE_11_5=1"
+else
+	NUMERIC_MACRO_OPTION="-D NUMERIC_TRUNC_GE_11_5=0"
+fi
+
 bits=`cubrid_rel|grep 64bit|grep -v grep|wc -l`
 if [ $bits -eq 1 ];then
      CFLAGS="$CFLAGS -m64"
@@ -60,7 +71,8 @@ fi
 #Do compile
 echo ""
 echo "======Start Compile======"
-gcc $MACRO_OPTION -o execute execute.c line_scanner.c $CUBRID_INCLUDE $CUBRID_LDFLAGS $CFLAGS
+# CUBRIDQA-1431 : Add $NUMERIC_MACRO_OPTION
+gcc $MACRO_OPTION $NUMERIC_MACRO_OPTION -o execute execute.c line_scanner.c $CUBRID_INCLUDE $CUBRID_LDFLAGS $CFLAGS
 statOfExecute=$?
 gcc -o ccqt ccqt.c $CFLAGS
 statOfCcqt=$?

--- a/CTP/sql_by_cci/compile.sh
+++ b/CTP/sql_by_cci/compile.sh
@@ -47,9 +47,9 @@ build_ver=`cubrid_rel|grep "CUBRID"|awk -F '(' '{print $2}'|sed 's/)//g'`
 cubrid_major=${build_ver%%.*}
 cubrid_minor=`echo $build_ver|awk -F '.' '{print $2}'`
 if [ "$cubrid_major" -gt 11 ] || { [ "$cubrid_major" -eq 11 ] && [ "$cubrid_minor" -ge 5 ]; }; then
-	NUMERIC_MACRO_OPTION="-D NUMERIC_TRUNC_GE_11_5=1"
+	MACRO_OPTION="$MACRO_OPTION -D NUMERIC_TRUNC_LEN=16"
 else
-	NUMERIC_MACRO_OPTION="-D NUMERIC_TRUNC_GE_11_5=0"
+	MACRO_OPTION="$MACRO_OPTION -D NUMERIC_TRUNC_LEN=11"
 fi
 
 bits=`cubrid_rel|grep 64bit|grep -v grep|wc -l`
@@ -72,7 +72,7 @@ fi
 echo ""
 echo "======Start Compile======"
 # CUBRIDQA-1431 : Add $NUMERIC_MACRO_OPTION
-gcc $MACRO_OPTION $NUMERIC_MACRO_OPTION -o execute execute.c line_scanner.c $CUBRID_INCLUDE $CUBRID_LDFLAGS $CFLAGS
+gcc $MACRO_OPTION -o execute execute.c line_scanner.c $CUBRID_INCLUDE $CUBRID_LDFLAGS $CFLAGS
 statOfExecute=$?
 gcc -o ccqt ccqt.c $CFLAGS
 statOfCcqt=$?

--- a/CTP/sql_by_cci/compile.sh
+++ b/CTP/sql_by_cci/compile.sh
@@ -71,7 +71,7 @@ fi
 #Do compile
 echo ""
 echo "======Start Compile======"
-# CUBRIDQA-1431 : Add $NUMERIC_MACRO_OPTION
+# CUBRIDQA-1431 : Add $MACRO_OPTION
 gcc $MACRO_OPTION -o execute execute.c line_scanner.c $CUBRID_INCLUDE $CUBRID_LDFLAGS $CFLAGS
 statOfExecute=$?
 gcc -o ccqt ccqt.c $CFLAGS

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -52,6 +52,13 @@
 #define MAX_SQL_LEN 1024*200
 #define MAX_LEN 1024
 
+// Add definition of the declaration.(CUBRIDQA-1431)
+#if NUMERIC_TRUNC_GE_11_5 == 1
+#define NUMERIC_TRUNC_LEN 16
+#else
+#define NUMERIC_TRUNC_LEN 11
+#endif
+
 typedef struct SqlStateStruct
 {
   char *sql;
@@ -367,9 +374,9 @@ trimnumeric (FILE * fp, char *buffer)
     }
   else
     {
-      if ((length - dot_position - 1) > 11)
+      if ((length - dot_position - 1) > NUMERIC_TRUNC_LEN)
 	{
-	  p[dot_position + 11] = 0;
+	  p[dot_position + NUMERIC_TRUNC_LEN] = 0;
 	}
     }
   fprintf (fp, "%s", p);

--- a/CTP/sql_by_cci/execute.c
+++ b/CTP/sql_by_cci/execute.c
@@ -52,12 +52,6 @@
 #define MAX_SQL_LEN 1024*200
 #define MAX_LEN 1024
 
-// Add definition of the declaration.(CUBRIDQA-1431)
-#if NUMERIC_TRUNC_GE_11_5 == 1
-#define NUMERIC_TRUNC_LEN 16
-#else
-#define NUMERIC_TRUNC_LEN 11
-#endif
 
 typedef struct SqlStateStruct
 {
@@ -374,7 +368,7 @@ trimnumeric (FILE * fp, char *buffer)
     }
   else
     {
-      if ((length - dot_position - 1) > NUMERIC_TRUNC_LEN)
+      if ((length - dot_position - 1) >= NUMERIC_TRUNC_LEN)
 	{
 	  p[dot_position + NUMERIC_TRUNC_LEN] = 0;
 	}


### PR DESCRIPTION
…art exceeds 11 digits, it is truncated to 15 digits instead of 10.

to refer : http://jira.cubrid.org/browse/CUBRIDQA-1431

- compile.sh : sql_by_cci 출력에서 numeric type인 경우 11.5 와 11.4 소수부 자리수 출력 변경 발생하여 버전 가져오는 로직 추가 및 gcc 변경
- execute.c : regression test 버전 11.5 이상인 경우 numeric 소수부 자리수 15자리,  11.4 이하면 10자리로 출력

참조)
http://jira.cubrid.org/browse/CBRD-26884
[CBRD-26884] Apply the NUMERIC precision/scale declared via %TYPE in PL/CSQL procedures/functions instead of falling back to float numeric#7283 #2959
