### PR TITLE
[CUBRIDQA-1461] mask Korean line numbers in diff_ignore_lineno()

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -891,7 +891,7 @@ function change_parameter
     parameter=$2
 
     key=${parameter%%=*}
-    value=${paramter##*=}
+    value=${parameter##*=}
     key=`echo $key|sed 's/^ *//g'`
     key=`echo $key|sed 's/ *$//g'`
 

--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -317,30 +317,67 @@ function diff_ignore_lineno
    local op=$3
    local tmp1="${f1}_temp_diff"
    local tmp2="${f2}_temp_diff"
-   cp -rf ${f1} ${tmp1}
-   cp -rf ${f2} ${tmp2}
+   cp -f "${f1}" "${tmp1}"
+   cp -f "${f2}" "${tmp2}"
 
-   local reg="s/In[\t ]*line[\t 0-9]*,[\t ]*column[\t 0-9]*/In      line    ?,      column  ?/g"
-   sed -i "$reg" ${tmp1}
-   sed -i "$reg" ${tmp2}
+   # Mask the line/column numbers that csql and loaddb print in their messages,
+   # so that only the message content is compared. Moving a statement inside a
+   # script shifts every following line number, which would show up as a diff
+   # even though the tested behaviour did not change.
+   #
+   # Both English and Korean messages are masked. i18n test cases run csql with
+   # CUBRID_MSG_LANG=ko_KR, and CUBRID translates part of these messages
+   # (csql.msg 47, 48 and 62), so the English patterns alone leave them
+   # unmasked. Each Korean pattern is listed twice, in UTF-8 and in EUC-KR,
+   # because both ko_KR.utf8 and ko_KR.euckr are in use; the EUC-KR patterns
+   # are written as byte escapes to keep this file itself UTF-8. sed runs under
+   # LC_ALL=C so that either encoding is matched byte-wise instead of failing
+   # on an invalid multibyte sequence.
+   #
+   # The order of the expressions matters: the Korean text for "In the command
+   # from line N," is "라인 N,", which is a prefix of the "라인 N, 열 N," used
+   # for "In line N, column N,". The longer form has to be masked first.
+   #
+   # Messages hardcoded in English in the CUBRID source (csql.c "Commit
+   # transaction at line", load_db.c "In <file> line") have no Korean form and
+   # are masked only once.
+   local -a mask_exprs=(
+      # csql "=== <Result of SELECT Command in Line N> ==="
+      -e "s/Command in Line[[:space:]]*[0-9][0-9]*/Command in Line ?/g"
+      # csql "=== <SELECT의 결과, 명령어 라인 N> ==="
+      -e "s/의[[:space:]]*결과,[[:space:]]*명령어[[:space:]]*라인[[:space:]]*[0-9][0-9]*/의 결과, 명령어 라인 ?/g"
+      -e $'s/\xc0\xc7[[:space:]]*\xb0\xe1\xb0\xfa,[[:space:]]*\xb8\xed\xb7\xc9\xbe\xee[[:space:]]*\xb6\xf3\xc0\xce[[:space:]]*[0-9][0-9]*/\xc0\xc7 \xb0\xe1\xb0\xfa, \xb8\xed\xb7\xc9\xbe\xee \xb6\xf3\xc0\xce ?/g'
 
-   reg="s/In the command from line[ 0-9]*/In the command from line ?/g"
-   sed -i "$reg" ${tmp1}
-   sed -i "$reg" ${tmp2}
+      # csql "In line N, column N," and "라인 N, 열 N,"
+      -e "s/In[\t ]*line[\t 0-9]*,[\t ]*column[\t 0-9]*/In      line    ?,      column  ?/g"
+      -e "s/라인[[:space:]]*[0-9][0-9]*,[[:space:]]*열[[:space:]]*[0-9][0-9]*,/라인 ?, 열 ?,/g"
+      -e $'s/\xb6\xf3\xc0\xce[[:space:]]*[0-9][0-9]*,[[:space:]]*\xbf\xad[[:space:]]*[0-9][0-9]*,/\xb6\xf3\xc0\xce ?, \xbf\xad ?,/g'
 
-   reg="s/Commit transaction at line[ 0-9]*/Commit transaction at line ?/g"
-   sed -i "$reg" ${tmp1}
-   sed -i "$reg" ${tmp2}
+      # csql "In the command from line N," and "라인 N,". The Korean text is
+      # only the word "라인" plus the number, so the trailing comma is required
+      # to keep it apart from the other messages that mention a "라인 N"
+      # (loaddb "라인 N:", "라인 N에서", ...).
+      -e "s/In the command from line[ 0-9]*/In the command from line ?/g"
+      -e "s/라인[[:space:]]*[0-9][0-9]*,/라인 ?,/g"
+      -e $'s/\xb6\xf3\xc0\xce[[:space:]]*[0-9][0-9]*,/\xb6\xf3\xc0\xce ?,/g'
 
-   reg="s/In schema[0-9]* line [0-9]*/In schema? line ?/g"
-   sed -i "$reg" ${tmp1}
-   sed -i "$reg" ${tmp2}
+      # csql/loaddb, hardcoded in English
+      -e "s/Commit transaction at line[ 0-9]*/Commit transaction at line ?/g"
+      -e "s/In schema[0-9]* line [0-9]*/In schema? line ?/g"
+      -e "s/In indexes[0-9]* line [0-9]*/In indexes? line ?/g"
+   )
 
-   reg="s/In indexes[0-9]* line [0-9]*/In indexes? line ?/g"
-   sed -i "$reg" ${tmp1}
-   sed -i "$reg" ${tmp2}
+   LC_ALL=C sed -i "${mask_exprs[@]}" "${tmp1}"
+   LC_ALL=C sed -i "${mask_exprs[@]}" "${tmp2}"
 
-   diff ${tmp1} ${tmp2} ${op}
+   # ${op} is left unquoted on purpose: it carries the diff options and has to
+   # disappear when the caller passes none.
+   # '|| rc=$?' keeps the exit code of diff without tripping 'set -e', so that
+   # the temporary files are removed on both the equal and the differing path.
+   local rc=0
+   diff "${tmp1}" "${tmp2}" ${op} || rc=$?
+   rm -f "${tmp1}" "${tmp2}"
+   return $rc
 }
 
 # After comparing two files, This function write the result int result files.


### PR DESCRIPTION
## 문제

CUBRID는 line 번호를 담은 메시지 중 일부를 **번역**합니다. 그래서 `CUBRID_MSG_LANG=ko_KR`로 csql을 실행하는 i18n 테스트케이스의 출력은 `diff_ignore_lineno()`가 전혀 마스킹하지 못했습니다.

| msg | 영문 | 한글 | 기존 마스킹 |
|---|---|---|---|
| csql.msg 47 | `In the command from line N,` | `라인 N,` | 영문만 |
| csql.msg 48 | `In line N, column N,` | `라인 N, 열 N,` | 영문만 |
| csql.msg 62 | `=== <Result of SELECT Command in Line N> ===` | `=== <SELECT의 결과, 명령어 라인 N> ===` | **양쪽 다 없음** |

이 때문에 테스트 안에서 SQL 문장 위치가 밀리기만 해도 diff가 발생해 오탐 NOK가 났습니다. 실제 사례는 `shell/_06_issues/_12_2h/bug_bts_9411_5`로, `CUBRID_MSG_LANG=ko_KR.euckr`로 수행되며 답지에 `라인 1,`, `라인 15, 열 24,`가 들어 있습니다.

`Commit transaction at line N`(`csql.c:2101`, `load_db.c:1076`), `In <file> line N,`(`load_db.c:1037`), `In line N, column N before ...`(cubrid.msg 111/112)은 CUBRID 소스에 영문으로 하드코딩되어 있거나 번역되지 않으므로 한글 패턴이 필요 없습니다.

## 변경 내용

- csql.msg 47, 48, 62의 한글 형태를 추가. 테스트케이스가 `ko_KR.utf8`과 `ko_KR.euckr`을 모두 사용하므로 **UTF-8과 EUC-KR 두 인코딩**으로 각각 등록했습니다. EUC-KR 패턴은 바이트 이스케이프로 작성해 `init.sh` 자체는 UTF-8을 유지합니다.
- `sed`를 `LC_ALL=C`로 실행. 어느 인코딩이든 바이트 단위로 매칭되며, EUC-KR 파일에서 multibyte 오류가 나지 않습니다.
- `sed -i` 10회 호출을 파일당 1회로 통합.
- csql.msg 62는 영문·한글 모두 마스킹되지 않았던 항목으로, 이번에 양쪽 다 추가했습니다.
- 함수가 호출마다 테스트케이스 디렉터리에 남기던 `*_temp_diff` 임시파일 2개를 삭제. 일치·불일치·에러 세 경로 모두에서 정리됩니다.
- `cp -rf` → `cp -f`, 파일명 인용 처리로 공백 포함 경로 대응. `${op}`는 diff 옵션을 담고 있어 호출자가 옵션을 주지 않으면 사라져야 하므로 **의도적으로 미인용 유지**했습니다.

치환 순서가 중요하며 코드에 주석으로 명시했습니다. msg 47의 한글(`라인 N,`)이 msg 48의 한글(`라인 N, 열 N,`)의 접두어이므로 긴 쪽을 먼저 치환해야 합니다. 반대로 하면 line 번호만 치환되고 column 번호가 남습니다.

## 호환성

- 기존 영문 표현식은 바이트 단위로 동일하며 상호 적용 순서도 그대로입니다.
- 추가한 모든 패턴은 숫자 1자 이상을 요구하므로, 이미 `?`로 마스킹된 답지를 두 번 마스킹하지 않습니다.
- 마스킹은 "더 많이 같아지는" 단조적 변경이므로, 현재 통과하는 비교가 실패로 바뀔 수 없습니다.

## 검증

- 실제 csql 출력을 `en_US.utf8`, `ko_KR.utf8`, `ko_KR.euckr` 3개 로케일에서 동일 SQL의 줄 위치만 바꿔 생성 → 기존 함수는 3개 모두 실패, 새 함수는 3개 모두 마스킹 성공.
- `bug_bts_9411_5`의 실제 EUC-KR 답지로 end-to-end 확인: 기존 `write_nok` → 변경 후 `write_ok`.
- 단위 검증 16건 통과. 기존 영문 패턴 5개, 신규 영문 패턴 1개, 한글 패턴을 두 인코딩으로 각각 검증했고, negative 케이스도 포함했습니다 — 메시지 내용이 실제로 다르면 여전히 검출되며, loaddb의 `라인 N:`은 의도적으로 마스킹하지 않습니다.
- 해당 메시지를 담은 저장소 내 `.answer`/`.expect`/`.result` **1,609개** 전체 회귀 스윕: 기존 마스킹과의 차이가 전부 의도한 신규 패턴이며 예상 밖 카테고리는 0건.
- 종료 코드 전파(0 일치 / 1 상이 / 2 에러) 동일, `| tee -a`로 쓰이는 `-y` 경로 출력 정상, 호출자의 `set -e` 하에서도 안전.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
