### PR TITLE
[CUBRIDQA-1461] keep the diff_ignore_lineno() temporary files

### DIFF
--- a/CTP/shell/init_path/init.sh
+++ b/CTP/shell/init_path/init.sh
@@ -372,12 +372,17 @@ function diff_ignore_lineno
 
    # ${op} is left unquoted on purpose: it carries the diff options and has to
    # disappear when the caller passes none.
-   # '|| rc=$?' keeps the exit code of diff without tripping 'set -e', so that
-   # the temporary files are removed on both the equal and the differing path.
-   local rc=0
-   diff "${tmp1}" "${tmp2}" ${op} || rc=$?
-   rm -f "${tmp1}" "${tmp2}"
-   return $rc
+   #
+   # ${tmp1} and ${tmp2} are deliberately left behind. Deleting them here looks
+   # like the tidier thing to do, but the test cases own that cleanup and one of
+   # them asserts on the file: shell/_38_fig/cbrd_24478/deduplicate case #7 is
+   # 'if [ -f create_table_data.answer_temp_diff ]', which turns into a NOK as
+   # soon as this function removes it. The other 42 references are the test
+   # cases deleting '*_temp_diff' at the end of the script, 13 of them with a
+   # bare 'rm' that also fails once the glob matches nothing.
+   #
+   # Keep diff as the last command so its exit code stays the return value.
+   diff "${tmp1}" "${tmp2}" ${op}
 }
 
 # After comparing two files, This function write the result int result files.


### PR DESCRIPTION
## 문제

#776에서 `diff_ignore_lineno()`가 생성하는 `*_temp_diff` 임시파일 2개를 함수 안에서 삭제하도록 바꿨는데, 이 때문에 `shell/_38_fig/cbrd_24478/deduplicate` 테스트케이스가 실패했습니다.

이 테스트의 case #7은 **임시파일의 존재 자체를 검증 조건으로 사용**합니다 (`deduplicate.sh:66`):

```bash
compare_result_between_files create_table_data.log create_table_data.answer  #6

if [ -f create_table_data.answer_temp_diff ];then   #7
    write_ok "[create table checked]"
else
    write_nok "[create table fail]"
fi
```

함수가 파일을 지우면 조건이 절대 참이 되지 않아 `write_nok`가 실행되고, `.result`에 NOK가 남아 테스트케이스가 실패합니다.

## 변경 내용

`rm -f`를 제거하고 `diff`를 다시 함수의 마지막 명령으로 되돌립니다. 그러면 `diff`의 종료 코드가 자연히 함수의 반환값이 되므로 `rc` 처리도 함께 제거됩니다.

임시파일 정리는 테스트케이스의 책임입니다. shell 테스트케이스의 `*_temp_diff` 참조 **43건**을 확인한 결과:

- **1건**은 위와 같이 파일을 읽습니다 (`deduplicate.sh:66`)
- **42건**은 스크립트 끝에서 직접 삭제합니다. 그중 **13건은 `-f` 없는 bare `rm *_temp_diff`**로, 라이브러리가 파일을 먼저 지우면 glob이 매칭되지 않아 이 `rm`도 실패합니다 (테스트 실패로는 이어지지 않지만 로그에 에러가 남습니다)

#776에서 추가한 영문·한글 마스킹, `cp -f`, 파일명 인용은 그대로 유지됩니다.

## 검증

**원인 재현** — case #7의 조건을 동일하게 구성해 두 버전을 비교:

| init.sh | case #7 결과 | CTP 판정 |
|---|---|---|
| `develop` (`rm -f` 있음) | `NOK [create table fail]` | **FAIL** |
| 이 브랜치 (`rm -f` 제거) | `OK [create table checked]` | **PASS** |

**회귀 확인**

- 마스킹 11건 전부 통과 — 영문 5건, 한글 UTF-8 3건, 한글 EUC-KR 2건, 실제 내용 차이를 검출하는 negative 1건. 이번 되돌림은 마스킹에 영향이 없습니다
- 종료 코드 여전히 정확: 0(일치) / 1(상이) / 2(에러)
- bare `rm *_temp_diff`가 다시 `exit=0`으로 성공
- `bash -n` 통과

## 참고

`grep`으로 `*_temp_diff` 참조를 조사할 때 `deduplicate.sh:66`이 누락되어 초기에 "모든 참조가 삭제 용도"라고 잘못 판단했습니다. `find | xargs grep`으로 다시 확인해 읽기 참조 1건을 찾았고, 그것이 정확한 실패 원인이었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
