### PR TITLE
[CUBRIDQA-1510] Skip synthetic methods when collecting JDBC test cases

### DIFF
--- a/CTP/shell/src/com/navercorp/cubridqa/shell/main/JdbcLocalTest.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/main/JdbcLocalTest.java
@@ -226,6 +226,10 @@ public class JdbcLocalTest {
 				if (methods == null || methods.length <= 0)
 					continue;
 				for (Method m : methods) {
+					// a lambda in testX() compiles to lambda$testX$0, which matches the name check below
+					if (m.isSynthetic())
+						continue;
+
 					String methodName = m.getName();
 					boolean isTestAnnotationMethod = m.isAnnotationPresent(org.junit.Test.class);
 					boolean isIgnoreTestAnnotationMethod = m.isAnnotationPresent(org.junit.Ignore.class);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1510

### Purpose
람다의 합성 메서드를 CTP에서 테스트 케이스로 등록하는 문제 해결

### Implementation
N/A

### Remarks
N/A