### PR TITLE
[CUBRIDQA-1534] Pin FeedbackDB to CTP's own JDBC driver via an isolated classloader

### DIFF
--- a/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
+++ b/CTP/shell/src/com/navercorp/cubridqa/shell/result/FeedbackDB.java
@@ -26,16 +26,25 @@
 
 package com.navercorp.cubridqa.shell.result;
 
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.util.Properties;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp.ConnectionFactory;
+import org.apache.commons.dbcp.DriverConnectionFactory;
+import org.apache.commons.dbcp.PoolableConnectionFactory;
+import org.apache.commons.dbcp.PoolingDataSource;
+import org.apache.commons.pool.impl.GenericObjectPool;
 
 import com.navercorp.cubridqa.common.ConfigParameterConstants;
 import com.navercorp.cubridqa.shell.common.CommonUtils;
@@ -49,6 +58,7 @@ public class FeedbackDB implements Feedback {
 
 	Context context;
 	DataSource ds = null;
+	GenericObjectPool connPool = null;
 	final int MAX_CONTENT_SIZE = 128 * 1024;
 
 	int task_id = 0;
@@ -751,18 +761,32 @@ public class FeedbackDB implements Feedback {
 		String user = context.getFeedbackDbUser();
 		String pwd = context.getFeedbackDbPwd();
 
-		BasicDataSource ds = new BasicDataSource();
-		ds.setDriverClassName("cubrid.jdbc.driver.CUBRIDDriver");
-		ds.setUsername(user);
-		ds.setPassword(pwd);
-		ds.setUrl(url);
-		return ds;
+		try {
+			// The feedback DB may be older than the test build, and the test
+			// build's JDBC driver on the classpath can refuse to connect to it.
+			// So load CTP's own bundled driver in an isolated classloader (the
+			// parent must be null) and inject the driver instance directly,
+			// instead of loading the driver by class name from the classpath.
+			File driverJar = new File(context.getToolHome(), "common/lib/cubrid_jdbc.jar");
+			URLClassLoader driverLoader = new URLClassLoader(new URL[] { driverJar.toURI().toURL() }, null);
+			Driver driver = (Driver) Class.forName("cubrid.jdbc.driver.CUBRIDDriver", true, driverLoader).newInstance();
+
+			Properties props = new Properties();
+			props.put("user", user);
+			props.put("password", pwd);
+
+			ConnectionFactory connFactory = new DriverConnectionFactory(driver, url, props);
+			connPool = new GenericObjectPool();
+			new PoolableConnectionFactory(connFactory, connPool, null, null, false, true);
+			return new PoolingDataSource(connPool);
+		} catch (Exception e) {
+			throw new RuntimeException("fail to create feedback datasource with CTP own JDBC driver", e);
+		}
 	}
 
 	private void shutdownDataSource() {
-		BasicDataSource bds = (BasicDataSource) ds;
 		try {
-			bds.close();
+			connPool.close();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1534

### Purpose

11.5.0.2437-9eb142d 빌드부터 jdbc regression 결과가 qaresu에 저장되지 않는다.
원인은 APIS-1088이다. 새 JDBC 드라이버는 10.2 미만 서버 접속을 거부한다(ER_NOT_SUPPORTED_PROTOCOL, -21029).
2437 빌드는 이 정책이 든 드라이버(cubrid-jdbc-11.4.0.0072)를 처음 동봉한 빌드다.
jdbc 테스트 JVM은 테스트 대상 빌드의 드라이버를 classpath 선두에 둔다.
그래서 FeedbackDB가 그 드라이버로 CUBRID 9.3 qaresu에 접속하다 거부당했다.
결과: 테스트는 완주해도 결과 전체가 유실됐다.

### Implementation

FeedbackDB의 feedback 접속을 CTP 자체 내장 드라이버로 고정했다.

- CTP 내장 `common/lib/cubrid_jdbc.jar`(9.3.0.0206)를 parent=null `URLClassLoader`로 로드한다.
- 로드한 `Driver` 인스턴스를 dbcp 1.2.2 부품에 직접 주입한다
  (`DriverConnectionFactory` → `GenericObjectPool` → `PoolableConnectionFactory` → `PoolingDataSource`).
- DriverManager를 경유하지 않는다. 이후 feedback 접속은 classpath에서 어떤 드라이버가 이기는지와 무관하다.

검증 — 운영 동형 mock qaresu(9.3.9.0002, db=qaresu, charset en_US, 접속 포트 33080,
운영 동일 DDL shell_* 5종 + cubrid_build 시드 + cversion SP)에 대해:

1. **jdbc full run** (2408건 전체, 테스트 빌드 11.5.0.2437-9eb142d, patched CTP):
   - `shell_main` 1행(2408/2408, 성공 2403·실패 5, success_rate 99.79%) + `shell_items` 2408건 + `shell_last_pass` 2404건 저장.
   - 실행 로그에 -21029 0건.
   - 실패 5건은 케이스 자체 이슈다. 운영 정상 run(2431 빌드: 2402/6)과 같은 부류다.
2. **드라이버 격리 실측** (do_test와 동일 classpath의 한 JVM에서 FeedbackDB를 리플렉션 검사):
   - 주입된 Driver 인스턴스의 소속 jar = `CTP/common/lib/cubrid_jdbc.jar`, feedback 커넥션 driverVersion = 9.3.0.0206.
   - 같은 JVM에서 classpath 드라이버(빌드 동봉 11.4.0.0072)로 같은 URL 접속 시 -21029 거부.
   - 즉 feedback 저장 성공 자체가 내장 드라이버 사용의 교차 증명이다.
3. **shell 회귀**: shell 카테고리 1건 실행 → feedback 정상 저장. 전역 고정에 따른 회귀 없음.

### Remarks

- FeedbackDB 전역 고정이다. 카테고리 분기가 없다.
- feedback 서버는 CTP 내장 드라이버(9.3.0.0206)가 접속할 수 있는 버전이어야 한다. 현 운영 qaresu(9.3)와 일치한다.
- CTP 내장 jar가 없으면 setupDataSource가 즉시 예외로 실패한다. classpath 드라이버로 조용히 폴백하지 않는다.
- 이 변경은 feedback 접속만 바꾼다. 테스트 케이스가 쓰는 드라이버(테스트 빌드 동봉)는 그대로다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ2W9vT8jEJViyw9VEF7rv
